### PR TITLE
Fix/ Edge browser - show custom max papers when the default is 0

### DIFF
--- a/components/browser/ProfileEntity.js
+++ b/components/browser/ProfileEntity.js
@@ -52,7 +52,7 @@ export default function ProfileEntity(props) {
     )?.weight ?? defaultWeight
 
   ignoreHeadBrowseInvitations.forEach((p) => {
-    if (!p.defaultLabel && !p.defaultWeight) return
+    if (!p.defaultLabel && !p.defaultWeight && p.defaultWeight !== 0) return
     if (!browseEdges?.find((q) => q.invitation === p.id)) {
       browseEdges = browseEdges.concat({
         id: nanoid(),


### PR DESCRIPTION
this pr should fix the issue that custom max papers browse edge is not shown when the default weight in custom max papers invitation is 0