### PR TITLE
fix/ React 17 breaking bootstrap dropdown

### DIFF
--- a/components/browser/EditEdgeDropdown.js
+++ b/components/browser/EditEdgeDropdown.js
@@ -2,11 +2,13 @@
 /* eslint-disable react/destructuring-assignment */
 /* globals $: false */
 
+import { useState } from 'react'
 import { getTooltipTitle } from '../../lib/edge-utils'
 
 export default function EditEdgeDropdown(props) {
   const defaultOption = props.default ? props.default : props.options[0]
   const showTrashButton = props.existingEdge?.writers?.length !== 0
+  const [showDropdown, setShowDropdown] = useState(false)
 
   const handleHover = (target) => {
     if (!props.existingEdge) return
@@ -25,19 +27,24 @@ export default function EditEdgeDropdown(props) {
         {props.label}
         :
       </label>
-      <div className="btn-group edit-edge-dropdown">
+      <div
+        className="btn-group edit-edge-dropdown"
+        onBlur={(e) => {
+          if (e.currentTarget?.contains(e.relatedTarget)) return // clicked option
+          setShowDropdown(false)
+        }}>
         <button
-          className="btn btn-default btn-xs btn-link dropdown-toggle"
+          className="btn btn-default btn-xs btn-link"
           type="button"
           data-toggle="dropdown"
           aria-haspopup="true"
           aria-expanded="false"
-          onClick={e => e.stopPropagation()}
+          onClick={(e) => { setShowDropdown(true); e.stopPropagation() }}
         >
           <span className="edge-weight">{props.selected ?? props.editEdgeTemplate?.defaultWeight}</span>
           <span className="caret" />
         </button>
-        <ul className="dropdown-menu">
+        <ul className={`dropdown-menu${showDropdown ? ' show' : ''}`}>
           {props.options && props.options.map(option => (
             <li key={option}>
               <a

--- a/styles/pages/edge-browser.scss
+++ b/styles/pages/edge-browser.scss
@@ -159,6 +159,10 @@ main.edge-browser {
         .dropdown-menu {
           min-width: 80px;
 
+          &.show {
+            display: block;
+          }
+
           & > li > a {
             font-size: .75rem;
             padding: 3px 10px;


### PR DESCRIPTION
the dropdown in edge browser calls stopPropagation to avoid creating a new column
event delegation changes in react 17 https://reactjs.org/blog/2020/08/10/react-v17-rc.html will cause it to break and when clicking on the button no options will be shown

this pr use a state and click and blur event to control the behavior of dropdown options