### PR TITLE
Fix/Bid console error pressing enter key when there's no scores and subject areas

### DIFF
--- a/components/webfield/BidConsole.js
+++ b/components/webfield/BidConsole.js
@@ -307,7 +307,15 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
       <form
         className="form-inline notes-search-form"
         role="search"
-        onSubmit={(e) => e.preventDefault()}
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (searchState.immediateSearchTerm.trim().length >= 2) {
+            setSearchState({
+              type: 'searchTerm',
+              payload: searchState.immediateSearchTerm,
+            })
+          }
+        }}
       >
         <div className="form-group search-content has-feedback">
           <input
@@ -320,14 +328,6 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
             onChange={(e) => {
               setSearchState({ type: 'immediateSearchTerm', payload: e.target.value })
               if (e.target.value.trim().length >= 3) delaySearch(e.target.value)
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && searchState.immediateSearchTerm.trim().length >= 2) {
-                setSearchState({
-                  type: 'searchTerm',
-                  payload: searchState.immediateSearchTerm,
-                })
-              }
             }}
           />
           <Icon name="search" extraClasses="form-control-feedback" />
@@ -358,6 +358,7 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
             />
           </div>
         )}
+        <button type="submit" style={{ display: 'none' }} />
       </form>
       {isLoading ? (
         <LoadingSpinner inline />

--- a/components/webfield/ProfileBidConsole.js
+++ b/components/webfield/ProfileBidConsole.js
@@ -239,7 +239,12 @@ const AllSubmissionsTab = ({
       <form
         className="form-inline notes-search-form"
         role="search"
-        onSubmit={(e) => e.preventDefault()}
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (immediateSearchTerm.trim().length >= 2) {
+            setSearchTerm(immediateSearchTerm)
+          }
+        }}
       >
         <div className="form-group search-content has-feedback">
           <input
@@ -253,11 +258,6 @@ const AllSubmissionsTab = ({
               setSearchTerm(e.target.value)
               if (e.target.value.trim().length >= 3) delaySearch(e.target.value)
               if (e.target.value.trim().length === 0) setSearchTerm('')
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && immediateSearchTerm.trim().length >= 2) {
-                setSearchTerm(immediateSearchTerm)
-              }
             }}
             disabled={!profileState.allProfiles}
           />
@@ -274,6 +274,7 @@ const AllSubmissionsTab = ({
             />
           </div>
         )}
+        <button type="submit" style={{ display: 'none' }} />
       </form>
       {isLoading ? (
         <LoadingSpinner inline />


### PR DESCRIPTION
this pr should fix the issue that pressing enter key to perform a search in bid console cause an error page to be shown when there's no score and subject areas

when the input length is <2, user need to press enter to search.
if the search input is the only control in the form (no score and subject area dropdown), the form will be submitted causing a page refresh.

this pr should prevent the form to be submitted by pressing enter