### PR TITLE
Fix/ Filter undefined values from values-copied fields

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -3292,7 +3292,7 @@ module.exports = (function () {
           if (_.startsWith(v, '{')) {
             var field = v.slice(1, -1)
             var fieldValue = _.get(original, field)
-            if (fieldValue) {
+            if (!_.isNil(fieldValue)) {
               if (!Array.isArray(fieldValue)) {
                 fieldValue = [fieldValue]
               }


### PR DESCRIPTION
When we are using values-copied one of the values might be optional in the note, so we should not pass `null` if the value does not resolve to anything:
```
'readers': {
      'values-copied': [
          self.support_group.id,
          '{signatures}',
          '{content["program_chair_emails"]}',
          '{content["publication_chair_email"]}'
      ]
  }
```
Uses: https://github.com/openreview/openreview-api-v1/pull/2906
Can be tested by creating a venue request with no publication chair (e.g. `test_icml_conference.py`)