### PR TITLE
Adds ecosystem.json to Next  server with PM2

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,21 +1,21 @@
 {
   "apps" : [
     {
-      "name"       : "openreview",
-      "script"     : "npm",
-      "args"       : "start",
-      "instances"  : 0,
-      "exec_mode"  : "cluster",
-      "watch"      : false,
+      "name": "openreview",
+      "script": "npm",
+      "args": "start",
+      "instances": 0,
+      "exec_mode": "cluster",
+      "watch": false,
       "env" : {
         "NODE_ENV": "development",
         "NEXT_PORT": 3030
       },
-      "env_staging" : {
+      "env_staging": {
         "NODE_ENV": "staging",
         "NEXT_PORT": 3030
       },
-      "env_production" : {
+      "env_production": {
         "NODE_ENV": "production",
         "NEXT_PORT": 3030
       }


### PR DESCRIPTION
This PR creates the file needed to run Next server with pm2. First `npm run build` needs to be run, this can be done in the `deploy.sh` file. Then within `openreview-web` run `pm2 start ecosystem.json` to start the server in development mode. Just like in openreview-api `--env production` can be passed to change the environment.