### PR TITLE
Fix/ Tasks page: note editor is opened twice when clicking on pending task

### DIFF
--- a/pages/forum.js
+++ b/pages/forum.js
@@ -118,7 +118,7 @@ const Forum = ({ forumNote, query, appContext }) => {
     // eslint-disable-next-line global-require
     const runForum = require('../client/forum')
     runForum(id, query.noteId, query.invitationId, user)
-  }, [clientJsLoading, user, authors, userLoading])
+  }, [clientJsLoading, user, JSON.stringify(authors), userLoading]) // authors is reset when clientJsLoading turns false
 
   return (
     <div className="forum-container">


### PR DESCRIPTION
authors is reset when clientJsLoading became false
and will trigger another run of hook/runForum

add JSON.stringify so that hook does not run when there's no content change.

for case of #203 it's empty array