### PR TITLE
Fix/ Profile editor: default start and end year to null

### DIFF
--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -265,8 +265,8 @@ const EducationHistorySection = ({
           {
             key: nanoid(),
             position: '',
-            start: '',
-            end: '',
+            start: null,
+            end: null,
             institution: {
               domain: '',
               name: '',
@@ -292,8 +292,8 @@ const EducationHistorySection = ({
       : [...Array(3).keys()].map(() => ({
           key: nanoid(),
           position: '',
-          start: '',
-          end: '',
+          start: null,
+          end: null,
           institution: {
             domain: '',
             name: '',

--- a/components/profile/ExpertiseSection.js
+++ b/components/profile/ExpertiseSection.js
@@ -51,8 +51,8 @@ const ExpertiseSection = ({ profileExpertises, updateExpertise }) => {
           {
             keywords: [],
             keyWordsValue: '',
-            start: '',
-            end: '',
+            start: null,
+            end: null,
             key: nanoid(),
           },
         ]
@@ -62,8 +62,8 @@ const ExpertiseSection = ({ profileExpertises, updateExpertise }) => {
           : [
               {
                 keywords: [],
-                start: '',
-                end: '',
+                start: null,
+                end: null,
                 key: nanoid(),
               },
             ]
@@ -85,8 +85,8 @@ const ExpertiseSection = ({ profileExpertises, updateExpertise }) => {
       : [...Array(3).keys()].map(() => ({
           keywords: [],
           keyWordsValue: '', // the value for input
-          start: '',
-          end: '',
+          start: null,
+          end: null,
           key: nanoid(),
         }))
   )

--- a/components/profile/RelationsSection.js
+++ b/components/profile/RelationsSection.js
@@ -243,8 +243,8 @@ const RelationsSection = ({
             relation: '',
             name: '',
             email: '',
-            start: '',
-            end: '',
+            start: null,
+            end: null,
             readers: ['everyone'],
           },
         ]
@@ -257,8 +257,8 @@ const RelationsSection = ({
                 relation: '',
                 name: '',
                 email: '',
-                start: '',
-                end: '',
+                start: null,
+                end: null,
                 readers: ['everyone'],
               },
             ]
@@ -281,8 +281,8 @@ const RelationsSection = ({
           relation: '',
           name: '',
           email: '',
-          start: '',
-          end: '',
+          start: null,
+          end: null,
           readers: ['everyone'],
         }))
   )


### PR DESCRIPTION
currently start/end year in profile edit page get empty string as its value if the input is not touched.
which caused some issue with matching

This pr should set the start/end year to null