### PR TITLE
DBLP import - use match_phrase in paper title search

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -271,7 +271,7 @@ function titleNameTransformation(title) {
 
 async function searchPublicationTitle(title, authorIndex, authorNames, venue, accessToken) {
   const searchResults = await api.get('/notes/search', {
-    term: title,
+    term: `"${title}"`,
     invitation: 'dblp.org/-/record',
   }, {
     accessToken,
@@ -452,7 +452,7 @@ export async function getProfileByDblpUrl(dblpUrl, profileId) {
 export async function getAllPapersImportedByOtherProfiles(dblpPublications, profileId, accessToken) {
   return Promise.all(dblpPublications.map(async (publication) => {
     const searchResult = await api.get('/notes/search', {
-      term: publication.title,
+      term: `"${publication.title}"`,
       invitation: 'dblp.org/-/record',
     }, {
       accessToken,


### PR DESCRIPTION
match_phrase is added in https://github.com/openreview/openreview/pull/2499
which can reduce the data transmitted (search results) to the minimum

match_phrase will be used when the term starts and ends with double quote
seems the search and import is working fine when the paper to be imported has double quotes in paper title