### PR TITLE
Fix/ Bold text extra padding

### DIFF
--- a/styles/utils/mixins.less
+++ b/styles/utils/mixins.less
@@ -44,6 +44,7 @@
   }
   strong {
     color: @darkBlue;
+    padding-right: 0;
   }
   ol, ul {
     padding-left: 1.5rem;


### PR DESCRIPTION
Add CSS rule for markdown-rendered strong tags to override default padding