### PR TITLE
Fix/test/github actions failure

### DIFF
--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -7,7 +7,7 @@ const waitForJobs = (noteId, superUserToken) => new Promise((resolve, reject) =>
   const interval = setInterval(async () => {
     try {
       const statuses = await getJobsStatus(superUserToken)
-      if (statuses.pyQueueStatus.failed > 0) {
+      if (Object.values(statuses).some((p: any) => p.failed > 0)) {
         clearInterval(interval)
         reject(new Error('Process function failed'))
       }


### PR DESCRIPTION
this should fix the property change(from pyQueueStatus to pyEntityQueueStatus ) 
in return of /jobs/status and failure in test of openreview-web
(https://github.com/openreview/openreview/pull/2359)

discussed this with Carlos. 
it's better to check all queues for failed job instead of checking just pyQueue
return of /job/status has several queue status objs like 
emailQueue
jsEntityQueue
pyEntityQueue
gatherEmailsQueue
