### PR TITLE
Fix/ Guest users should not see privately revealed label

### DIFF
--- a/client/template-helpers.js
+++ b/client/template-helpers.js
@@ -311,7 +311,7 @@ Handlebars.registerHelper('noteAuthorsV2', function (readers, content, signature
   if (
     content?.authorids?.readers &&
     !content.authorids.readers.includes('everyone') &&
-    !_.isEqual(readers?.sort(), content?.authorids?.readers?.sort())
+    !_.isEqual(readers?.sort(), content.authorids.readers.sort())
   ) {
     // note reader and author reader are not the same
     privateLabel = true


### PR DESCRIPTION
when a user is guest, submission list of v2 may display 'privately revealed to you label' to guest user by comparing note.readers and note.content.authorids.readers

for a guest, note.content.authorids.readers does not exist so the not equal comparison becomes true

added a check of authorids readers