### PR TITLE
Fix/v2 forum is not showing login banner for guest

### DIFF
--- a/client/view-v2.js
+++ b/client/view-v2.js
@@ -1138,6 +1138,7 @@ module.exports = (function() {
       buildEditor(editReaders, editSignatures, noteReaders, noteSignatures);
     } catch (error) {
       console.error(error);
+      if (error === 'no_results') error = 'You do not have permission to create a note'
       if (params.onError) {
         params.onError([error]);
       } else {


### PR DESCRIPTION
in view.buildsignaure it rejects with error 'no_results'
check for this error string and set the error to match the string in forum(v2).js error handler

with this pr it should show login banner instead of error message 'no_results' when guest click public comment