### PR TITLE
Remove window and document being equals to null

### DIFF
--- a/pages/group/index.js
+++ b/pages/group/index.js
@@ -87,8 +87,6 @@ window.user = ${JSON.stringify(userOrGuest)};
 $(function() {
   var args = ${JSON.stringify(ctx.query)};
   var group = ${JSON.stringify(groupObjSlim)};
-  var document = null;
-  var window = null;
   var model = {
     tokenPayload: function() {
       return { user: user }

--- a/pages/invitation/index.js
+++ b/pages/invitation/index.js
@@ -159,8 +159,6 @@ $(function() {
   var args = ${JSON.stringify(ctx.query)};
   var invitation = ${JSON.stringify(invitationObjSlim)};
   var user = ${JSON.stringify(userOrGuest)};
-  var document = null;
-  var window = null;
 
   $('#invitation-container').empty();
   ${showModeBanner ? 'Webfield.editModeBanner(invitation.id, args.mode);' : ''}


### PR DESCRIPTION
I want to set the accessToken cookie from the group [webfield of Impersonate](https://dev.openreview.net/group?id=NeurIPS.cc/2021/Conference/Impersonate), but I am unable to do so because document and window are null. Other ideas are also welcome