### PR TITLE
Fix/Profile relation readers selection: unselect 'everyone' when another option is selected

### DIFF
--- a/client/profile-view.js
+++ b/client/profile-view.js
@@ -288,7 +288,7 @@ module.exports = function(profile, params, submitF, cancelF) {
       buttonText: getDropdownText(prefill.readers),
       id: uniqueId,
       htmlFilters: prefixedRelationReaders?.map(p => ({ valueFilter: p, textFilter: view.prettyId(p) })),
-      hideSelectAll: prefixedRelationReaders?.length <= 1 // false to render select all
+      hideSelectAll: true
     });
 
     var $row = $('<tr>', {border: 0, class: 'info_row'}).append(
@@ -325,16 +325,13 @@ module.exports = function(profile, params, submitF, cancelF) {
     }
 
     $row.find('.dropdown-menu').on('change', (e) => {
-      if ($(e.target).attr('class') === 'select-all-checkbox') {
-        $row.find('.dropdown-menu input').prop('checked', e.target.checked);
-        $row.find('.multiselector').data('val', e.target.checked ? prefixedRelationReaders : ['everyone']); // set data attr, default to everyone
-        if (!e.target.checked) $row.find('.dropdown-menu').find('input[value="everyone"]').prop('checked', true); // leave everyone checked
-        $row.find('.multiselector .dropdown-toggle').html('everyone'); // display text
-      } else {
         var selectedReaders = [];
-        // set select all checkbox
         $row.find('.dropdown-menu input.' + uniqueId + '-multiselector-checkbox:checked').each((index, element) => selectedReaders.push(element.value));
-        $row.find('.dropdown-menu input.select-all-checkbox').prop('checked', _.isEqual(selectedReaders.sort(), prefixedRelationReaders.sort()));
+        // uncheck everyone when another option is selected
+        if(e.target.value!=='everyone' && e.target.checked) {
+          $row.find('.dropdown-menu input[value="everyone"]').prop('checked', false);
+          selectedReaders = selectedReaders.filter(p => p !== 'everyone');
+        }
         // set default value (everyone) if nothing selected
         if (selectedReaders.length === 0) {
           $row.find('.dropdown-menu input[value="everyone"]').prop('checked', true);
@@ -344,7 +341,6 @@ module.exports = function(profile, params, submitF, cancelF) {
         $row.find('.multiselector .dropdown-toggle').html(getDropdownText(selectedReaders));
         // set data attr
         $row.find('.multiselector').data('val', selectedReaders);
-      }
     });
     return $row;
 


### PR DESCRIPTION
uncheck everyone when some other value is checked;
removed select-all option as its behavior would conflict with the logic to uncheck everyone when some other value is checked;