### PR TITLE
Fix/Wrong file type error in file upload

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -3714,11 +3714,16 @@ module.exports = (function() {
               var chunkSize = 1024 * 1000 * 5; //5mb
               var chunkCount = Math.ceil(file.size / chunkSize);
               var clientUploadId = nanoid();
-              var chunks = Array.from(new Array(chunkCount), (e, chunkIndex) => {
-                return file.slice(
-                  chunkIndex * chunkSize,
-                  (chunkIndex + 1) * chunkSize,
-                  file.type
+              var chunks = Array.from(new Array(chunkCount), function (e, chunkIndex) {
+                return new File(
+                  [
+                    file.slice(
+                      chunkIndex * chunkSize,
+                      (chunkIndex + 1) * chunkSize,
+                      file.type
+                    )
+                  ],
+                  file.name
                 );
               });
               var sendSingleChunk = function (chunk, index) {


### PR DESCRIPTION
this is the ui change missed after changing the file validation from MIME type validation to file name validation

when the file is sliced the file name in api becomes to be always "blob"
by converting blob to file the correct file name can be added to each blob/chunk 