### PR TITLE
Fix/Edge browser - sort by bid is not working

### DIFF
--- a/lib/edge-utils.js
+++ b/lib/edge-utils.js
@@ -338,10 +338,10 @@ export function translateFieldSpec(invitation, fieldName, version) {
     if (field.param?.regex) {
       spec['value-regex'] = field.param.regex
       spec.query = {
-        'value-regex': field.param.regex
+        'value-regex': field.param.regex,
       }
     }
-    if (field.param?.enum && field.param?.input?.radio) {
+    if (field.param?.enum && field.param?.input === 'radio') {
       spec['value-radio'] = field.param.enum
     }
     if (field.param?.enum) {


### PR DESCRIPTION
sort by bid in edge browser is not working for v2

the sort fn checks for sorting labels which is spec['value-radio'], otherwise the sort will be using weight instead of label

the bid invitation will also need to specify label.param.input to be 'radio'