### PR TITLE
Fix/ Info page mode toggle

### DIFF
--- a/pages/group/edit.js
+++ b/pages/group/edit.js
@@ -38,6 +38,14 @@ export default function GroupEdit({ appContext }) {
         setError({ statusCode: 404, message: 'Group not found' })
       }
     } catch (apiError) {
+      if (apiError.name === 'forbidden' || apiError.name === 'ForbiddenError') {
+        if (!accessToken) {
+          router.replace(`/login?redirect=${encodeURIComponent(router.asPath)}`)
+        } else {
+          setError({ statusCode: 403, message: 'You don\'t have permission to read this group' })
+        }
+        return
+      }
       setError({ statusCode: apiError.status, message: apiError.message })
     }
   }

--- a/pages/group/info.js
+++ b/pages/group/info.js
@@ -20,8 +20,8 @@ const GroupInfo = ({ appContext }) => {
   const [group, setGroup] = useState(null)
   const query = useQuery()
   const router = useRouter()
-  const { setBannerHidden, clientJsLoading } = appContext
   const containerRef = useRef(null)
+  const { setBannerHidden, clientJsLoading } = appContext
 
   const loadGroup = async (id) => {
     try {

--- a/pages/invitation/edit.js
+++ b/pages/invitation/edit.js
@@ -41,6 +41,14 @@ const InvitationEdit = ({ appContext }) => {
         setError({ statusCode: 404, message: 'Group not found' })
       }
     } catch (apiError) {
+      if (apiError.name === 'forbidden' || apiError.name === 'ForbiddenError') {
+        if (!accessToken) {
+          router.replace(`/login?redirect=${encodeURIComponent(router.asPath)}`)
+        } else {
+          setError({ statusCode: 403, message: 'You don\'t have permission to read this invitation' })
+        }
+        return
+      }
       setError({ statusCode: apiError.status, message: apiError.message })
     }
   }


### PR DESCRIPTION
Changes the group info and invitation info pages so that they will show a button to switch to edit mode (if writable) or view mode (if web field exists).

Also adds better error handling to those pages, to redirect the user to login if the API returns a forbidden error.