### PR TITLE
Limited profile - show banner only to profile owner

### DIFF
--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -312,7 +312,9 @@ const Profile = ({ profile, publicProfile, appContext }) => {
         <title key="title">{`${profile.preferredName} | OpenReview`}</title>
       </Head>
 
-      {profile.state === 'Limited' && <LimitedStatusAlert />}
+      {profile.state === 'Limited' && profile.id === user?.profile?.id && (
+        <LimitedStatusAlert />
+      )}
 
       <header className="clearfix">
         <div className="title-container">


### PR DESCRIPTION
currently the limited status banner can be seen even if the logged in user is not owner of profile

i think only profile owner should see this banner