### PR TITLE
Fix/ Note content: display correct field name

### DIFF
--- a/components/NoteContent.js
+++ b/components/NoteContent.js
@@ -73,7 +73,9 @@ function NoteContent({
 
 function NoteContentField({ name, customFieldName }) {
   return (
-    <strong className="note-content-field">{customFieldName ?? prettyField(name)}:</strong>
+    <strong className="note-content-field disable-tex-rendering">
+      {customFieldName ?? prettyField(name)}:
+    </strong>
   )
 }
 


### PR DESCRIPTION
Check presentation.fieldName when rendering v2 note content. 