### PR TITLE
check when the API returns an empty array instead of an error

### DIFF
--- a/pages/forum.js
+++ b/pages/forum.js
@@ -224,7 +224,7 @@ Forum.getInitialProps = async (ctx) => {
       id: ctx.query.id, trash: true, details: 'original,invitation,replyCount,writable',
     }, { accessToken: token })
 
-    // Can not see the note but there is not error thrown from the API and an empty array is returned
+    // Can not see the note but there is no error thrown from the API and an empty array is returned instead
     if (!result.notes.length) {
       const redirect = await shouldRedirect(ctx.query.id)
       if (redirect) {


### PR DESCRIPTION
Fixes

<img width="816" alt="Screen Shot 2021-05-24 at 9 20 25 AM" src="https://user-images.githubusercontent.com/545506/119355410-3b795380-bc73-11eb-9501-3bb9f904a4ea.png">
