### PR TITLE
DBLP import - erroneous name lookup may cause duplicated notes to be created

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -320,7 +320,7 @@ async function searchPublicationTitle(title, authorIndex, authorNames, venue, ac
         return {
           paperExistInOpenReview: true,
           authorNameInAuthorsList: note.content.authors.some((name) =>
-            authorNames.includes(name)
+            authorNames.map((authorName) => getNameString(authorName)).includes(name)
           ),
           paperId: note.forum,
           authorIds: note.content.authorids,


### PR DESCRIPTION
found this while checking the issue reported that dblp import failed but notes are in activities page (the error of import failure is caused by mismatch of email/id group member ship)

the erroneous name lookup logic will cause a new note to be posted after the email/profile id matching is corrected