### PR TITLE
Fix/edge browser permission denied error

### DIFF
--- a/components/browser/EdgeBrowser.js
+++ b/components/browser/EdgeBrowser.js
@@ -304,7 +304,7 @@ export default class EdgeBrowser extends React.Component {
             promptError(error.message)
           }
         }
-        const interpolatedSignature = editInvitation.signatures['values-regex'].replace(/{head.number}/g, '.*')
+        const interpolatedSignature = editInvitation.signatures['values-regex'].replace(/{head\.number}/g, '.*')
         try {
           const interpolatedLookupResult = await api.get('/groups', { regex: interpolatedSignature, signatory: this.userId }, { accessToken: this.accessToken })
           editInvitationSignaturesMap.push({

--- a/lib/edge-utils.js
+++ b/lib/edge-utils.js
@@ -269,10 +269,10 @@ export function getInterpolatedValues({
       let finalV = v
       if (columnType === 'head') {
         finalV = shouldReplaceHeadNumber
-          ? finalV.replace(/{head.number}/g, paperNumber).replace(/{tail}/g, parentId) // note
+          ? finalV.replace(/{head\.number}/g, paperNumber).replace(/{tail}/g, parentId) // note
           : finalV.replace(/{tail}/g, parentId) // profile
       } else if (columnType === 'tail') {
-        finalV = finalV.replace(/{head.number}/g, parentPaperNumber).replace(/{tail}/g, id)
+        finalV = finalV.replace(/{head\.number}/g, parentPaperNumber).replace(/{tail}/g, id)
       }
       return finalV
     })


### PR DESCRIPTION
Celeste found the cause of this error. if the user is using older versions of chrome, replaceAll may not be supported and will cause the availableSignature to be empty which is shown as permission denied when the user edit an edge