### PR TITLE
Fix/ Webfield: support venueid parameter in search options

### DIFF
--- a/client/webfield-v2.js
+++ b/client/webfield-v2.js
@@ -2073,11 +2073,13 @@ module.exports = (function() {
     });
   };
 
-  var searchSubmissions = function(groupId, term, options) {
+  var searchSubmissions = function(term, options) {
     var defaults = {
       pageSize: 100,
       offset: 0,
-      invitation: null
+      invitation: null,
+      venue: null,
+      venueid: null
     };
     options = _.assign(defaults, options);
 
@@ -2086,13 +2088,20 @@ module.exports = (function() {
       type: 'terms',
       content: 'all',
       source: 'forum',
-      group: groupId,
       limit: options.pageSize,
       offset: options.offset
     };
 
     if (options.invitation) {
       searchParams.invitation = options.invitation;
+    }
+
+    if (options.venueid) {
+      searchParams.venueid = options.venueid;
+    }
+
+    if (options.venue) {
+      searchParams.venue = options.venue;
     }
 
     return get('/notes/search', searchParams)
@@ -2163,7 +2172,12 @@ module.exports = (function() {
         searchParams.term += ' ' + searchParams.subject;
         searchParams.term = searchParams.term.trim();
       }
-      return searchSubmissions(groupId, searchParams.term, {pageSize: searchParams.pageSize, invitation: searchParams.invitation})
+      return searchSubmissions(searchParams.term, {
+        pageSize: searchParams.pageSize,
+        invitation: searchParams.invitation,
+        venue: searchParams.venue,
+        venueid: searchParams.venueid
+      })
         .then(searchParams.onResults);
     }
   };
@@ -2355,6 +2369,8 @@ module.exports = (function() {
         enabled: true,
         localSearch: true,
         invitation: null,
+        venue: null,
+        venueid: null,
         subjectAreas: null,
         subjectAreaDropdown: 'advanced',
         pageSize: 1000,
@@ -2454,6 +2470,8 @@ module.exports = (function() {
                 term: term,
                 pageSize: options.search.pageSize,
                 invitation: options.search.invitation,
+                venue: options.search.venue,
+                venueid: options.search.venueid,
                 onResults: options.search.onResults,
                 localSearch: options.search.localSearch
               });
@@ -2481,6 +2499,8 @@ module.exports = (function() {
                 pageSize: options.search.pageSize,
                 subject: selectedSubject,
                 invitation: options.search.invitation,
+                venue: options.search.venue,
+                venueid: options.search.venueid,
                 onResults: options.search.onResults,
                 localSearch: options.search.localSearch
               });
@@ -2514,6 +2534,8 @@ module.exports = (function() {
               pageSize: options.search.pageSize,
               subject: selectedSubject,
               invitation: options.search.invitation,
+              venue: options.search.venue,
+              venueid: options.search.venueid,
               onResults: options.search.onResults,
               localSearch: options.search.localSearch
             });
@@ -2551,6 +2573,8 @@ module.exports = (function() {
                 term: term,
                 pageSize: options.search.pageSize,
                 invitation: options.search.invitation,
+                venue: options.search.venue,
+                venueid: options.search.venueid,
                 onResults: options.search.onResults,
                 localSearch: options.search.localSearch
               }, extraParams));
@@ -2908,6 +2932,8 @@ module.exports = (function() {
         enabled: true,
         localSearch: false,
         invitation: invitation,
+        venue: options.query['content.venue'],
+        venueid: options.query['content.venueid'],
         onResults: function(searchResults) {
           Webfield.ui.searchResults(searchResults, searchResultsListOptions);
         },

--- a/client/webfield.js
+++ b/client/webfield.js
@@ -298,6 +298,10 @@ module.exports = (function() {
       searchParams.venue = options.venue;
     }
 
+    if (options.venueid) {
+      searchParams.venueid = options.venueid;
+    }
+
     return get('/notes/search', searchParams)
       .then(function(result) {
         return result.notes;
@@ -378,7 +382,12 @@ module.exports = (function() {
         searchParams.term += ' ' + searchParams.subject;
         searchParams.term = searchParams.term.trim();
       }
-      return searchSubmissions(groupId, searchParams.term, {pageSize: searchParams.pageSize, invitation: searchParams.invitation, venue: searchParams.venue})
+      return searchSubmissions(groupId, searchParams.term, {
+        pageSize: searchParams.pageSize,
+        invitation: searchParams.invitation,
+        venue: searchParams.venue,
+        venueid: searchParams.venueid
+      })
         .then(searchParams.onResults);
     }
   };
@@ -925,6 +934,7 @@ module.exports = (function() {
                 pageSize: options.search.pageSize,
                 invitation: options.search.invitation,
                 venue: options.search.venue,
+                venueid: options.search.venueid,
                 onResults: options.search.onResults,
                 localSearch: options.search.localSearch
               });
@@ -953,6 +963,7 @@ module.exports = (function() {
                 subject: selectedSubject,
                 invitation: options.search.invitation,
                 venue: options.search.venue,
+                venueid: options.search.venueid,
                 onResults: options.search.onResults,
                 localSearch: options.search.localSearch
               });
@@ -987,6 +998,7 @@ module.exports = (function() {
               subject: selectedSubject,
               invitation: options.search.invitation,
               venue: options.search.venue,
+              venueid: options.search.venueid,
               onResults: options.search.onResults,
               localSearch: options.search.localSearch
             });
@@ -1025,6 +1037,7 @@ module.exports = (function() {
                 pageSize: options.search.pageSize,
                 invitation: options.search.invitation,
                 venue: options.search.venue,
+                venueid: options.search.venueid,
                 onResults: options.search.onResults,
                 localSearch: options.search.localSearch
               }, extraParams));


### PR DESCRIPTION
Sometime we need to show different tabs in the venue home and each tab corresponds to a different venueid. The search should be able to filter the notes by venueid too. 