### PR TITLE
Fix/ Invitation webfield: note is undefined

### DIFF
--- a/pages/group/index.js
+++ b/pages/group/index.js
@@ -107,8 +107,9 @@ $(function() {
   };
 
   $('#group-container').empty();
-
-  ${webfieldCode}
+// START GROUP CODE
+${webfieldCode}
+// END GROUP CODE
 });
 //# sourceURL=webfieldCode.js`
   }

--- a/pages/invitation/index.js
+++ b/pages/invitation/index.js
@@ -161,7 +161,11 @@ $(function() {
 
   $('#invitation-container').empty();
 
-  ${noteEditorCode || webfieldCode}
+  ${noteEditorCode || `(function(note) {
+// START INVITATION CODE
+${webfieldCode}
+// END INVITATION CODE
+  })(null);`}
 });
 //# sourceURL=webfieldCode.js`
   }


### PR DESCRIPTION
Pass note arg to webfield code to fix edge case that occurs when the invitation page is loaded without and url params.