### PR TITLE
Fix/ Forum page: load expired invitations

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -74,26 +74,26 @@ export default function Forum({
   const getInvitationsByReplyForum = (forumId, includeTags) => {
     if (!forumId) return Promise.resolve([])
 
-    const extraParams = includeTags ? { tags: true } : { details: 'repliedNotes' }
+    const extraParams = includeTags ? { tags: true, details: 'writable' } : { details: 'repliedNotes,writable' }
     return api
       .get(
         '/invitations',
-        { replyForum: forumId, ...extraParams },
+        { replyForum: forumId, expired: true, ...extraParams },
         { accessToken, version: 2 }
       )
       .then(({ invitations }) => {
         if (!invitations?.length) return []
-
         return invitations.map((inv) => {
           // Check if invitation does not have multiReply prop OR invitation is set to multiReply
           // but it is not false OR there have not been any replies to the invitation yet
           const repliesAvailable =
             !inv.maxReplies || inv.details?.repliedNotes?.length < inv.maxReplies
+          const writable = inv.details?.writable
           return {
             ...inv,
             process: null,
             preprocess: null,
-            details: { repliesAvailable },
+            details: { repliesAvailable, writable },
           }
         })
       })

--- a/lib/forum-utils.js
+++ b/lib/forum-utils.js
@@ -63,19 +63,14 @@ export function getNoteInvitations(invitations, note) {
   let deleteInvitation = null
   let editInvitations = []
   if (note.details?.writable) {
-    deleteInvitation = invitations
-      .filter(
-        (p) =>
-          p.edit?.note?.id === note.id ||
-          note.invitations.includes(p.edit?.note?.id?.param?.withInvitation)
-      )
-      .find((p) => p.edit?.note?.ddate)
-
     editInvitations = invitations.filter(
       (p) =>
-        p.edit?.note?.id === note.id ||
-        note.invitations.includes(p.edit?.note?.id?.param?.withInvitation)
+        p.details?.writable &&
+        (p.edit?.note?.id === note.id ||
+          note.invitations.includes(p.edit?.note?.id?.param?.withInvitation))
     )
+    deleteInvitation = editInvitations.find((p) => p.edit?.note?.ddate)
+
     // pure delete invitations should not be included as an edit invitation
     if (!deleteInvitation?.edit?.note?.content) {
       editInvitations = editInvitations.filter((p) => p.id !== deleteInvitation?.id)
@@ -89,7 +84,8 @@ export function getNoteInvitations(invitations, note) {
       replyTo &&
       (replyTo === note.id ||
         replyTo.param?.withForum === note.forum ||
-        (replyTo.param?.withInvitation && note.invitations.includes(replyTo.param?.withInvitation)))
+        (replyTo.param?.withInvitation &&
+          note.invitations.includes(replyTo.param?.withInvitation)))
     )
   })
 


### PR DESCRIPTION
Load expired invitations in addition to unexpired ones and check if they are writable. Fixes an issue preventing the delete button from showing on some forum pages.