### PR TITLE
Fix/ Add check to avoid error when clicking venue request buttons

### DIFF
--- a/client/forum.js
+++ b/client/forum.js
@@ -231,9 +231,9 @@ module.exports = function(forumId, noteId, invitationId, user) {
     var $note = view.mkNotePanel(rec.note, {
       onEditRequested: function(invitation, options) {
         var noteToRender;
-        if (options.original) {
+        if (options?.original) {
           noteToRender = rec.note.details?.original;
-        } else if (options.revision) {
+        } else if (options?.revision) {
           noteToRender = invitation.details?.repliedNotes?.[0]
           if (noteToRender) {
             // Include both the referent and the note id so the API doesn't create a new reference


### PR DESCRIPTION
@celestemartinez found an error of

Uncaught TypeError: Cannot read property 'original' of undefined  
when pressing any button (Revision, Review Stage,...) on any venue request

this is caused by mkPanel() in forum.js
```javascript
if (options.original) {
```
when options is undefined(not passed in).

there was a line to assign {} to options
which is removed in https://github.com/openreview/openreview-web/pull/255

this pr added ? to avoid error