### PR TITLE
Fix/ Tasks page: recommendation invitations throw JS error

### DIFF
--- a/client/webfield.js
+++ b/client/webfield.js
@@ -2020,7 +2020,7 @@ module.exports = (function () {
             // number of papers assigned.
             if (_.endsWith(inv.id, 'Recommendation')) {
               var groupedEdgesCounts = _.countBy(inv.details.repliedEdges, 'head')
-              var allPapersRecommended = Object.keys(groupedEdgesCounts).length >= 15
+              var allPapersRecommended = Object.keys(groupedEdgesCounts).length >= 30
               inv.completed =
                 allPapersRecommended &&
                 _.every(groupedEdgesCounts, function (count) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -791,7 +791,7 @@ export function formatTasksData(
           const groupedEdgesCounts = countBy(inv.details.repliedEdges, 'head')
           const headIds = Object.keys(groupedEdgesCounts)
           inv.completed =
-            headIds.length >= 15 &&
+            headIds.length >= 30 &&
             headIds.every((headId) => groupedEdgesCounts[headId] >= completionCount)
         } else {
           inv.completed = true


### PR DESCRIPTION
Fix JS error with Recommendation invitations. Currently Recommendation invitations are being omitted from the Tasks page because of an error in the special case code.