### PR TITLE
Fix/Sign up page - remove profile search limit

### DIFF
--- a/pages/signup.js
+++ b/pages/signup.js
@@ -42,7 +42,7 @@ const SignupForm = ({ setSignupConfirmation }) => {
     debounce(async (first, last) => {
       try {
         // Don't include middle name in profile search to find more results
-        const { profiles } = await api.get('/profiles', { first, last, limit: 50 })
+        const { profiles } = await api.get('/profiles', { first, last })
         if (profiles) {
           setExistingProfiles(
             profiles.map((profile) => ({


### PR DESCRIPTION
this pr should remove the limit of 50 profiles.
for very common names, the number of profiles returned can >50 so it's possible that some user won't be able to claim a profile.