### PR TITLE
Fix/ user moderation merged profiles listed as blocked

### DIFF
--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -57,7 +57,7 @@ const UserModerationQueue = ({
         sort: 'tcdate:desc',
         limit: pageSize,
         offset: (pageNumber - 1) * pageSize,
-        trash: !onlyModeration,
+        withBlocked: onlyModeration ? undefined : true,
       }, { accessToken })
       setTotalCount(result.count ?? 0)
       setProfiles(result.profiles ?? [])

--- a/styles/components.less
+++ b/styles/components.less
@@ -935,7 +935,7 @@ table.table-minimal {
     min-height: 100px;
 
     ul.list-paginated > li.blocked{
-      opacity: 50%;
+      opacity: 0.5;
     }
 
     ul.list-paginated > li > span {


### PR DESCRIPTION
**merged profiles are shown as blocked**:the profiles are fetched with trash true so the merged profiles are included and ddate is check to differentiate blocked and normal profiles so merged profiles are shown as blocked
@carlosmondra will add a param withBlocked for the result to include blocked profiles


**opacity is 0.01 for blocked profiles**:next build will cause the percentage opacity to be set to 0.01 and the blocked profiles become invisible
it looks like this is a bug of the build tool used
https://github.com/vercel/next.js/discussions/13069