### PR TITLE
Fix/Characters with accent are not displayed correctly in Microsoft excel

### DIFF
--- a/components/ExportCSV.js
+++ b/components/ExportCSV.js
@@ -21,7 +21,9 @@ const ExportCSV = ({ records, fileName, exportColumns }) => {
             })
             .join(',')}\n`
       )
-      const blob = new Blob([headerRow, ...dataRows], { type: 'text/csv' })
+      const blob = new Blob([new Uint8Array([0xef, 0xbb, 0xbf]), headerRow, ...dataRows], {
+        type: 'text/csv',
+      })
       const url = window.URL || window.webkitURL
       setHref(url.createObjectURL(blob))
     } catch (error) {


### PR DESCRIPTION
this is related to issue 
https://github.com/openreview/openreview-py/issues/1106

In csv file exported from console, some characters with accent are not displayed correctly in Microsoft Excel.
for example 
áéíóúüñ¿¡ 
is displayed as
<img width="145" alt="image" src="https://user-images.githubusercontent.com/60613434/230492687-2646870e-42b8-440e-b75f-100b807f9011.png">

this pr may fix this issue by adding byte order mark of utf-8 to start of the csv blob