### PR TITLE
Fix/Edge browser allow filtering out quota reached reviewers

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -796,35 +796,32 @@ export default function Column(props) {
             <span className="glyphicon glyphicon-search form-control-feedback" aria-hidden="true" />
           </div>
           {parentId && (
-            <>
-              <div className="sort-container form-group">
-                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                <label>Order By:</label>
-                <select className="form-control input-sm" onChange={e => setColumnSort(e.target.value)}>
-                  {
-                    sortOptions.map(p => (
-                      <option key={p.key} value={p.value}>
-                        {p.text}
-                      </option>
-                    ))
-                  }
-                </select>
-              </div>
-              {showHideQuotaReachedCheckbox && (
-                <div className="d-flex">
-                  <input id={`hide-quota-checkbox${props.index}`} type="checkbox" checked={hideQuotaReached} onChange={(e) => { setHideQuotaReached(e.target.checked) }} />
-                  <label className="hide-quota" htmlFor={`hide-quota-checkbox${props.index}`}>
-                    Only show
-                    {' '}
-                    {prettyId(traverseInvitation[type].query.group, true).toLowerCase()}
-                    {' '}
-                    with fewer than the max
-                    {' '}
-                    {pluralizeString(traverseInvitation.name, true).toLowerCase()}
-                  </label>
-                </div>
-              )}
-            </>
+            <div className="sort-container form-group">
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label>Order By:</label>
+              <select className="form-control input-sm" onChange={e => setColumnSort(e.target.value)}>
+                {sortOptions.map(p => (
+                  <option key={p.key} value={p.value}>
+                    {p.text}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          {parentId && showHideQuotaReachedCheckbox && (
+            <div className="checkbox">
+              <label>
+                <input type="checkbox" checked={hideQuotaReached} onChange={(e) => { setHideQuotaReached(e.target.checked) }} />
+                {' '}
+                Only show
+                {' '}
+                {prettyId(traverseInvitation[type].query.group, true).toLowerCase()}
+                {' '}
+                with fewer than max
+                {' '}
+                {pluralizeString(traverseInvitation.name, true).toLowerCase()}
+              </label>
+            </div>
           )}
         </form>
       </div>

--- a/styles/pages/edge-browser.less
+++ b/styles/pages/edge-browser.less
@@ -394,14 +394,14 @@ main.edge-browser {
           width: ~"calc(100% - 60px)";
         }
       }
-      div.d-flex {
-        display: flex;
-        align-items: flex-start;
+      div.checkbox {
         margin-top: .25rem;
-        label.hide-quota {
+        margin-bottom: 0;
+        label {
           font-size: .75rem;
-          margin-left: .25rem;
-          font-weight: 400;
+        }
+        input {
+          margin-top: 2px;
         }
       }
     }


### PR DESCRIPTION
the issue this pr is solving is
>Add a checkbox in the edge browser to filter the reviewers with remaining quotas.

~a checkbox is add(for profile column with custom load in browse param) to hide reviewers reaching max load quota.
native select is changed to bootstrap dropdown in order to add this checkbox~

checkbox is moved out of dropdown so we can use back the native select