### PR TITLE
Fix/DBLP upload: Improve add alternate name instructions

### DIFF
--- a/components/DblpImportModal.js
+++ b/components/DblpImportModal.js
@@ -11,14 +11,12 @@ import {
 import UserContext from './UserContext'
 import { inflect } from '../lib/utils'
 
-const errorMessage = (message, dblpNames, profileNames) => {
-  if (!dblpNames?.length) {
-    return <p>{message}</p>
-  }
+const ErrorMessage = ({ message, dblpNames, profileNames }) => {
+  if (!dblpNames?.length) return <p>{message}</p>
   return (
-    <div>
+    <>
       <p>
-        Your OpenReview Profile must contain the
+        Your OpenReview profile must contain the
         {' '}
         <strong>EXACT</strong>
         {' '}
@@ -44,7 +42,7 @@ const errorMessage = (message, dblpNames, profileNames) => {
           </ul>
         </>
       )}
-    </div>
+    </>
   )
 }
 
@@ -214,7 +212,13 @@ export default function DblpImportModal({ profileId, profileNames, email }) {
           </div>
 
           <div className={`modal-body ${isSavingPublications ? 'disable-scroll' : ''}`}>
-            {message && errorMessage(message, dblpNames.current, profileNames)}
+            {message && (
+              <ErrorMessage
+                message={message}
+                dblpNames={dblpNames.current}
+                profileNames={profileNames}
+              />
+            )}
 
             {showPersistentUrlInput && (
               <form>

--- a/tests/profilePage.ts
+++ b/tests/profilePage.ts
@@ -108,12 +108,12 @@ test('import paper from dblp', async (t) => {
     .click(persistentUrlInput) // to make sure input get focus
     .typeText(persistentUrlInput, testPersistentUrl)
     .click(showPapersButton)
-    .expect(Selector('#dblp-import-modal').find('div.modal-body').innerText).contains('Please ensure that the DBLP URL provided is yours and the name used in your DBLP papers is listed in your profile.')
+    .expect(Selector('#dblp-import-modal').find('div.modal-body>p').nth(0).innerText).contains('Your OpenReview profile must contain the EXACT name used in your DBLP papers.')
     .click(dblpImportModalCancelButton)
     // put persistent url of other people in page
     .typeText(Selector('input#dblp_url'), testPersistentUrl, { replace: true })
     .click(addDBLPPaperToProfileButton)
-    .expect(Selector('#dblp-import-modal').find('div.modal-body').innerText).contains('Please ensure that the DBLP URL provided is yours and the name used in your DBLP papers is listed in your profile.')
+    .expect(Selector('#dblp-import-modal').find('div.modal-body>p').nth(0).innerText).contains('Your OpenReview profile must contain the EXACT name used in your DBLP papers.')
     .click(dblpImportModalCancelButton)
     // add name to skip validation error
     .click(nameSectionPlusIconSelector)


### PR DESCRIPTION
change the message displayed in dblp import modal when name in user's profile does not match any of the names in dblp page