### PR TITLE
Fix/Edge browser: remove fields added for UI display

### DIFF
--- a/components/browser/NoteEntity.js
+++ b/components/browser/NoteEntity.js
@@ -69,18 +69,16 @@ export default function NoteEntity(props) {
       promptError('You don\'t have permission to edit this edge')
       return
     }
+    const {
+      creationDate, modificationDate, name, writable, ...body // removed fields added for entity display
+    } = {
+      tail: id,
+      ddate: Date.now(),
+      ...editEdge,
+      signatures,
+    }
     try {
-      const result = await api.post('/edges', {
-        tail: id,
-        ddate: Date.now(),
-        ...editEdge,
-        signatures,
-        creationDate: undefined, // removed fields added for entity display
-        modificationDate: undefined,
-        name: undefined,
-        writable: undefined,
-      },
-      { accessToken })
+      const result = await api.post('/edges', body, { accessToken })
       props.removeEdgeFromEntity(id, result)
     } catch (error) {
       promptError(error.message)
@@ -100,24 +98,22 @@ export default function NoteEntity(props) {
       promptError('You don\'t have permission to edit this edge')
       return
     }
-    try {
-      const result = await api.post('/edges', {
-        tail: id,
-        ddate: null,
-        ...existingEdge ?? {
-          ...editEdgeTemplate,
-          readers: getInterpolatedValues(editInvitation.readers),
-          nonreaders: getInterpolatedValues(editInvitation.nonreaders),
-          writers: getInterpolatedValues(editInvitation.writers),
-          signatures,
-        },
-        ...updatedEdgeFields,
-        creationDate: undefined, // removed fields added for entity display
-        modificationDate: undefined,
-        name: undefined,
-        writable: undefined,
+    const {
+      creationDate, modificationDate, name, writable, ...body // removed fields added for entity display
+    } = {
+      tail: id,
+      ddate: null,
+      ...existingEdge ?? {
+        ...editEdgeTemplate,
+        readers: getInterpolatedValues(editInvitation.readers),
+        nonreaders: getInterpolatedValues(editInvitation.nonreaders),
+        writers: getInterpolatedValues(editInvitation.writers),
+        signatures,
       },
-      { accessToken })
+      ...updatedEdgeFields,
+    }
+    try {
+      const result = await api.post('/edges', body, { accessToken })
       props.addEdgeToEntity(id, result)
     } catch (error) {
       promptError(error.message)

--- a/components/browser/ProfileEntity.js
+++ b/components/browser/ProfileEntity.js
@@ -62,17 +62,16 @@ export default function ProfileEntity(props) {
       promptError('You don\'t have permission to edit this edge')
       return
     }
+    const {
+      creationDate, modificationDate, name, writable, ...body // removed fields added for entity display
+    } = {
+      tail: id,
+      ddate: Date.now(),
+      ...editEdge,
+      signatures,
+    }
     try {
-      const result = await api.post('/edges', {
-        tail: id,
-        ddate: Date.now(),
-        ...editEdge,
-        signatures,
-        creationDate: undefined, // removed fields added for entity display
-        modificationDate: undefined,
-        name: undefined,
-        writable: undefined,
-      }, { accessToken })
+      const result = await api.post('/edges', body, { accessToken })
       props.removeEdgeFromEntity(id, result)
     } catch (error) {
       promptError(error.message)
@@ -93,23 +92,22 @@ export default function ProfileEntity(props) {
       promptError('You don\'t have permission to edit this edge')
       return
     }
+    const {
+      creationDate, modificationDate, name, writable, ...body // removed fields added for entity display
+    } = {
+      tail: id,
+      ddate: null,
+      ...existingEdge ?? {
+        ...editEdgeTemplate,
+        readers: getInterpolatedValues(editInvitation.readers),
+        nonreaders: getInterpolatedValues(editInvitation.nonreaders),
+        writers: getInterpolatedValues(editInvitation.writers),
+        signatures,
+      },
+      ...updatedEdgeFields,
+    }
     try {
-      const result = await api.post('/edges', {
-        tail: id,
-        ddate: null,
-        ...existingEdge ?? {
-          ...editEdgeTemplate,
-          readers: getInterpolatedValues(editInvitation.readers),
-          nonreaders: getInterpolatedValues(editInvitation.nonreaders),
-          writers: getInterpolatedValues(editInvitation.writers),
-          signatures,
-        },
-        ...updatedEdgeFields,
-        creationDate: undefined, // removed fields added for entity display
-        modificationDate: undefined,
-        name: undefined,
-        writable: undefined,
-      }, { accessToken })
+      const result = await api.post('/edges', body, { accessToken })
       props.addEdgeToEntity(id, result)
     } catch (error) {
       promptError(error.message)


### PR DESCRIPTION
this is the accompanying pr of https://github.com/openreview/openreview/pull/2354
which updates the edge validation.

there are some fields that are added to existing edit edge and edit edge template for UI display(edge name, tooltip...). 
When an edit edge is created/deleted, the edge/template is spreaded as body of API call and the fields for UI display will cause API validation failure as the fields for UI display does not exist in edge invitation.
