### PR TITLE
Fix/ Tasks page: don't show public invitations

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -818,7 +818,7 @@ export function formatTasksData(
   }
 
   const isNotPublicInvitation = (invitation) =>
-    intersection(['(everyone)', '~', '(guest)'], invitation.invitees).length === 0
+    intersection(['everyone', '~', '(guest)', '(anonymous)'], invitation.invitees).length === 0
 
   if (skipGrouping) {
     return tagInvitations


### PR DESCRIPTION
Filter out tasks that include the invitees ~, (everyone), or (guest)

Fixes #1221 