### PR TITLE
Fix/ Replace replaceAll

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -2897,9 +2897,9 @@ module.exports = (function() {
 
       } else if (contentObj.hasOwnProperty('value-file') || (contentObj['value-regex'] && contentObj['value-regex'] === 'upload')) {
         var $fileSection = $contentMap[k];
-        var $fileInput = $fileSection && $fileSection.find('input.note_' + k.replace(/\W/g, '-') + '[type="file"]');
+        var $fileInput = $fileSection && $fileSection.find('input.note_' + k.replace(/\W/g, '.') + '[type="file"]');
         var file = $fileInput && $fileInput.val() ? $fileInput[0].files[0] : null;
-        var $textInput = $fileSection && $fileSection.find('input.note_' + k.replace(/\W/g, '-') + '[type="text"]');
+        var $textInput = $fileSection && $fileSection.find('input.note_' + k.replace(/\W/g, '.') + '[type="text"]');
         var url = $textInput && $textInput.val();
 
         // Check if there's a file. If not, check if there's a url and update ONLY if the new value


### PR DESCRIPTION
Replace uses of String.replaceAll. This function is not polyfilled by Next.js: https://github.com/vercel/next.js/blob/canary/packages/next-polyfill-nomodule/src/index.js and is unsupported in older browsers.