### PR TITLE
Fix/ Support using group id as paper invitation on stats page

### DIFF
--- a/client/assignment-stats.js
+++ b/client/assignment-stats.js
@@ -50,7 +50,7 @@ var loadFromEdges = function(assignmentConfigNote) {
   } else {
     papersP = Webfield.get('/groups', {id: paperInvitationElements[0]})
     .then(function(result) {
-      return _.get(result, 'groups[0].members').map(function(member) { return { id: member }; });
+      return _.get(result, 'groups[0].members', []).map(function(member) { return { id: member }; });
     });
   }
   var usersP = Webfield.get('/groups', {id: assignmentConfigNote.match_group})


### PR DESCRIPTION
The 'paper_invitation' from the configuration note can be either a paper invitation or a group id.