### PR TITLE
Fix/ Bidding console: disable button after bid is removed

### DIFF
--- a/client/webfield.js
+++ b/client/webfield.js
@@ -1077,6 +1077,12 @@ module.exports = (function() {
           ddate = Date.now();
           $self.removeClass('active');
           $self.children('input').prop('checked', false);
+          $self.attr('disabled', true)
+          $self.attr("style", "pointer-events:none");
+          setTimeout(function() {
+            $self.attr('disabled', false)
+            $self.attr("style", "pointer-events:auto");
+          }, 1500)
           returnVal = false;
         }
 


### PR DESCRIPTION
Disables button after a bid is removed and enables it after a while, allowing the paper to be removed from the bid tab (to avoid the content and count being out of sync)

@Xukun proposed adding `pointer-events:none` to the button.

Fixes #551 