### PR TITLE
Fix/Message viewer - offset is not reset on search param change

### DIFF
--- a/pages/messages.js
+++ b/pages/messages.js
@@ -35,7 +35,7 @@ const FilterForm = ({ searchQuery, loading }) => {
   }, [])
 
   const onFiltersChange = (field, value) => {
-    const newSearchQuery = { ...searchQuery, [field]: value }
+    const newSearchQuery = { ...searchQuery, [field]: value, page: 1 }
     router.push({ pathname: '/messages', query: newSearchQuery }, undefined, { shallow: true })
   }
 


### PR DESCRIPTION
this pr should reset page to 1 when search/filter param is changed