### PR TITLE
Fix/ Bid widget: remove tauthor condition

### DIFF
--- a/client/template-helpers.js
+++ b/client/template-helpers.js
@@ -613,7 +613,7 @@ Handlebars.registerHelper(
       var idx = _.findIndex(tagInvitations, function (inv) {
         return inv.id === tag.invitation
       })
-      if (tag.tauthor && idx > -1) {
+      if (idx > -1) {
         addPairToCollection(tagsWithInvitations, [[tag], tagInvitations[idx]])
       } else {
         addPairToCollection(tagsWithoutInvitations, [[tag], null])


### PR DESCRIPTION
When we edit the edges as super user, the tauthor changes to OpenReview.net and the reviewers/AC doesn't get the tauthor  when getting the bids in the UI.

The UI validates there is a tauthor in order to show the edge. I'm not sure why this condition is there. 

Removing the condition fixes the issue. 