### PR TITLE
DBLP import - avoid error when user is not listed as author

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -368,43 +368,44 @@ export async function getDblpPublicationsFromXmlUrl(xmlUrl, profileId) {
     }
 
     return {
-      notes: publicationNodes
-        .filter((publicationNode) => publicationNode.getElementsByTagName('author').length > 0)
-        .flatMap((publicationNode) => {
-          const authorPids = Array.from(publicationNode.getElementsByTagName('author')).map(
-            (p) => p.getAttribute('pid')
-          )
-          if (authorPids.indexOf(authorPidInXML) === -1) {
-            return [] // could be editor
-          }
-          const originalTitle = publicationNode.getElementsByTagName('title')[0].textContent
-          let venue =
-            publicationNode.getElementsByTagName('journal')[0]?.textContent ??
-            publicationNode.getElementsByTagName('booktitle')[0]?.textContent
-          const year = publicationNode.getElementsByTagName('year')[0]?.textContent
-          if (year) venue = `${venue} ${year}`
+      notes: publicationNodes.flatMap((publicationNode) => {
+        if (publicationNode.getElementsByTagName('author').length === 0) return []
 
-          return {
-            note: {
-              content: {
-                dblp: publicationNode.outerHTML,
-              },
-              invitation: 'dblp.org/-/record',
-              readers: ['everyone'],
-              writers: ['dblp.org'],
-              signatures: [profileId],
+        const authorPids = Array.from(publicationNode.getElementsByTagName('author')).map(
+          (p) => p.getAttribute('pid')
+        )
+        if (authorPids.indexOf(authorPidInXML) === -1) {
+          return [] // could be editor
+        }
+
+        const originalTitle = publicationNode.getElementsByTagName('title')[0].textContent
+        let venue =
+          publicationNode.getElementsByTagName('journal')[0]?.textContent ??
+          publicationNode.getElementsByTagName('booktitle')[0]?.textContent
+        const year = publicationNode.getElementsByTagName('year')[0]?.textContent
+        if (year) venue = `${venue} ${year}`
+
+        return {
+          note: {
+            content: {
+              dblp: publicationNode.outerHTML,
             },
-            title: originalTitle,
-            formattedTitle: titleNameTransformation(originalTitle),
-            authorIndex: authorPids.indexOf(authorPidInXML),
-            authorNames: Object.values(publicationNode.getElementsByTagName('author')).map(
-              (p) => p.textContent
-            ),
-            authorCount: authorPids.length,
-            venue,
-            year: year ?? 'Unknown',
-          }
-        }),
+            invitation: 'dblp.org/-/record',
+            readers: ['everyone'],
+            writers: ['dblp.org'],
+            signatures: [profileId],
+          },
+          title: originalTitle,
+          formattedTitle: titleNameTransformation(originalTitle),
+          authorIndex: authorPids.indexOf(authorPidInXML),
+          authorNames: Object.values(publicationNode.getElementsByTagName('author')).map(
+            (p) => p.textContent
+          ),
+          authorCount: authorPids.length,
+          venue,
+          year: year ?? 'Unknown',
+        }
+      }),
       possibleNames: [...possibleNames],
     }
   } catch (error) {


### PR DESCRIPTION
a user reported that the dblp import is not recognizing the persistent url.

there is a checking of whether the author pid is in the author list of dblp papers

In this case the user is listed as an editor instead of author and caused the import to fail without error

this pr should fix this issue by skipping the papers where the user is not listed as an author
if the user is using unrelated dblp url the name checking will catch it