### PR TITLE
Fix/Profile edit page - trim first middle and last name before saving

### DIFF
--- a/components/profile/ProfileEditor.js
+++ b/components/profile/ProfileEditor.js
@@ -119,9 +119,14 @@ export default function ProfileEditor({
       return promptInvalidLink('homepage', 'You must enter at least one personal link')
     }
     // must not have any invalid links
-    const invalidLinkName = personalLinkNames.find((p) => profileContent[p]?.value && profileContent[p].valid === false)
+    const invalidLinkName = personalLinkNames.find(
+      (p) => profileContent[p]?.value && profileContent[p].valid === false
+    )
     if (invalidLinkName) {
-      return promptInvalidLink(invalidLinkName, 'One of your personal links is invalid. Please make sure all URLs start with http:// or https://')
+      return promptInvalidLink(
+        invalidLinkName,
+        'One of your personal links is invalid. Please make sure all URLs start with http:// or https://'
+      )
     }
     // #endregion
 
@@ -282,7 +287,10 @@ export default function ProfileEditor({
       names: profileContent.names.map((p) => {
         const fieldsToInclude = ['first', 'middle', 'last', 'preferred']
         if (!p.newRow && p.username) fieldsToInclude.push('username')
-        return pick(p, fieldsToInclude)
+        return pick(
+          { ...p, first: p.first.trim(), middle: p.middle.trim(), last: p.last.trim() },
+          fieldsToInclude
+        )
       }),
       emails: profileContent.emails.map((p) => p.email),
       history: profileContent.history.map((p) =>


### PR DESCRIPTION
just realized that we never had logic to remove space from names so user can always add name with heading/trailing space

so add the logic to remove space before saving the profile.