### PR TITLE
Fix/ Forum page: don't filter invitations by writable

### DIFF
--- a/lib/forum-utils.js
+++ b/lib/forum-utils.js
@@ -63,12 +63,12 @@ export function getNoteInvitations(invitations, note) {
   let deleteInvitation = null
   let editInvitations = []
   if (note.details?.writable) {
-    editInvitations = invitations.filter(
-      (p) =>
-        p.details?.writable &&
-        (p.edit?.note?.id === note.id ||
-          note.invitations.includes(p.edit?.note?.id?.param?.withInvitation))
-    )
+    editInvitations = invitations.filter((p) => {
+      const appliesToNote = (p.edit?.note?.id === note.id ||
+        note.invitations.includes(p.edit?.note?.id?.param?.withInvitation))
+      const invitationExpired = p.expdate < Date.now()
+      return appliesToNote && (!invitationExpired || p.details?.writable)
+    })
     deleteInvitation = editInvitations.find((p) => p.edit?.note?.ddate)
 
     // pure delete invitations should not be included as an edit invitation


### PR DESCRIPTION
Change filter logic to only check details.writable when the invitation is expired.