### PR TITLE
Fix/ PC Console: change PDF download link

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1460,7 +1460,7 @@ export function getNotePdfUrl(note, isReference, isV2Note) {
   if (isReference) {
     urlPath = isV2Note ? '/notes/edits/pdf' : '/references/pdf'
   } else {
-    urlPath = pdfValue?.startsWith('/pdf') ? '/pdf' : '/attachment'
+    urlPath = '/pdf'
   }
   const nameParam = urlPath === '/pdf' ? '' : '&name=pdf'
 


### PR DESCRIPTION
Change logic for building note PDF download url to fix issue with files stored under /attachment