### PR TITLE
Fix/ Author console: check if email is confirmed

### DIFF
--- a/components/webfield/NoteSummary.js
+++ b/components/webfield/NoteSummary.js
@@ -42,14 +42,25 @@ const NoteSummary = ({ note, referrerUrl, isV2Note, profileMap, showDates = fals
           {authorsValue.map((authorName, i) => {
             const authorId = authorIdsValue[i]
             const authorProfile = profileMap?.[authorIdsValue[i]]
+            const errorTooltip = authorProfile
+              ? 'Profile not yet activated'
+              : 'Profile not yet created or email not confirmed'
             return (
               <span key={authorId}>
                 {authorName}
                 {profileMap && (
                   authorProfile?.active ? (
-                    <Icon name="ok-sign" tooltip="Profile active" extraClasses="pl-1 text-success" />
+                    <Icon
+                      name="ok-sign"
+                      tooltip="Profile is active and email confirmed"
+                      extraClasses="pl-1 text-success"
+                    />
                   ) : (
-                    <Icon name="remove-sign" tooltip="Profile inactive" extraClasses="pl-1 text-danger" />
+                    <Icon
+                      name="remove-sign"
+                      tooltip={errorTooltip}
+                      extraClasses="pl-1 text-danger"
+                    />
                   )
                 )}
               </span>


### PR DESCRIPTION
Currently the author console gets some profiles by email, meaning it's possible that the if the email has been added to a users profile but not confirmed the console will still show a green check next to their name. This PR fixes this by:

- Use emailsConfirmed to load profiles
- Change error tooltip based on what's missing
- Properly display tooltips on icons