### PR TITLE
Fix/ Note content: privately revealed icon isn't being displayed

### DIFF
--- a/components/Edit/EditContent.js
+++ b/components/Edit/EditContent.js
@@ -18,7 +18,7 @@ const EditContent = ({ edit, type = 'note' }) => {
 
         const fieldReaders = Array.isArray(field?.readers) ? field.readers.sort() : null
         const showPrivateIcon =
-          fieldReaders && edit.readers && !fieldReaders.every((p, i) => p === edit.readers[i])
+          fieldReaders && edit.readers && !edit.readers.every((p, i) => p === fieldReaders[i])
         const fieldValue = prettyContentValue(field?.value)
         const enableMarkdown = edit.details?.presentation?.find(
           (p) => p.name === fieldName

--- a/components/NoteContent.js
+++ b/components/NoteContent.js
@@ -188,7 +188,7 @@ export const NoteContentV2 = ({
           ? content[fieldName].readers.sort()
           : null
         const showPrivateIcon =
-          fieldReaders && noteReaders && !fieldReaders.every((p, j) => p === noteReaders[j])
+          fieldReaders && noteReaders && !noteReaders.every((p, j) => p === fieldReaders[j])
 
         // Only show the PDF and HTML field in note content if it has restricted readers
         if ((fieldName === 'pdf' || fieldName === 'html') && !showPrivateIcon) return null


### PR DESCRIPTION
Fix condition for displaying private field icon. Since the note should have more groups readers, we need to check that the field has all those readers as well.