### PR TITLE
Fix/Profile merge/Name deletion - avoid full data load

### DIFF
--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -135,7 +135,9 @@ const NameDeletionTab = ({ accessToken, superUser, setNameDeletionRequestCountMs
   const loadNameDeletionRequests = async (noteId) => {
     const nameDeletionDecisionInvitationId = `${process.env.SUPER_USER}/Support/-/Profile_Name_Removal_Decision`
     try {
-      let nameRemovalNotesP, decisionResultsP, processLogsP
+      let nameRemovalNotesP
+      let decisionResultsP
+      let processLogsP
 
       if (noteId) {
         nameRemovalNotesP = api.get('/notes', { id: noteId }, { accessToken })
@@ -426,7 +428,9 @@ const ProfileMergeTab = ({ accessToken, superUser, setProfileMergeRequestCountMs
 
   const loadProfileMergeRequests = async (noteId) => {
     try {
-      let profileMergeNotesP, decisionResultsP, processLogsP
+      let profileMergeNotesP
+      let decisionResultsP
+      let processLogsP
 
       if (noteId) {
         profileMergeNotesP = api.get('/notes', { id: noteId }, { accessToken })


### PR DESCRIPTION
currently when a 

- profile merge request
- name deletion request

is approved/rejected/ignored, it will reload all the process logs which is very slow.

this pr should load only the note and references of the merge request that is approved/rejected/ignored and not to load the process log (because process function is still running so there's no status in process log)

so process log status will only update when performing a full page load