### PR TITLE
Edge browser - allow search of profiles when column has no items

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -776,7 +776,8 @@ export default function Column(props) {
   }
 
   useEffect(() => {
-    if (!items || !items.length) {
+    if (!items) return
+    if (!items.length && !parentId) {
       return
     }
     // Reset column to show original items and no search heading


### PR DESCRIPTION
in https://github.com/openreview/openreview-py/pull/1219
the ethics chair can't see the ethics reviewer because there's no edge associating the paper and ethics reviewer

currently the logic will skip search in global entity map if the reviewer column is empty

this pr should allow search in global entity map even if the column is empty