### PR TITLE
Fix/API 2 compare revisions: authors and authorids are not being shown in the same order

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -463,8 +463,8 @@ export function editNoteContentDiff(leftEdit, rightEdit) {
 
   const constructDiff = (keys) =>
     keys.reduce((result, key) => {
-      let leftValue = key.split('.').reduce((p, q) => p?.[q], leftEdit)
-      let rightValue = key.split('.').reduce((p, q) => p?.[q], rightEdit)
+      const leftValue = key.split('.').reduce((p, q) => p?.[q], leftEdit)
+      const rightValue = key.split('.').reduce((p, q) => p?.[q], rightEdit)
 
       if (!isEqual(leftValue, rightValue)) {
         // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
this pr should remove array sorting when edits are compared in revisions page