### PR TITLE
Fix/ Forum page: support for notes with no content field

### DIFF
--- a/components/forum/ForumReply.js
+++ b/components/forum/ForumReply.js
@@ -26,7 +26,7 @@ export default function ForumReply({ note, replies, replyDepth, parentId, update
   } = useContext(ForumReplyContext)
   const { user } = useUser()
 
-  const { invitations, content, signatures, ddate } = note
+  const { invitations, signatures, content, ddate } = note
   const { hidden, collapsed, contentExpanded } = displayOptionsMap[note.id]
   const allChildIds = replies.reduce(
     (acc, reply) =>
@@ -348,7 +348,7 @@ export default function ForumReply({ note, replies, replyDepth, parentId, update
 
       <NoteContentCollapsible
         id={note.id}
-        content={note.content}
+        content={content}
         presentation={note.details?.presentation}
         noteReaders={note.readers}
         contentExpanded={contentExpanded}

--- a/lib/forum-utils.js
+++ b/lib/forum-utils.js
@@ -36,7 +36,7 @@ export function formatNote(
     mdate: note.mdate || note.tmdate,
     ddate: note.ddate,
     replyto: note.replyto || note.forum,
-    content: note.content,
+    content: note.content || {},
     signatures: note.signatures,
     readers: note.readers.sort(),
     searchText: buildNoteSearchText(note, true),


### PR DESCRIPTION
The certain components on the new forum page assumed that content would always be an object.