### PR TITLE
Fix/ Authors widget changes author ids

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -2802,7 +2802,7 @@ module.exports = (function() {
           }
         }
 
-      } else if (contentObj.hasOwnProperty('value-file')) {
+      } else if (contentObj.hasOwnProperty('value-file') || (contentObj['value-regex'] && contentObj['value-regex'] === 'upload')) {
         var $fileSection = $contentMap[k];
         var $fileInput = $fileSection && $fileSection.find('input.note_' + k + '[type="file"]');
         var file = $fileInput && $fileInput.val() ? $fileInput[0].files[0] : null;


### PR DESCRIPTION
Use same author id when re-ordering authors rather than switching to the preferred id.
Also, support old-style pdf field invitations.

Fixes #332 
Fixes #330 