### PR TITLE
Fix/ Edge browser invite reviewer form validation

### DIFF
--- a/components/browser/EditEdgeInviteEmail.js
+++ b/components/browser/EditEdgeInviteEmail.js
@@ -91,6 +91,7 @@ const EditEdgeInviteEmail = ({
         }}
       >
         <input
+          type="text"
           id="email-invite"
           autoComplete="off"
           value={emailToInvite}


### PR DESCRIPTION
@celestemartinez found the issue that inviting external reviewer using tilde id is causing form validation error

the input has type=email so when the data is converted to be submitted through the form tilde id will fail email validation