### PR TITLE
Fix/ Edge browser search

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -618,7 +618,7 @@ export default function Column(props) {
             removeEdgeFromEntity={removeEdgeFromEntity}
             setSelectedItemId={setSelectedItemId}
             canTraverse={!props.finalColumn}
-            showHiddenItems={itemsHeading === 'Search Results'}
+            showHiddenItems={false}
           />
         )}
       </div>


### PR DESCRIPTION
Hide edges specified by hide param from search results as well. Should make it slightly harder (though not impossible) to guess an author's affiliation based on their conflicts.