### PR TITLE
Enable running Next.js in cluster and with systemctl

### DIFF
--- a/deploy/setup-openreview-web.sh
+++ b/deploy/setup-openreview-web.sh
@@ -26,7 +26,7 @@ sudo -u openreview bash -c 'gsutil cp gs://openreview-files/conf/deploy-web.sh /
 sudo -u openreview bash -c 'cd ~/ && export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && bash /home/openreview/bin/clone-web.sh'
 # Create and start openreview service
 sudo -u openreview bash -c 'gsutil cp gs://openreview-files/conf/openreview-web.service /home/openreview/bin/'
-# sudo -u openreview bash -c 'sudo cp /home/openreview/bin/openreview-web.service /lib/systemd/system'
-# sudo -u openreview bash -c 'cd ~/ && sudo systemctl daemon-reload'
-# sudo -u openreview bash -c 'cd ~/ && sudo systemctl start openreview-web'
-# sudo -u openreview bash -c 'cd ~/ && sudo systemctl enable openreview-web'
+sudo -u openreview bash -c 'sudo cp /home/openreview/bin/openreview-web.service /lib/systemd/system'
+sudo -u openreview bash -c 'cd ~/ && sudo systemctl daemon-reload'
+sudo -u openreview bash -c 'cd ~/ && sudo systemctl start openreview-web'
+sudo -u openreview bash -c 'cd ~/ && sudo systemctl enable openreview-web'

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -2,9 +2,9 @@
   "apps" : [
     {
       "name": "openreview-web",
-      "script": "npm",
-      "args": "start",
-      "instances": 0,
+      "script": "./node_modules/.bin/next",
+      "args": "start -p 3030",
+      "instances": "max",
       "exec_mode": "cluster",
       "watch": false,
       "env" : {


### PR DESCRIPTION
Well, that was quite an adventure.

I had to hardcode the port in ecosystem.json, I didn't know how to pick it from the environment variable

Got solution from here: https://github.com/vercel/next.js/discussions/10675#discussioncomment-34615