### PR TITLE
Fix/Check profile name deletion invitation

### DIFF
--- a/components/profile/NameSection.js
+++ b/components/profile/NameSection.js
@@ -252,7 +252,7 @@ const NamesSection = ({ profileNames, updateNames, preferredUsername }) => {
       if (invitationResult.invitations.length) {
         setShowDeleteNameButton(true)
       }
-    } catch (error) {}
+    } catch (error) {} // eslint-disable-line no-empty
     // #endregion
     try {
       const result = await api.get(


### PR DESCRIPTION
this pr should hide delete name button in profile edit page before creation of profile name deletion invitation

delete name button should be displayed after profile name deletion invitation is created
related openreview-py pr is https://github.com/openreview/openreview-py/pull/1361