### PR TITLE
Fix/ Webfield: add option to filter invitations by paper number

### DIFF
--- a/client/webfield-v2.js
+++ b/client/webfield-v2.js
@@ -296,10 +296,8 @@ module.exports = (function() {
 
     var filterInviteeAndNumbers = function(inv) {
       var number = getNumberfromInvitation(inv.id, options.submissionGroupName);
-      if (number && options.numbers) {
-        return options.numbers.includes(number) && _.some(inv.invitees, function(invitee) { return invitee.indexOf(roleName) !== -1; });
-      }
-      return _.some(inv.invitees, function(invitee) { return invitee.indexOf(roleName) !== -1; });
+      var invMatchesNumber = !(number && options.numbers) || options.numbers.includes(number)
+      return _.some(inv.invitees, function(invitee) { return invitee.includes(roleName) }) && invMatchesNumber;
     };
 
     return $.when(


### PR DESCRIPTION
Editors in Chief can be Action Editors or Reviewers. The invitations should be filtered out by invitees AND assigned papers. 