### PR TITLE
Fix/ Forum page: always show revision links on replies

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -107,7 +107,7 @@ export default function Forum({
       {
         forum: forumId,
         trash: true,
-        details: 'replyCount,editsCount,writable,signatures,invitation,presentation',
+        details: 'replyCount,writable,signatures,invitation,presentation', // TODO: add editsCount back
       },
       { accessToken, version: 2 }
     )

--- a/components/forum/ForumReply.js
+++ b/components/forum/ForumReply.js
@@ -337,7 +337,7 @@ export default function ForumReply({ note, replies, replyDepth, parentId, update
           <Icon name="eye-open" />
           {note.readers.map((reader) => prettyId(reader, true)).join(', ')}
         </span>
-        {note.details?.editsCount > 1 && (
+        {(true || note.details?.editsCount > 1) && (
           <span className="revisions">
             <Icon name="duplicate" />
             <Link href={`/revisions?id=${note.id}`}>


### PR DESCRIPTION
Don't request editsCount and always display a revisions link. This is a temporary fix while the slow query is being fixed.