### PR TITLE
Fix/Content toggle cause page to scroll to wrong position

### DIFF
--- a/components/Accordion.js
+++ b/components/Accordion.js
@@ -36,7 +36,7 @@ const SectionHeading = ({ id, heading, options }) => (
 
 const SectionHeadingLink = ({ targetId, parentId, children }) => (
   <a
-    href={`#${targetId}`}
+    data-target={`#${targetId}`}
     className="collapse-btn collapsed"
     role="button"
     data-toggle="collapse"

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -38,7 +38,7 @@ function Faq({ generalQuestions, pcQuestions, appContext }) {
 
     // Scroll to and expand question referenced in URL
     if (window.location.hash) {
-      const $titleLink = $(`.panel-title a[href="${window.location.hash}"]`).eq(0)
+      const $titleLink = $(`.panel-title a[data-target="${window.location.hash}"]`).eq(0)
       if ($titleLink.length) {
         $titleLink.click()
 
@@ -51,7 +51,7 @@ function Faq({ generalQuestions, pcQuestions, appContext }) {
 
     // Update URL hash when clicking a question
     $('.faq-container .panel-title a').on('click', function onClick() {
-      router.replace(window.location.pathname + window.location.search + $(this).attr('href'))
+      router.replace(window.location.pathname + window.location.search + $(this).attr('data-target'))
     })
   }, [formattedGeneralQuestions, formattedPCQuestions])
 

--- a/styles/pages/faq.less
+++ b/styles/pages/faq.less
@@ -21,4 +21,10 @@ main.faq {
     }
   }
 
+  .collapsing {
+    -webkit-transition: none;
+    transition: none;
+    display: none;
+  }
+
 }


### PR DESCRIPTION
changed href attribute to data-target;
disabled transition animation;

chaning ln54 of faq.js from
```javascript
router.replace(window.location.pathname + window.location.search + $(this).attr('href'))
```
to
```javascript
window.location.hash=$(this).attr('data-target')
```
can prevent the scroll by next.js but will cause all # urls to be added to browser history
