### PR TITLE
Fix/ Mathjax defer call to typeset

### DIFF
--- a/components/EditorComponents/Markdown.js
+++ b/components/EditorComponents/Markdown.js
@@ -19,8 +19,13 @@ const Markdown = ({ text }) => {
   }, [text])
 
   useEffect(() => {
-    if (sanitizedHtml && containerEl.current) {
-      MathJax.typesetPromise([containerEl.current])
+    if (sanitizedHtml && containerEl.current && MathJax.startup?.promise) {
+      MathJax.startup.promise
+        .then(() => MathJax.typesetPromise([containerEl.current]))
+        .catch(() => {
+          // eslint-disable-next-line no-console
+          console.warn('Could not typeset TeX content')
+        })
     }
   }, [sanitizedHtml, containerEl])
 


### PR DESCRIPTION
Use MathJax.startup.promise to defer typesetting until after MathJax is loaded.

Fixes issue reported here: https://github.com/openreview/openreview-web/pull/1111#discussion_r993878821