### PR TITLE
Fix/ Venue homepage: don't show homepage in user console list

### DIFF
--- a/components/webfield/VenueHomepage.js
+++ b/components/webfield/VenueHomepage.js
@@ -66,7 +66,9 @@ function ConsolesList({
         }
         if (userGroups?.length > 0) {
           userGroups.forEach((g) => {
-            groupIds.push(g.id)
+            if (g.id !== venueId) {
+              groupIds.push(g.id)
+            }
           })
         }
         setUserConsoles(uniq(groupIds))


### PR DESCRIPTION
Currently PCs of API 2 venues are shown the venue homepage in their list of consoles. This PR filters that ID from the list of groups.