### PR TITLE
PC/SAC/AC console query search: 0 is not parse correctly

### DIFF
--- a/client/webfield.js
+++ b/client/webfield.js
@@ -655,7 +655,7 @@ module.exports = (function() {
   const evaluateOperator = (operator, propertyValue, targetValue) => {
     // propertyValue can be number/array/string/obj
     let isString = false
-    if (!propertyValue || !targetValue) return false
+    if (propertyValue === null || propertyValue === undefined || targetValue === null || targetValue === undefined) return false
     if (typeof (propertyValue) === 'object' && !Array.isArray(propertyValue)) { // reviewers are objects
       propertyValue = Object.values(propertyValue).map(p => p.name.toString().toLowerCase())
       targetValue = targetValue.toString().toLowerCase()
@@ -697,7 +697,7 @@ module.exports = (function() {
       ? [property] // not a nested property
       : propertiesAllowed[property].map(p => p.split('.')) // has dot or match multiple properties
 
-    const convertedValue = Number(value) || value
+    const convertedValue = isNaN(Number(value))?value:Number(value)
     return collections.filter(p => {
       if (propertyPath.length === 1) {
         return evaluateOperator(filterOperator, propertyPath[0].reduce((r, s) => r?.[s], p), convertedValue)


### PR DESCRIPTION
discovered this issue while working on the sac console https://github.com/openreview/openreview-py/pull/897.
0 is not parsed correctly as number so queries such as +replyCount=0 does not work