### PR TITLE
Fix/ Forum page: hide PDF icon if readers are restricted

### DIFF
--- a/components/NoteContent.js
+++ b/components/NoteContent.js
@@ -163,11 +163,9 @@ export const NoteContentV2 = ({
     'title',
     'authors',
     'authorids',
-    'pdf',
     'verdict',
     'paperhash',
     'ee',
-    'html',
     'year',
     'venue',
     'venueid',
@@ -192,6 +190,9 @@ export const NoteContentV2 = ({
         const showPrivateIcon =
           fieldReaders && noteReaders && !fieldReaders.every((p, j) => p === noteReaders[j])
 
+        // Only show the PDF and HTML field in note content if it has restricted readers
+        if ((fieldName === 'pdf' || fieldName === 'html') && !showPrivateIcon) return null
+
         return (
           <div key={fieldName}>
             <NoteContentField name={fieldName} />{' '}
@@ -204,7 +205,7 @@ export const NoteContentV2 = ({
                   .join(', ')}`}
               />
             )}
-            {fieldValue.startsWith('/attachment/') ? (
+            {(fieldValue.startsWith('/attachment/') || fieldValue.startsWith('/pdf/')) ? (
               <span className="note-content-value">
                 <DownloadLink
                   noteId={id}

--- a/components/forum/ForumNote.js
+++ b/components/forum/ForumNote.js
@@ -28,6 +28,17 @@ function ForumNote({ note, updateNote }) {
   const [activeNote, setActiveNote] = useState(null)
   const { user } = useUser()
 
+  const canShowIcon = (fieldName) => {
+    if (!content[fieldName]?.value) return false
+
+    const fieldReaders = Array.isArray(content[fieldName].readers)
+      ? content[fieldName].readers.sort()
+      : null
+    return (
+      !fieldReaders || (note.readers && fieldReaders.every((p, j) => p === note.readers[j]))
+    )
+  }
+
   const openNoteEditor = (invitation, options) => {
     if (activeInvitation && activeInvitation.id !== invitation.id) {
       promptError(
@@ -94,8 +105,8 @@ function ForumNote({ note, updateNote }) {
       <ForumTitle
         id={id}
         title={content.title?.value}
-        pdf={content.pdf?.value}
-        html={content.html?.value}
+        pdf={canShowIcon('pdf')}
+        html={canShowIcon('html')}
       />
 
       <div className="forum-authors mb-2">


### PR DESCRIPTION
Instead show pdf download in note contents with private icon.

Fixes #1336 