### PR TITLE
Note readers (v1) - Add support of multiple regex in values-dropdown

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -4089,7 +4089,7 @@ module.exports = (function () {
           } else {
             fieldDescription['values-dropdown'].splice(regexIndex, 1)
           }
-          return updateFieldDescription(result.groups)
+          return updateFieldDescription()
         })
       } else {
         extraGroupsP = Promise.resolve([])


### PR DESCRIPTION
when invitation.reply.readers is defined as values-dropdown which contains multiple .* regex
only the first regex is used in api call to get groups and the groups will replace the .* regex and displayed as an option in the dropdown.

this pr should support multiple .* regexes in values-dropdown by recursively updating/replacing the readers fieldDescription

an example is 
```javascript
"values-dropdown" : [
                "lifelong-ml.cc/CoLLAs/2023/Conference/Program_Chairs",
                "lifelong-ml.cc/CoLLAs/2023/Conference/Paper4/Reviewers",
                "lifelong-ml.cc/CoLLAs/2023/Conference/Paper4/Reviewer_.*",
                "lifelong-ml.cc/CoLLAs/2023/Conference/Paper4/Senior_Reviewer_.*",
                "lifelong-ml.cc/CoLLAs/2023/Conference/Paper4/Senior_Reviewers"
            ]
``` 
master
<img width="496" alt="image" src="https://user-images.githubusercontent.com/60613434/228666945-7727de97-f792-4a99-abea-8d449e1e5ca4.png">

with changes in this pr
<img width="496" alt="image" src="https://user-images.githubusercontent.com/60613434/228666845-4b8311dc-3b5f-4d28-a222-993c8019c245.png">

