### PR TITLE
Fix/Error accepting/rejecting v2 recruitment invitation

### DIFF
--- a/client/view-v2.js
+++ b/client/view-v2.js
@@ -1473,9 +1473,13 @@ module.exports = (function() {
             if (params.isEdit) {
               params.onNoteEdited();
             } else {
-              Webfield2.get('/notes', { id: note.id }).then(function (result) {
-                params.onNoteEdited(result);
-              })
+              if (note.id) { // recruitment invitation web may pass note without id
+                Webfield2.get('/notes', { id: note.id }).then(function (result) {
+                  params.onNoteEdited(result);
+                });
+              } else {
+                params.onNoteEdited();
+              }
             }
           }
           $noteEditor.remove();


### PR DESCRIPTION
in mkNoteEditor in view-v2.js, it's getting the note before calling params.onNoteEdited()
this is because view-v2 is posting edits and the return of POST to /notes/edits is the edit instead of the note

mkNoteEditor is used to edit existing notes and note.id can be used to get the updated note after posting an edit.

but it's also used by recruitment invitation webfield which constructed an object from url param which is not an actual note and caused validation error because it's calling /notes without id/invitation and when a user accept/reject a v2 recruitment invitation it will show an error.

this pr should fix that by skipping the call when there's no id