### PR TITLE
Fix/tasks page for api v2

### DIFF
--- a/pages/tasks.js
+++ b/pages/tasks.js
@@ -63,7 +63,7 @@ const Tasks = ({ appContext }) => {
     const invitationPromises = [
       api.getCombined('/invitations', { ...commonQueryParam, replyto: true, details: 'replytoNote,repliedNotes' }, null, commonOption).then(addPropertyToInvitations('noteInvitation')),
       api.getCombined('/invitations', { ...commonQueryParam, type: 'tags' }, null, commonOption).then(addPropertyToInvitations('tagInvitation')),
-      api.getCombined('/invitations', { ...commonQueryParam, type: 'edges', details: 'repliedEdges' }, isNull, commonOption).then(addPropertyToInvitations('tagInvitation')),
+      api.getCombined('/invitations', { ...commonQueryParam, type: 'edges', details: 'repliedEdges' }, null, commonOption).then(addPropertyToInvitations('tagInvitation')),
     ]
 
     Promise.all(invitationPromises)


### PR DESCRIPTION
branch is created off fix/activity-page-v2 branch so it contains some existing commits

only the changes in pages/tasks.js  is for tasks page
v2 invitations are fetched in v1 format so the only change is in the useEffect hook to get invitations