### PR TITLE
Fix/ Update GitHub actions Node.js version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - name: Start MongoDB


### PR DESCRIPTION
Update github actions to use Node.js v18. Currently tests are breaking because the API uses JS features that are not supported in v16.