### PR TITLE
Fix/Note Panel: submitting a very long abstract without spaces is spread out without wrapping on the paper page 

### DIFF
--- a/styles/pages/forum.less
+++ b/styles/pages/forum.less
@@ -25,6 +25,7 @@ main.forum {
     }
     .note-content-value, .note_content_value {
       white-space: pre-wrap;
+      overflow-wrap: break-word;
       &.markdown-rendered {
         .markdown-content-styles;
       }


### PR DESCRIPTION
add overflow-wrap: break-word style to prevent overflow of long text