### PR TITLE
fix/pc console query search:default N/A to 0

### DIFF
--- a/client/webfield.js
+++ b/client/webfield.js
@@ -768,7 +768,6 @@ module.exports = (function() {
       const filterResult = filterTreeNode(collections, syntaxTree, filterOperators, propertiesAllowed, uniqueIdentifier)
       return { filteredRows: filterResult }
     } catch (error) {
-      console.log(error)
       return { filteredRows: collections, queryIsInvalid: true }
     }
   }


### PR DESCRIPTION
Alina reported that +ratingAvg>=6 is not working

it is caused by a paper which does not have any review and the ratingAvg is string 'N/A' and we don't allow comparison of string and number.

this pr set the default value of 0 to 'N/A' value when the target value to compare with is a number, this is similar to what the sort is doing now