### PR TITLE
Fix/Edge browser - load all entities when filter by quota

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -861,9 +861,32 @@ export default function Column(props) {
       return
     }
     // Reset column to show original items and no search heading
-    if (!search.term) {
+    if (!search.term && !hideQuotaReached) {
       setFilteredItems(sortItems(filterQuotaReachedItems(items)))
       setItemsHeading(null)
+      return
+    }
+
+    // Show all entities when filter by quota reached without searching
+    if (!search.term && hideQuotaReached && parentId) {
+      const allItems = [...items]
+      Object.values(globalEntityMap).forEach((item) => {
+        if (allItems.find((p) => p.id === item.id)) return
+        allItems.push({
+          ...item,
+          // eslint-disable-next-line max-len
+          editEdgeTemplates: editInvitations.map((editInvitation) =>
+            buildNewEditEdge(editInvitation, item.id)
+          ),
+          editEdges: [],
+          browseEdges: [],
+          metadata: {
+            isAssigned: false,
+          },
+        })
+      })
+
+      setFilteredItems(sortItems(filterQuotaReachedItems(allItems)))
       return
     }
     if (search.term.length < 2) {


### PR DESCRIPTION
when user check the "Only show {role} with fewer than max assigned papers" checkbox
it will filter based on the entities which are already loaded (having an edge with parent entity)

for neurips 2023 this could mean that some ACs get to see only a few reviewers unless searching for a reviewer which will lookup loaded items first then also look up in all the entities.

this pr should make the column to load all the entities (+ already loaded items) when user filter by quota without searching