### PR TITLE
Fix/ Forum tabs empty filters

### DIFF
--- a/client/forum.js
+++ b/client/forum.js
@@ -1011,7 +1011,6 @@ module.exports = function(forumId, noteId, invitationId, user) {
       return map;
     }, {});
     sm.update('forumFiltersMap', filterMap);
-    console.log(filterMap);
 
     return $('<ul class="nav nav-tabs filter-tabs">').append(
       replyForumViews.map(function(view) {


### PR DESCRIPTION
Remove empty strings from filters so they don't show up in the dropdowns.
