### PR TITLE
Fix unique key error in NoteReaders component

### DIFF
--- a/components/NoteReaders.js
+++ b/components/NoteReaders.js
@@ -6,7 +6,8 @@ const NoteReaders = ({ readers }) => {
     return (
       <>
         <Icon name="globe" extraClasses="readers-icon" />
-        {' Everyone'}
+        {' '}
+        Everyone
       </>
     )
   }


### PR DESCRIPTION
I think react complains about unique key because note readers is returning a list when reader is everyone.
breaking the list down seems to solve the problem