### PR TITLE
Fix/ Profile edit page: fix alignment of preferred name label

### DIFF
--- a/components/profile/NameSection.js
+++ b/components/profile/NameSection.js
@@ -11,7 +11,7 @@ const NamesButton = ({
 }) => {
   if (!newRow && readonly) {
     if (preferred) {
-      return <span className="preferred hint">(Preferred Name)</span>
+      return <div className="preferred hint">(Preferred Name)</div>
     }
     return <button type="button" className="btn preferred_button" onClick={handleMakePreferred}>Make Preferred</button>
   }

--- a/styles/pages/profile-edit.scss
+++ b/styles/pages/profile-edit.scss
@@ -180,7 +180,7 @@ main.profile-edit {
         text-overflow: ellipsis;
       }
     }
-    &__tilde-id {
+    &__tilde-id, .preferred {
       color: constants.$subtleGray;
       font-size: .75rem;
       margin-right: .5rem;


### PR DESCRIPTION
it seems that the alignment of "Preferred Name" text is a bit off


this pr should make it align with tilde id