### PR TITLE
fix/profile page may have duplicated calls to get notes

### DIFF
--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -266,6 +266,7 @@ const Profile = ({ profile, publicProfile, appContext }) => {
     // Always show user's preferred username in the URL
     if (profileQuery.email || (profileQuery.id !== profile.preferredId)) {
       router.replace(`/profile?id=${profile.preferredId}`, undefined, { shallow: true })
+      return
     }
 
     if (profile.id === user?.profile?.id) {


### PR DESCRIPTION
when a profile is accessed using email or a profile id that's not the user's preferred id, a redirection is performed(using the preferred id) but the useEffect will continue to execute to load publications, the same function will be executed again with the preferred id which leads to duplicated calls.

added return to stop execution after redirection