### PR TITLE
Fix/Note editor - not to pass empty string when user clear textbox with type string[]

### DIFF
--- a/components/EditorComponents/TextboxWidget.js
+++ b/components/EditorComponents/TextboxWidget.js
@@ -58,7 +58,7 @@ const TextboxWidget = () => {
         invitation?.id,
         note?.id,
         replyToNote?.id,
-        fieldName,
+        fieldName
       )
       savedText = localStorage.getItem(keyOfSavedText)
     }

--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -60,7 +60,7 @@ const NoteSignatures = ({
         extraClasses={styles.signatures}
         clearError={() =>
           setErrors((existingErrors) =>
-            existingErrors.filter((p) => p.fieldName !== fieldName),
+            existingErrors.filter((p) => p.fieldName !== fieldName)
           )
         }
       />
@@ -103,7 +103,7 @@ const EditSignatures = ({
         extraClasses={styles.signatures}
         clearError={() =>
           setErrors((existingErrors) =>
-            existingErrors.filter((p) => p.fieldName !== fieldName),
+            existingErrors.filter((p) => p.fieldName !== fieldName)
           )
         }
       />
@@ -147,12 +147,12 @@ const NoteEditor = ({
         invitation.id,
         note?.id,
         replyToNote?.id,
-        fieldName,
+        fieldName
       )
       localStorage.setItem(keyOfSavedText, value ?? '')
       setAutoStorageKeys((keys) => [...keys, keyOfSavedText])
     }, 1500),
-    [invitation, note, replyToNote],
+    [invitation, note, replyToNote]
   )
 
   const defaultNoteEditorData = {
@@ -174,7 +174,7 @@ const NoteEditor = ({
   }
   const [noteEditorData, setNoteEditorData] = useReducer(
     noteEditorDataReducer,
-    defaultNoteEditorData,
+    defaultNoteEditorData
   )
 
   const renderField = (fieldName, fieldDescription) => {
@@ -210,7 +210,7 @@ const NoteEditor = ({
             setErrors,
             clearError: () => {
               setErrors((existingErrors) =>
-                existingErrors.filter((p) => p.fieldName !== fieldName),
+                existingErrors.filter((p) => p.fieldName !== fieldName)
               )
             },
           }}
@@ -302,14 +302,14 @@ const NoteEditor = ({
   const addMissingReaders = (
     readersSelected,
     readersDefinedInInvitation,
-    signatureInputValues,
+    signatureInputValues
   ) => {
     if (!readersSelected) return undefined
     if (signatureInputValues?.length && !readersSelected.includes('everyone')) {
       const signatureId = signatureInputValues[0]
       const anonReviewerIndex = Math.max(
         signatureId.indexOf('AnonReviewer'),
-        signatureId.indexOf('Reviewer_'),
+        signatureId.indexOf('Reviewer_')
       )
       if (anonReviewerIndex > 0) {
         const reviewersSubmittedGroupId = signatureId
@@ -323,7 +323,7 @@ const NoteEditor = ({
               signatureId,
               reviewersSubmittedGroupId,
               reviewersGroupId,
-            ]),
+            ])
           )
         ) {
           if (readersDefinedInInvitation?.includes(signatureId)) {
@@ -339,7 +339,7 @@ const NoteEditor = ({
       } else {
         const acIndex = Math.max(
           signatureId.indexOf('Area_Chair1'),
-          signatureId.indexOf('Area_Chair_'),
+          signatureId.indexOf('Area_Chair_')
         )
         const acGroupId =
           acIndex >= 0 ? signatureId.slice(0, acIndex).concat('Area_Chairs') : signatureId
@@ -368,7 +368,7 @@ const NoteEditor = ({
       noteEditorData.noteReaderValues,
       invitation.edit.note.readers?.param?.enum ??
         invitation.edit.note.readers?.param?.items?.map((p) => p.value), // prefix values are not used
-      signatureInputValues,
+      signatureInputValues
     )
   }
 
@@ -378,7 +378,7 @@ const NoteEditor = ({
       noteEditorData.editReaderValues,
       invitation.edit.readers?.param?.enum ??
         invitation.edit.readers?.param?.items?.map((p) => p.value),
-      noteEditorData.editSignatureInputValues,
+      noteEditorData.editSignatureInputValues
     )
   }
 
@@ -405,7 +405,7 @@ const NoteEditor = ({
       const result = await api.get(
         '/notes',
         { id: noteCreated.id, details: 'invitation,presentation,writable' },
-        { accessToken, version: 2 },
+        { accessToken, version: 2 }
       )
       return result.notes?.[0] ? result.notes[0] : constructedNote
     } catch (error) {
@@ -461,25 +461,22 @@ const NoteEditor = ({
         setErrors(
           error.errors.map((p) => {
             const fieldName = getErrorFieldName(p.details.path)
-            if (isNonDeletableError(p.details.invalidValue, p.message))
+            if (isNonDeletableError(p.details.invalidValue))
               return { fieldName, message: `${prettyField(fieldName)} is not deletable` }
             return { fieldName, message: p.message.replace(fieldName, prettyField(fieldName)) }
-          }),
+          })
         )
         const hasOnlyMissingFieldsError = error.errors.every(
-          (p) => p.name === 'MissingRequiredError',
+          (p) => p.name === 'MissingRequiredError'
         )
         displayError(
           hasOnlyMissingFieldsError
             ? 'Required field values are missing.'
-            : 'Some info submitted are invalid.',
+            : 'Some info submitted are invalid.'
         )
       } else if (error.details?.path) {
         const fieldName = getErrorFieldName(error.details.path)
-        const prettyErrorMessage = isNonDeletableError(
-          error.details.invalidValue,
-          error.message,
-        )
+        const prettyErrorMessage = isNonDeletableError(error.details.invalidValue)
           ? `${prettyField(fieldName)} is not deletable`
           : error.message.replace(fieldName, prettyField(fieldName))
         setErrors([
@@ -509,8 +506,8 @@ const NoteEditor = ({
 
     setFields(
       Object.entries(invitation.edit.note.content).sort(
-        (a, b) => (a[1].order ?? 100) - (b[1].order ?? 100),
-      ),
+        (a, b) => (a[1].order ?? 100) - (b[1].order ?? 100)
+      )
     )
   }, [invitation, user, userLoading])
 
@@ -558,7 +555,7 @@ const NoteEditor = ({
           error={errors.find((e) => e.fieldName === 'editReaderValues')}
           clearError={() =>
             setErrors((existingErrors) =>
-              existingErrors.filter((p) => p.fieldName !== 'editReaderValues'),
+              existingErrors.filter((p) => p.fieldName !== 'editReaderValues')
             )
           }
         />

--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -23,7 +23,7 @@ export function parseComponentCode(entity, domain, user, args) {
       'domain',
       'user',
       'args',
-      `'use strict';\n${entity.web.replace('// Webfield component', '')}`,
+      `'use strict';\n${entity.web.replace('// Webfield component', '')}`
     )(entity, domain, user, args)
 
     if (typeof componentConfig !== 'object') {
@@ -311,7 +311,7 @@ const queryToTree = (queryParam) => {
             return new TreeNode(
               'AND',
               queryToTree(stuffInBrackets),
-              queryToTree(query.slice(i + 3)),
+              queryToTree(query.slice(i + 3))
             )
             // eslint-disable-next-line no-else-return
           } else {
@@ -335,7 +335,7 @@ const queryToTree = (queryParam) => {
             return new TreeNode(
               'OR',
               queryToTree(stuffInBrackets),
-              queryToTree(query.slice(i + 2)),
+              queryToTree(query.slice(i + 2))
             )
             // eslint-disable-next-line no-else-return
           } else {
@@ -382,10 +382,10 @@ const combineResults = (collection1, collection2, operator, uniqueIdentifier) =>
       return [...new Set([...collection1, ...collection2])]
     case 'AND': {
       const collection2UniqueIdentifiers = collection2.map((p) =>
-        propertyPath.reduce((r, s) => r?.[s], p),
+        propertyPath.reduce((r, s) => r?.[s], p)
       )
       return collection1.filter((p) =>
-        collection2UniqueIdentifiers.includes(propertyPath.reduce((r, s) => r?.[s], p)),
+        collection2UniqueIdentifiers.includes(propertyPath.reduce((r, s) => r?.[s], p))
       )
     }
     default:
@@ -449,7 +449,7 @@ const evaluateOperator = (operator, propertyValue, targetValue) => {
     case '=':
       if (Array.isArray(propertyValue))
         return propertyValue.some((p) =>
-          p.toString().toLowerCase().includes(targetValue.toString().toLowerCase()),
+          p.toString().toLowerCase().includes(targetValue.toString().toLowerCase())
         )
       return isString ? propertyValue.includes(targetValue) : propertyValue === targetValue
     case '>':
@@ -467,7 +467,7 @@ const evaluateOperator = (operator, propertyValue, targetValue) => {
     case '!=':
       if (Array.isArray(propertyValue))
         return !propertyValue.some((p) =>
-          p.toString().toLowerCase().includes(targetValue.toString().toLowerCase()),
+          p.toString().toLowerCase().includes(targetValue.toString().toLowerCase())
         )
       return propertyValue !== targetValue
     default:
@@ -501,14 +501,14 @@ const filterOneOperand = (collections, operand, filterOperators, propertiesAllow
         return evaluateOperator(
           filterOperator,
           propertyPath[0].reduce((r, s) => r?.[s], p),
-          convertedValue,
+          convertedValue
         )
       }
       if (valuePath?.length === 1) {
         return evaluateOperator(
           filterOperator,
           propertyPath[0].reduce((r, s) => r?.[s], p) ?? 0,
-          valuePath[0].reduce((r, s) => r?.[s], p) ?? 0,
+          valuePath[0].reduce((r, s) => r?.[s], p) ?? 0
         )
       }
       // valuePath?.length>1
@@ -518,8 +518,8 @@ const filterOneOperand = (collections, operand, filterOperators, propertiesAllow
           evaluateOperator(
             filterOperator,
             propertyPath[0].reduce((r, s) => r?.[s], p),
-            t,
-          ),
+            t
+          )
         )
     }
     if (propertyPath.length > 1 && valuePath?.length > 1) {
@@ -529,7 +529,7 @@ const filterOneOperand = (collections, operand, filterOperators, propertiesAllow
         .some((t) =>
           valuePath
             .map((q) => q.reduce((r, s) => r?.[s], p))
-            .some((u) => evaluateOperator(filterOperator, t, u)),
+            .some((u) => evaluateOperator(filterOperator, t, u))
         )
     }
     return propertyPath
@@ -543,7 +543,7 @@ const filterTreeNode = (
   treeNode,
   filterOperators,
   propertiesAllowed,
-  uniqueIdentifier,
+  uniqueIdentifier
 ) => {
   if (treeNode instanceof TreeNode) {
     return combineResults(
@@ -552,17 +552,17 @@ const filterTreeNode = (
         treeNode.left,
         filterOperators,
         propertiesAllowed,
-        uniqueIdentifier,
+        uniqueIdentifier
       ),
       filterTreeNode(
         collections,
         treeNode.right,
         filterOperators,
         propertiesAllowed,
-        uniqueIdentifier,
+        uniqueIdentifier
       ),
       treeNode.value,
-      uniqueIdentifier,
+      uniqueIdentifier
     )
   }
   // single expression
@@ -584,7 +584,7 @@ export function filterCollections(
   filterString,
   filterOperators,
   propertiesAllowed,
-  uniqueIdentifier,
+  uniqueIdentifier
 ) {
   try {
     const syntaxTree = queryToTree(filterString)
@@ -593,7 +593,7 @@ export function filterCollections(
       syntaxTree,
       filterOperators,
       propertiesAllowed,
-      uniqueIdentifier,
+      uniqueIdentifier
     )
     return { filteredRows: filterResult }
   } catch (error) {
@@ -619,13 +619,13 @@ export function buildEdgeBrowserUrl(
   invGroup,
   invName,
   scoresName,
-  apiVersion = 2,
+  apiVersion = 2
 ) {
   const invitationId = `${invGroup}/-/${invName}`
   const referrerUrl = `/group${window.location.search}${window.location.hash}`
   const conflictInvitationId = invitations.find((p) => p.id === `${invGroup}/-/Conflict`)?.id
   const scoresInvitationId = invitations.find(
-    (p) => p.id === `${invGroup}/-/${scoresName}`,
+    (p) => p.id === `${invGroup}/-/${scoresName}`
   )?.id
 
   // Right now this is only showing bids, affinity scores, and conflicts as the
@@ -733,15 +733,9 @@ export function convertToType(value, targetType) {
  * check if the error invalid value is {delete:true}
  *
  * @param {any} invalidValue
- * @param {string} errorMessage
  * @returns {boolean}
  */
-export function isNonDeletableError(invalidValue, errorMessage) {
-  if (
-    !invalidValue ||
-    (typeof invalidValue !== 'object' &&
-      errorMessage !== 'The property delete must NOT be present')
-  )
-    return false
+export function isNonDeletableError(invalidValue) {
+  if (!invalidValue || typeof invalidValue !== 'object') return false
   return JSON.stringify(invalidValue) === JSON.stringify({ delete: true })
 }

--- a/unitTests/TextboxWidget.test.js
+++ b/unitTests/TextboxWidget.test.js
@@ -46,7 +46,7 @@ describe('TextboxWidget', () => {
     }
     reRenderWithEditorComponentContext(rerender, <TextboxWidget />, providerProps)
     expect(screen.getByDisplayValue('keyword one,keyword two,keyword three')).toHaveAttribute(
-      'readonly',
+      'readonly'
     )
 
     providerProps = {
@@ -72,7 +72,7 @@ describe('TextboxWidget', () => {
     }
     reRenderWithEditorComponentContext(rerender, <TextboxWidget />, providerProps)
     expect(screen.getByDisplayValue('keyword one,keyword two,keyword three')).toHaveAttribute(
-      'readonly',
+      'readonly'
     )
 
     providerProps = {
@@ -94,7 +94,7 @@ describe('TextboxWidget', () => {
     }
     reRenderWithEditorComponentContext(rerender, <TextboxWidget />, providerProps)
     expect(screen.getByDisplayValue('keyword one,keyword two,keyword three')).toHaveAttribute(
-      'readonly',
+      'readonly'
     )
   })
 
@@ -243,7 +243,7 @@ describe('TextboxWidget', () => {
     }
     renderWithEditorComponentContext(<TextboxWidget />, providerProps)
     expect(
-      screen.getByDisplayValue('keyword one,keyword two,keyword three'),
+      screen.getByDisplayValue('keyword one,keyword two,keyword three')
     ).toBeInTheDocument()
   })
 
@@ -294,7 +294,7 @@ describe('TextboxWidget', () => {
     const input = screen.getByDisplayValue('')
     await userEvent.type(input, '  keyword one,  keyword two    ,keyword three    ')
     expect(onChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ value: ['keyword one', 'keyword two', 'keyword three'] }),
+      expect.objectContaining({ value: ['keyword one', 'keyword two', 'keyword three'] })
     )
     expect(clearError).toHaveBeenCalled()
   })
@@ -399,7 +399,7 @@ describe('TextboxWidget', () => {
     renderWithEditorComponentContext(<TextboxWidget />, providerProps)
     expect(getItem).toHaveBeenCalledWith('some key')
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ value: 'some saved value' }),
+      expect.objectContaining({ value: 'some saved value' })
     )
     expect(clearError).toHaveBeenCalled()
   })


### PR DESCRIPTION
this pr should fix the following issue:
when a mandatory textbox field with type string[], for example keywords, is touched and then cleared in note editor, it will be sent to API with the value [""] which may not fail API validation.

this is not desired behavior as the user didn't put anything in the textbox.
this pr should fix this case by passing undefined

when value of such a field is cleared when user is editing a note, note editor is currently sending the value [""] to API which is also not the desired behavior.
this pr should fix this case by passing {delete:true} which will fail at api because this field is not deletable.
this pr required https://github.com/openreview/openreview-api/pull/243 to show the proper error message "{field} is not deletable"