### PR TITLE
Fix/ Legacy webfields missing controller

### DIFF
--- a/pages/group/index.js
+++ b/pages/group/index.js
@@ -97,16 +97,11 @@ $(function() {
   };
   var controller = {
     get: Webfield.get,
-    post: Webfield.post,
-    put: Webfield.put,
-    sendFile: Webfield.sendFile,
     addHandler: function(name, funcMap) {
       Object.values(funcMap).forEach(function(func) {
         func();
       });
     },
-    removeHandler: function() {},
-    removeAllButMain: function() {},
   };
 
   $('#group-container').empty();


### PR DESCRIPTION
Add a dummy controller object for legacy webfield code. An example of a group that uses this function is https://openreview.net/group/edit?id=AKBC.ws/2019/Conference/Program_Chairs