### PR TITLE
mark registration task as completed

### DIFF
--- a/client/webfield.js
+++ b/client/webfield.js
@@ -2817,7 +2817,7 @@ module.exports = (function() {
   // or AC profile confirmation tasks are complete
   var temporaryMarkExpertiseCompleted = function(invitationsGroup) {
     var profileConfirmationInv = _.find(invitationsGroup, function(inv) {
-      return _.endsWith(inv.id, 'Profile_Confirmation');
+      return _.endsWith(inv.id, 'Profile_Confirmation') || _.endsWith(inv.id, 'Registration');
     });
     var expertiseInv = _.find(invitationsGroup, function(inv) {
       return _.endsWith(inv.id, 'Expertise_Selection');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -615,7 +615,7 @@ export function formatTasksData([noteInvitations, tagInvitations, edgeInvitation
   // Mark expertise selection task as completed when reviewer profile confirmation
   // or AC profile confirmation tasks are complete
   const temporaryMarkExpertiseCompleted = (invitationsGroup) => {
-    const profileConfirmationInv = invitationsGroup.invitations.find(inv => inv.id.endsWith('Profile_Confirmation'))
+    const profileConfirmationInv = invitationsGroup.invitations.find(inv => inv.id.endsWith('Profile_Confirmation') || inv.id.endsWith('Registration'))
     const expertiseInv = invitationsGroup.invitations.find(inv => inv.id.endsWith('Expertise_Selection'))
     if (expertiseInv && profileConfirmationInv && profileConfirmationInv.completed) {
       expertiseInv.completed = true


### PR DESCRIPTION
Similar to ECCV, if the `Registration` task is completed then we should mark the expertise task as completed too.