### PR TITLE
Fix/ Remove url params after submitting invitation response

### DIFF
--- a/pages/invitation.js
+++ b/pages/invitation.js
@@ -113,6 +113,7 @@ view.mkNoteEditor(
   {
     onNoteEdited: function(replyNote) {
       $('#invitation-container').empty();
+      history.replaceState({}, '', '/invitation?id=' + invitation.id)
       runWebfield(replyNote);
     },
     onNoteCancelled: function(result) {


### PR DESCRIPTION
This is to prevent users from refreshing the page and posting a duplicate note.