### PR TITLE
Fix/ API client: getCombined error

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -177,10 +177,13 @@ const getCombined = async (path, data1 = {}, data2 = null, options = {}) => {
 
   if (!process.env.API_V2_URL) {
     const results = await get(path, data1, options)
-    return {
-      ...results,
-      [resultsKey]: results[resultsKey].map((p) => ({ ...p, apiVersion: 1 })),
+    if (options.includeVersion) {
+      return {
+        ...results,
+        [resultsKey]: results[resultsKey]?.map((p) => ({ ...p, apiVersion: 1 })) ?? [],
+      }
     }
+    return results
   }
 
   const [apiRes1, apiRes2] = await Promise.all([
@@ -188,8 +191,16 @@ const getCombined = async (path, data1 = {}, data2 = null, options = {}) => {
     get(path, data2 ?? data1, { ...options, version: 2 }).catch((error) => error),
   ])
 
-  const results1 = apiRes1[resultsKey].map((p) => ({ ...p, apiVersion: 1 })) ?? []
-  const results2 = apiRes2[resultsKey].map((p) => ({ ...p, apiVersion: 2 })) ?? []
+  let results1
+  let results2
+  if (options.includeVersion) {
+    results1 = apiRes1[resultsKey]?.map((p) => ({ ...p, apiVersion: 1 })) ?? []
+    results2 = apiRes2[resultsKey]?.map((p) => ({ ...p, apiVersion: 2 })) ?? []
+  } else {
+    results1 = apiRes1[resultsKey] ?? []
+    results2 = apiRes2[resultsKey] ?? []
+  }
+
   const sortOptions = {
     'cdate:asc': (a, b) => a.cdate - b.cdate,
     'cdate:desc': (a, b) => b.cdate - a.cdate,

--- a/pages/tasks.js
+++ b/pages/tasks.js
@@ -26,7 +26,7 @@ const Tasks = ({ appContext }) => {
       duedate: true,
       details: 'repliedTags',
     }
-    const commonOptions = { accessToken }
+    const commonOptions = { accessToken, includeVersion: true }
 
     const invitationPromises = [
       api


### PR DESCRIPTION
When api v2 throws an error in the getCombined function the current function is still trying to call map on the results, causing an error.