### PR TITLE
fix/ add a step to create index in elasticsearch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         touch empty.json
         mv empty.json openreview-api
         cd openreview-api
+        pip install elasticsearch
         python scripts/create_index.py scripts/empty.json
         cd ..
     - name: Run OpenReview API


### PR DESCRIPTION
scripts/create_index.py will create the required body mapping for elasticsearch to work.
without this step elasticsearch won't index any note so tests related to search (or /notes/search api) will likely to fail