### PR TITLE
Fix/SAC console tasks - revert the way of getting invitations

### DIFF
--- a/components/webfield/SeniorAreaChairConsole/SeniorAreaChairTasks.js
+++ b/components/webfield/SeniorAreaChairConsole/SeniorAreaChairTasks.js
@@ -13,50 +13,57 @@ const SeniorAreaChairTasks = () => {
   const [isLoading, setIsLoading] = useState(true)
   const { venueId, apiVersion, seniorAreaChairName } = useContext(WebFieldContext)
 
-  const addInvitaitonTypeAndVersion = (invitation) => {
-    let invitaitonType = 'tagInvitation'
-    if (apiVersion === 2 && invitation.edit?.note) invitaitonType = 'noteInvitation'
-    if (apiVersion === 1 && !invitation.reply.content?.tag && !invitation.reply.content?.head)
-      invitaitonType = 'noteInvitation'
-    return { ...invitation, [invitaitonType]: true, apiVersion }
-  }
-
   const loadInvitations = async () => {
     try {
-      let allInvitations = await api.getAll(
-        '/invitations',
-        {
-          ...(apiVersion !== 2 && { regex: `${venueId}/.*` }),
-          ...(apiVersion === 2 && { prefix: `${venueId}/.*` }),
-          invitee: true,
-          duedate: true,
-          type: 'all',
-        },
-        { accessToken, version: apiVersion }
+      let allInvitations = await Promise.all([
+        api.getAll(
+          '/invitations',
+          {
+            prefix: `${venueId}/.*`,
+            invitee: true,
+            duedate: true,
+            replyto: true,
+            type: 'note',
+            details: 'replytoNote,repliedNotes',
+          },
+          { accessToken, version: 2 }
+        ),
+        api.getAll(
+          '/invitations',
+          {
+            prefix: `${venueId}/.*`,
+            invitee: true,
+            duedate: true,
+            type: 'edge',
+            details: 'repliedEdges',
+          },
+          { accessToken, version: 2 }
+        ),
+        api.getAll(
+          '/invitations',
+          {
+            prefix: `${venueId}/.*`,
+            invitee: true,
+            duedate: true,
+            type: 'tag',
+            details: 'repliedTags',
+          },
+          { accessToken, version: 2 }
+        ),
+      ]).then(([noteInvitations, edgeInvitations, tagInvitations]) =>
+        noteInvitations
+          .map((inv) => ({ ...inv, noteInvitation: true, apiVersion: 2 }))
+          .concat(
+            edgeInvitations.map((inv) => ({ ...inv, tagInvitation: true, apiVersion: 2 }))
+          )
+          .concat(
+            tagInvitations.map((inv) => ({ ...inv, tagInvitation: true, apiVersion: 2 }))
+          )
       )
 
       allInvitations = allInvitations
-        .map((p) => addInvitaitonTypeAndVersion(p))
         .filter((p) => filterHasReplyTo(p, apiVersion))
         .filter((p) => p.invitees.some((invitee) => invitee.includes(seniorAreaChairName)))
-
-      if (allInvitations.length) {
-        // add details
-        const validInvitationDetails = await api.getAll(
-          '/invitations',
-          {
-            ids: allInvitations.map((p) => p.id),
-            details: 'all',
-            select: 'id,details',
-          },
-          { accessToken, version: apiVersion }
-        )
-
-        allInvitations.forEach((p) => {
-          // eslint-disable-next-line no-param-reassign
-          p.details = validInvitationDetails.find((q) => q.id === p.id)?.details
-        })
-      }
 
       setInvitations(formatTasksData([allInvitations, [], []], true))
     } catch (error) {


### PR DESCRIPTION
currently sac console tasks tab will get invitations using the following 2 queries:
1. prefix =venueid and type=all to get invitations without detail
2. get invitation details using invitation ids

step2 may fail when there are many tasks, so revert the queries to separate call for each invitation type.