### PR TITLE
Fix/deleteOrRestoreNote should call to getCopiedValues to update the properties of the note

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -2420,6 +2420,8 @@ module.exports = (function() {
     if (isDeleted) {
       // Restore deleted note
       newNote.ddate = null;
+      newNote.writers = getWriters(newNote.details.invitation, newNote.signatures, user);
+      newNote = getCopiedValues(newNote, newNote.details.invitation.reply);
       return Webfield.post('/notes', newNote, { handleErrors: false }).then(function(updatedNote) {
         onTrashedOrRestored(Object.assign(newNote, updatedNote));
       }, function(jqXhr, textStatus) {
@@ -2435,6 +2437,8 @@ module.exports = (function() {
       }
       newNote.signatures = newSignatures;
       newNote.ddate = Date.now();
+      newNote.writers = getWriters(newNote.details.invitation, newSignatures, user);
+      newNote = getCopiedValues(newNote, newNote.details.invitation.reply);
       Webfield.post('/notes', newNote, { handleErrors: false }).then(function(updatedNote) {
         onTrashedOrRestored(Object.assign(newNote, updatedNote));
       }, function(jqXhr, textStatus) {


### PR DESCRIPTION
currently writers is not touched when a note is deleted or restored
this pr should update the writers 

logic is the same as editing a note