### PR TITLE
Fix/User moderation and profile compare page - show active/block when there's no state

### DIFF
--- a/pages/profile/compare.js
+++ b/pages/profile/compare.js
@@ -482,9 +482,11 @@ const Compare = ({ left, right, accessToken, appContext }) => {
     }
     const toProfile = {
       id: basicProfiles[to].id,
-      active: ['Active Institutional', 'Active Automatic', 'Active'].includes(
-        basicProfiles[to].state
-      ),
+      active: basicProfiles[to].state
+        ? ['Active Institutional', 'Active Automatic', 'Active'].includes(
+            basicProfiles[to].state
+          )
+        : basicProfiles[to].active,
       state: basicProfiles[to].state,
     }
     const postMerge = async () => {
@@ -504,7 +506,9 @@ const Compare = ({ left, right, accessToken, appContext }) => {
       if (
         // eslint-disable-next-line no-alert
         window.confirm(
-          `You are merging an ${fromProfile.state} profile into an ${toProfile.state} profile. Are you sure you want to proceed?`
+          `You are merging an ${fromProfile.state ?? 'active'} profile into an ${
+            toProfile.state ?? 'inactive'
+          } profile. Are you sure you want to proceed?`
         )
       ) {
         postMerge()

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -615,7 +615,7 @@ const UserModerationQueue = ({
   }
 
   const blockUnblockUser = async (profile) => {
-    const actionIsBlock = profile?.state !== 'Blocked'
+    const actionIsBlock = profile?.state !== 'Blocked' && !profile?.block
     const signedNotes = !onlyModeration
       ? await api.getCombined('/notes', { signature: profile.id }, null, {
           accessToken,
@@ -699,7 +699,9 @@ const UserModerationQueue = ({
             return (
               <li
                 key={profile.id}
-                className={`${profile.state === 'Blocked' ? 'blocked' : null}`}
+                className={`${
+                  profile.state === 'Blocked' || profile.block ? 'blocked' : null
+                }`}
               >
                 <span className="col-name">
                   <a
@@ -717,8 +719,12 @@ const UserModerationQueue = ({
                   <span className={`label label-${profile.password ? 'success' : 'danger'}`}>
                     password
                   </span>{' '}
-                  <span className={getProfileStateLabelClass(profile.state)}>
-                    {profile.state}
+                  <span
+                    className={getProfileStateLabelClass(
+                      profile.state ?? (profile.active ? 'Active' : 'Inactive')
+                    )}
+                  >
+                    {profile.state ?? 'active'}
                   </span>
                 </span>
                 <span className="col-actions">
@@ -751,7 +757,7 @@ const UserModerationQueue = ({
                     </>
                   ) : (
                     <>
-                      {!profile.state === 'Blocked' && profile.active && (
+                      {!(profile.state === 'Blocked' || profile.block) && profile.active && (
                         <button
                           type="button"
                           className="btn btn-xs"
@@ -766,9 +772,15 @@ const UserModerationQueue = ({
                         onClick={() => blockUnblockUser(profile)}
                       >
                         <Icon
-                          name={`${profile.state === 'Blocked' ? 'refresh' : 'ban-circle'}`}
+                          name={`${
+                            profile.state === 'Blocked' || profile.block
+                              ? 'refresh'
+                              : 'ban-circle'
+                          }`}
                         />{' '}
-                        {`${profile.state === 'Blocked' ? 'Unblock' : 'Block'}`}
+                        {`${
+                          profile.state === 'Blocked' || profile.block ? 'Unblock' : 'Block'
+                        }`}
                       </button>
                     </>
                   )}


### PR DESCRIPTION
this pr should show active/inactive correctly when there's no profile state

currently it shows empty or undefined

changes in this pr should be reverted when profile states are migrated