### PR TITLE
Fix/ Authors console: don't assume notes are v2 only

### DIFF
--- a/components/webfield/NoteMetaReviewStatus.js
+++ b/components/webfield/NoteMetaReviewStatus.js
@@ -2,17 +2,17 @@
 
 // modified from noteMetaReviewStatus.hbs handlebar template
 import { useContext, useEffect, useState } from 'react'
-import { inflect, prettyField } from '../../lib/utils'
+import WebFieldContext from '../WebFieldContext'
 import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
-import WebFieldContext from '../WebFieldContext'
-import { getNoteContent } from '../../lib/webfield-utils'
+import { inflect, prettyField } from '../../lib/utils'
+import { getNoteContentValues } from '../../lib/forum-utils'
 
 const IEEECopyrightForm = ({ note, isV2Note }) => {
   const { showIEEECopyright, IEEEPublicationTitle, IEEEArtSourceCode } =
     useContext(WebFieldContext)
   const { user } = useUser()
-  const noteContent = getNoteContent(note, isV2Note)
+  const noteContent = isV2Note ? getNoteContentValues(note) : note.content
 
   if (showIEEECopyright && IEEEPublicationTitle && IEEEArtSourceCode) {
     return (
@@ -56,7 +56,7 @@ export const AuthorConsoleNoteMetaReviewStatus = ({
     ? note.content?.venue?.value?.toLowerCase()?.includes('accept')
     : decisionContent?.toLowerCase()?.includes('accept')
 
-  if (!decision)
+  if (!decision) {
     return (
       <>
         {isV2Note && (
@@ -70,10 +70,11 @@ export const AuthorConsoleNoteMetaReviewStatus = ({
         {isAcceptedPaper && <IEEECopyrightForm note={note} isV2Note={isV2Note} />}
       </>
     )
+  }
 
   return (
     <>
-      {decisionContent ? (
+      {decisionContent && (
         <div>
           {isV2Note && (
             <h4>
@@ -94,7 +95,7 @@ export const AuthorConsoleNoteMetaReviewStatus = ({
             </a>
           </p>
         </div>
-      ) : null}
+      )}
       {isAcceptedPaper && <IEEECopyrightForm note={note} isV2Note={isV2Note} />}
     </>
   )

--- a/components/webfield/ProgramChairConsole/AreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatus.js
@@ -1,16 +1,13 @@
 /* globals promptError: false */
 import { sortBy } from 'lodash'
 import { useContext, useEffect, useState } from 'react'
-import {
-  buildEdgeBrowserUrl,
-  getNoteContent,
-  getProfileLink,
-} from '../../../lib/webfield-utils'
 import LoadingSpinner from '../../LoadingSpinner'
 import PaginationLinks from '../../PaginationLinks'
 import Table from '../../Table'
 import WebFieldContext from '../../WebFieldContext'
 import AreaChairStatusMenuBar from './AreaChairStatusMenuBar'
+import { buildEdgeBrowserUrl, getProfileLink } from '../../../lib/webfield-utils'
+import { getNoteContentValues } from '../../../lib/forum-utils'
 
 const CommitteeSummary = ({ rowData, bidEnabled, recommendationEnabled, invitations }) => {
   const { id, preferredName, preferredEmail } = rowData.areaChairProfile ?? {}
@@ -167,7 +164,7 @@ const NoteAreaChairStatus = ({ rowData, referrerUrl }) => {
       {rowData.notes.length !== 0 && <strong>Papers:</strong>}
       <div>
         {rowData.notes.map((p) => {
-          const noteContent = getNoteContent(p.note)
+          const noteContent = getNoteContentValues(p.note)
           const noteVenue = noteContent?.venue
           const metaReviews = p.metaReviewData?.metaReviews
           const hasMetaReview = metaReviews?.length
@@ -177,7 +174,7 @@ const NoteAreaChairStatus = ({ rowData, referrerUrl }) => {
               {hasMetaReview ? (
                 <>
                   {metaReviews.map((metaReview) => {
-                    const metaReviewContent = getNoteContent(metaReview)
+                    const metaReviewContent = getNoteContentValues(metaReview)
                     return (
                       <div key={metaReview.id} className="meta-review">
                         <span>{`${

--- a/components/webfield/SeniorAreaChairConsole/AreaChairStatus.js
+++ b/components/webfield/SeniorAreaChairConsole/AreaChairStatus.js
@@ -1,12 +1,13 @@
 /* globals promptError: false */
 import { sortBy } from 'lodash'
 import { useContext, useEffect, useState } from 'react'
-import { getNoteContent, getProfileLink } from '../../../lib/webfield-utils'
 import LoadingSpinner from '../../LoadingSpinner'
 import PaginationLinks from '../../PaginationLinks'
 import Table from '../../Table'
 import WebFieldContext from '../../WebFieldContext'
 import AreaChairStatusMenuBar from '../ProgramChairConsole/AreaChairStatusMenuBar'
+import { getProfileLink } from '../../../lib/webfield-utils'
+import { getNoteContentValues } from '../../../lib/forum-utils'
 
 const CommitteeSummary = ({ rowData }) => {
   const { id, preferredName, preferredEmail } = rowData.areaChairProfile ?? {}
@@ -98,7 +99,7 @@ const NoteAreaChairStatus = ({ rowData, referrerUrl }) => {
       {rowData.notes.length !== 0 && <strong className="paper-label">Papers:</strong>}
       <div>
         {rowData.notes.map((p) => {
-          const noteContent = getNoteContent(p.note)
+          const noteContent = getNoteContentValues(p.note)
           const noteVenue = noteContent?.venue
           const metaReviews = p.metaReviewData?.metaReviews
           const hasMetaReview = metaReviews?.length
@@ -108,7 +109,7 @@ const NoteAreaChairStatus = ({ rowData, referrerUrl }) => {
               {hasMetaReview ? (
                 <>
                   {metaReviews.map((metaReview) => {
-                    const metaReviewContent = getNoteContent(metaReview)
+                    const metaReviewContent = getNoteContentValues(metaReview)
                     return (
                       <div key={metaReview.id} className="meta-review">
                         <span>{`${

--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -602,23 +602,6 @@ export function buildEdgeBrowserUrl(
 }
 
 /**
- * get note content of v2 note
- * extract actual value out of .value
- *
- * @param {object} note
- * @returns object
- */
-export function getNoteContent(note) {
-  return Object.entries(note?.content ?? {}).reduce(
-    (prev, [key, value]) => ({
-      ...prev,
-      [key]: value?.value,
-    }),
-    {}
-  )
-}
-
-/**
  * get a link to user profile for webfield console
  *
  * @param {string} profileId


### PR DESCRIPTION
This fixes a JS error that preventing the authors console from loading. To reproduce impersonate an author of CVPR 2023 and load the page http://localhost:3030/group?id=thecvf.com/CVPR/2023/Conference/Authors