### PR TITLE
Profile compare: show associated edges

### DIFF
--- a/pages/profile/compare.js
+++ b/pages/profile/compare.js
@@ -1,6 +1,6 @@
 /* globals promptError: false */
 
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Router from 'next/router'
 import Head from 'next/head'
 import isEmpty from 'lodash/isEmpty'


### PR DESCRIPTION
profile merge may break existing edges as the profile id won't auto update.
this pr shows the associated edges at the bottom of profile compare page so that edges can be checked before profile merge.