### PR TITLE
Fix/ Revisions page error

### DIFF
--- a/pages/revisions/index.js
+++ b/pages/revisions/index.js
@@ -27,6 +27,7 @@ const ConfirmDeleteRestoreModal = ({
 
   useEffect(() => {
     if (!edit || !invitation) return
+
     const getAllSignatures = async () => {
       const result = await api.get('/groups', { regex: invitation.edit.signatures['values-regex'], signatory: user.id }, { accessToken })
       setSignatureDropdownOptions(result.groups.flatMap((p, i) => {

--- a/styles/pages/revisions.scss
+++ b/styles/pages/revisions.scss
@@ -202,7 +202,6 @@ main.revisions {
   .meta_actions {
     float: right;
     margin-right: 0;
-    padding-right: 15px;
 
     button {
       margin-left: .25rem;


### PR DESCRIPTION
the following error happened in revisions page
![image](https://user-images.githubusercontent.com/60613434/144137290-b02c9564-d34e-4d52-a27e-d4fefe678b2b.png)

ConfirmDeleteRestoreModal will only work with edits and running it against reference cause the error

this pr added a check to return early if it's a reference instead of edit