### PR TITLE
remove includeCount from the query params

### DIFF
--- a/client/webfield-v2.js
+++ b/client/webfield-v2.js
@@ -232,7 +232,7 @@ module.exports = (function() {
     };
     options = _.defaults(options, defaults);
 
-    query = _.omit(options, ['pageSize', 'includeCount']);
+    var query = _.omit(options, ['pageSize', 'includeCount']);
     query.limit = options.pageSize;
     query.invitation = invitationId;
 


### PR DESCRIPTION
the new API doesn't accept `includeCount` as a query param. 