### PR TITLE
Fix/ markdown options & profile compare page error

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -201,6 +201,9 @@ export default class OpenReviewApp extends App {
     require('../client/template-helpers')
     require('../client/globals')
 
+    // setup marked options and renderer overwrite
+    window.view.setupMarked()
+
     // Set required constants
     window.OR_API_URL = process.env.API_URL
     window.Webfield.setToken(token)

--- a/pages/profile/compare.js
+++ b/pages/profile/compare.js
@@ -184,7 +184,7 @@ const Others = ({ fieldContent, highlightValue }) => {
             style={content.confirmed ? null : { color: '#8c1b13' }}
           >
             <td>
-              {content.value.startsWith('http') ? (
+              {content.value?.startsWith('http') ? (
                 <a href={content.value} target="_blank" rel="noreferrer">
                   <span className={highlightValue.includes(content.value) ? 'highlight' : null}>{content.value}</span>
                 </a>


### PR DESCRIPTION
this pr adds a call to view.setupMarked() so that the markdown related options and renderer overwrite are working.
should solve #214 and #215 

optional chaining operator is added in profile compare page so that it does not throw error when a profile compared does not exist.
should solve #212