### PR TITLE
Fix/ Edge browser - Remove edge signature hardcoded submission name

### DIFF
--- a/lib/edge-utils.js
+++ b/lib/edge-utils.js
@@ -436,11 +436,16 @@ export function getSignatures(
     if (invitationMapItem?.signature) return [invitationMapItem.signature] // default value
     const availableSignatures = invitationMapItem?.signatures
     const nonPaperSpecificGroup = availableSignatures?.filter(
-      (p) => !/(Paper)[0-9]\d*/.test(p)
+      (p) =>
+        !(
+          editInvitation.submissionName
+            ? new RegExp(`(${editInvitation.submissionName})[0-9]\\d*`)
+            : /(Paper)[0-9]\d*/
+        ).test(p)
     )?.[0]
     if (nonPaperSpecificGroup) return [nonPaperSpecificGroup]
     const paperSpecificGroup = availableSignatures?.filter((q) =>
-      q.includes(`Paper${paperNumberToLookup}`)
+      q.includes(`${editInvitation.submissionName ?? 'Paper'}${paperNumberToLookup}`)
     )?.[0]
     return paperSpecificGroup ? [paperSpecificGroup] : []
   }

--- a/pages/edges/browse.js
+++ b/pages/edges/browse.js
@@ -49,22 +49,7 @@ const Browse = ({ appContext }) => {
     statusCode: 500,
   }
 
-  useEffect(() => {
-    if (userLoading || !query) return
-
-    if (!query.traverse) {
-      setError(notFoundError)
-      return
-    }
-
-    setLayoutOptions({ fullWidth: true, minimalFooter: true })
-
-    if (query.referrer) {
-      setBannerContent(referrerLink(query.referrer))
-    } else {
-      setBannerHidden(true)
-    }
-
+  const loadAllInvitations = async () => {
     const startInvitations = parseEdgeList(query.start, 'start')
     const traverseInvitations = parseEdgeList(query.traverse, 'traverse')
     const editInvitations = parseEdgeList(query.edit, 'edit')
@@ -88,97 +73,121 @@ const Browse = ({ appContext }) => {
 
     const apiVersion = Number.parseInt(query.version, 10)
     setVersion(apiVersion)
-
     const idsToLoad = uniq(allInvitations.map((i) => i.id)).filter((id) => id !== 'staticList')
-    api
-      .get(
+    try {
+      const apiRes = await api.get(
         '/invitations',
         { ids: idsToLoad.join(','), expired: true, type: 'edges' },
         { accessToken, version: apiVersion }
       )
-      .then((apiRes) => {
-        if (!apiRes.invitations?.length) {
-          setError(invalidError)
-          return
-        }
+      if (!apiRes.invitations?.length) {
+        setError(invalidError)
+        return
+      }
 
-        let allValid = true
-        allInvitations.forEach((invObj) => {
-          const fullInvitation = apiRes.invitations.find((inv) => {
-            // For static lists, use the properties of the first traverse invitation
-            const invId = invObj.id === 'staticList' ? allInvitations[0].id : invObj.id
-            return inv.id === invId
-          })
-          if (!fullInvitation) {
-            // Filter out invalid edit or browse invitations, but don't fail completely
-            if (invObj.category === 'edit' || invObj.category === 'browse') {
-              // eslint-disable-next-line no-console
-              console.error(
-                `${invObj.category} invitation ${invObj.id} does not exist or is expired`
-              )
-              // eslint-disable-next-line no-param-reassign
-              invObj.invalid = true
-            } else {
-              setError({
-                name: 'Not Found',
-                message: `Could not load edge explorer. Invitation not found: ${invObj.id}`,
-                statusCode: 404,
-              })
-              allValid = false
-            }
-            return
-          }
-
-          const readers = buildInvitationReplyArr(fullInvitation, 'readers', user.profile.id)
-          const writers =
-            buildInvitationReplyArr(fullInvitation, 'writers', user.profile.id) || readers
-          const signatures = translateSignatures(fullInvitation, apiVersion)
-          const nonreaders = buildInvitationReplyArr(
-            fullInvitation,
-            'nonreaders',
-            user.profile.id
-          )
-          Object.assign(invObj, {
-            head: translateFieldSpec(fullInvitation, 'head', apiVersion),
-            tail: translateFieldSpec(fullInvitation, 'tail', apiVersion),
-            weight: translateFieldSpec(fullInvitation, 'weight', apiVersion),
-            defaultWeight: translateFieldSpec(fullInvitation, 'weight', apiVersion)?.default,
-            label: translateFieldSpec(fullInvitation, 'label', apiVersion),
-            defaultLabel: translateFieldSpec(fullInvitation, 'label', apiVersion)?.default,
-            readers,
-            writers,
-            signatures,
-            nonreaders,
-          })
+      let allValid = true
+      allInvitations.forEach((invObj) => {
+        const fullInvitation = apiRes.invitations.find((inv) => {
+          // For static lists, use the properties of the first traverse invitation
+          const invId = invObj.id === 'staticList' ? allInvitations[0].id : invObj.id
+          return inv.id === invId
         })
-        if (!allValid) {
+        if (!fullInvitation) {
+          // Filter out invalid edit or browse invitations, but don't fail completely
+          if (invObj.category === 'edit' || invObj.category === 'browse') {
+            // eslint-disable-next-line no-console
+            console.error(
+              `${invObj.category} invitation ${invObj.id} does not exist or is expired`
+            )
+            // eslint-disable-next-line no-param-reassign
+            invObj.invalid = true
+          } else {
+            setError({
+              name: 'Not Found',
+              message: `Could not load edge explorer. Invitation not found: ${invObj.id}`,
+              statusCode: 404,
+            })
+            allValid = false
+          }
           return
         }
 
-        setInvitations({
-          startInvitation: startInvitations[0],
-          traverseInvitations,
-          editInvitations: editInvitations.filter((inv) => !inv.invalid),
-          browseInvitations: browseInvitations.filter((inv) => !inv.invalid),
-          hideInvitations,
-          allInvitations: allInvitations.filter((inv) => !inv.invalid),
+        const readers = buildInvitationReplyArr(fullInvitation, 'readers', user.profile.id)
+        const writers =
+          buildInvitationReplyArr(fullInvitation, 'writers', user.profile.id) || readers
+        const signatures = translateSignatures(fullInvitation, apiVersion)
+        const nonreaders = buildInvitationReplyArr(
+          fullInvitation,
+          'nonreaders',
+          user.profile.id
+        )
+        Object.assign(invObj, {
+          head: translateFieldSpec(fullInvitation, 'head', apiVersion),
+          tail: translateFieldSpec(fullInvitation, 'tail', apiVersion),
+          weight: translateFieldSpec(fullInvitation, 'weight', apiVersion),
+          defaultWeight: translateFieldSpec(fullInvitation, 'weight', apiVersion)?.default,
+          label: translateFieldSpec(fullInvitation, 'label', apiVersion),
+          defaultLabel: translateFieldSpec(fullInvitation, 'label', apiVersion)?.default,
+          readers,
+          writers,
+          signatures,
+          nonreaders,
         })
       })
-      .catch((apiError) => {
-        if (typeof apiError === 'object' && apiError.name) {
-          if (apiError.name === 'NotFoundError') {
-            setError(notFoundError)
-          } else if (apiError.name === 'ForbiddenError') {
-            setError(forbiddenError)
-          }
-        } else if (
-          typeof apiError === 'string' &&
-          apiError.startsWith('Invitation Not Found')
-        ) {
+      if (!allValid) {
+        return
+      }
+
+      // user domain of first traverse invitation to look up submission name
+      const domainGroupId = apiRes.invitations.find(
+        (p) => p.id === traverseInvitations[0].id
+      )?.domain
+      const domainContent = domainGroupId
+        ? (await api.get('/groups', { id: domainGroupId, select: 'content' }, { accessToken }))
+            ?.groups?.[0]?.content
+        : null
+
+      setInvitations({
+        startInvitation: startInvitations[0],
+        traverseInvitations,
+        editInvitations: editInvitations
+          .filter((inv) => !inv.invalid)
+          .map((p) => ({ ...p, submissionName: domainContent?.submission_name?.value })),
+        browseInvitations: browseInvitations.filter((inv) => !inv.invalid),
+        hideInvitations,
+        allInvitations: allInvitations.filter((inv) => !inv.invalid),
+      })
+    } catch (apiError) {
+      if (typeof apiError === 'object' && apiError.name) {
+        if (apiError.name === 'NotFoundError') {
           setError(notFoundError)
+        } else if (apiError.name === 'ForbiddenError') {
+          setError(forbiddenError)
         }
-        setError(unknownError)
-      })
+      } else if (typeof apiError === 'string' && apiError.startsWith('Invitation Not Found')) {
+        setError(notFoundError)
+      }
+      setError(unknownError)
+    }
+  }
+
+  useEffect(() => {
+    if (userLoading || !query) return
+
+    if (!query.traverse) {
+      setError(notFoundError)
+      return
+    }
+
+    setLayoutOptions({ fullWidth: true, minimalFooter: true })
+
+    if (query.referrer) {
+      setBannerContent(referrerLink(query.referrer))
+    } else {
+      setBannerHidden(true)
+    }
+
+    loadAllInvitations()
   }, [userLoading, query, user])
 
   useEffect(() => {


### PR DESCRIPTION
there's an assumption that submission name is 'Paper'
when getting edge signature which is not always true.

this pr should fix this issue by reading submission name from domain content

this pr takes the domain group from the first traverse invitation (because other invitations might not exist)
so if traverse/edit invitations has different domain it might get wrong