### PR TITLE
Fix/SAC Console - Filter out withdrawn/rejected papers

### DIFF
--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -36,6 +36,8 @@ const SeniorAreaChairConsole = ({ appContext }) => {
     decisionName = 'Decision',
     recommendationName,
     edgeBrowserDeployedUrl,
+    withdrawnVenueId,
+    deskRejectedVenueId,
   } = useContext(WebFieldContext)
   const { setBannerContent } = appContext
   const { user, accessToken, userLoading } = useUser()
@@ -51,16 +53,25 @@ const SeniorAreaChairConsole = ({ appContext }) => {
     try {
       // #region getSubmissions
       const notesP = submissionId
-        ? api.getAll(
-            '/notes',
-            {
-              invitation: submissionId,
-              details: 'invitation,tags,original,replyCount,directReplies',
-              select: 'id,number,forum,content,details,invitations,invitation,readers',
-              sort: 'number:asc',
-            },
-            { accessToken, version: apiVersion }
-          )
+        ? api
+            .getAll(
+              '/notes',
+              {
+                invitation: submissionId,
+                details: 'invitation,tags,original,replyCount,directReplies',
+                select: 'id,number,forum,content,details,invitations,invitation,readers',
+                sort: 'number:asc',
+              },
+              { accessToken, version: apiVersion }
+            )
+            .then((notes) =>
+              notes.filter(
+                (note) =>
+                  ![withdrawnVenueId, deskRejectedVenueId].includes(
+                    note.content?.venueid?.value
+                  )
+              )
+            )
         : Promise.resolve([])
       // #endregion
 


### PR DESCRIPTION
SAC console may send reminder to ACs if some paper under this ac is rejected/withdrawn and does not have meta review.

this pr should filter out withdrawn and rejected papers from SAC console.

two extra configs are required:
```javascript
withdrawnVenueId: domain.content.withdrawn_venue_id.value,
deskRejectedVenueId: domain.content.desk_rejected_venue_id.value,
``` 