### PR TITLE
Fix/Forum page - show readers tooltip in multiple lines

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -545,7 +545,7 @@ export default function Forum({
     setTimeout(() => {
       typesetMathJax()
 
-      $('[data-toggle="tooltip"]').tooltip()
+      $('[data-toggle="tooltip"]').tooltip({ html: true })
 
       // Scroll note and invitation specified in url
       if (selectedNoteId && !scrolled) {
@@ -602,7 +602,9 @@ export default function Forum({
     // Special case for chat layout: make sure all participants in the chat can read all the notes
     let chatReaders = null
     if (expandedInvitations?.length > 0) {
-      const primaryInv = parentNote.replyInvitations.find((inv) => inv.id === expandedInvitations[0])
+      const primaryInv = parentNote.replyInvitations.find(
+        (inv) => inv.id === expandedInvitations[0]
+      )
       chatReaders = primaryInv ? primaryInv.edit.note.readers : null
     }
 
@@ -657,7 +659,7 @@ export default function Forum({
 
     setTimeout(() => {
       typesetMathJax()
-      $('[data-toggle="tooltip"]').tooltip()
+      $('[data-toggle="tooltip"]').tooltip({ html: true })
     }, 200)
   }, [replyNoteMap, orderedReplies, selectedFilters, expandedInvitations])
 

--- a/components/forum/ForumNote.js
+++ b/components/forum/ForumNote.js
@@ -249,7 +249,9 @@ function ForumMeta({ note }) {
           className="readers item"
           data-toggle="tooltip"
           data-placement="top"
-          title={`Visible to ${note.readers.join(', ')}${note.odate ? ` since ${forumDate(note.odate)}` : ''}`}
+          title={`Visible to <br/>${note.readers.join('<br/>')}${
+            note.odate ? `<br/>since ${forumDate(note.odate)}` : ''
+          }`}
         >
           <Icon name="eye-open" />
           {note.readers.map((reader) => prettyId(reader, true)).join(', ')}


### PR DESCRIPTION
when the note reader has multiple values, the tooltip will be too wide especially when the group names are also long text
this pr should show them in multiple lines.

same page with this pr