### PR TITLE
Fix/ add "Cancelled" status

### DIFF
--- a/pages/assignments/index.js
+++ b/pages/assignments/index.js
@@ -118,7 +118,7 @@ const AssignmentRow = ({
       </td>
 
       <td className="assignment-actions">
-        {['Initialized', 'Error', 'No Solution'].includes(status) && (
+        {['Initialized', 'Error', 'No Solution', 'Cancelled'].includes(status) && (
           <ActionLink
             label="Run Matcher"
             iconName="cog"


### PR DESCRIPTION
status "Cancelled" of a assignment config note means there's some server interruption such as matching server restart when the matching is running

it's an internal status used by the matching and matching is not cancellable by the user

related to https://github.com/openreview/openreview-py/pull/1310#issuecomment-1158113693