### PR TITLE
Fix/Edge Browser: when the traverse and browse parameter is the same, the sorting option is being shown twice

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -590,7 +590,7 @@ export default function Column(props) {
               <label>Order By:</label>
               <select className="form-control input-sm" onChange={e => setColumnSort(e.target.value)}>
                 <option key={traverseInvitation.id} value="default">
-                  {prettyInvitationId(traverseInvitation.id)}
+                  default
                 </option>
                 {browseInvitations.map(inv => (
                   <option key={inv.id} value={inv.id}>


### PR DESCRIPTION
the 1st option text is a pretty id of traverse invitation id and it's the default value.
change the text to "default"