### PR TITLE
Fix/Note Editor: respect the order of the readers based on the invitation

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -505,7 +505,7 @@ module.exports = (function() {
       });
 
       if (selected) { //add musthavevalues
-        _.forEach(alwaysHaveValues, function (alwaysHaveValue) {
+        _.forEachRight(alwaysHaveValues, function (alwaysHaveValue) {
           if (selectedValues.find(function (selectedValue) { //alwayshavevalue is already selected
             return selectedValue.id === alwaysHaveValue.id;
           })) {


### PR DESCRIPTION
_.forEachRight will start from the last default value so that after unshift() the first value defined in invitation can appear at the beginning.