### PR TITLE
Fix/ add missing style to username and password input in login page

### DIFF
--- a/styles/pages/login.less
+++ b/styles/pages/login.less
@@ -39,4 +39,8 @@ main.login {
       width: 120px;
     }
   }
+
+  #email-input, #password-input {
+    width: 22rem;
+  }
 }


### PR DESCRIPTION
username and password input is missing width style from legacy css
without this they will take 100% width which is too wide