### PR TITLE
Fix/Revisions page - error is thrown when invitation is not readable by user

### DIFF
--- a/pages/revisions/index.js
+++ b/pages/revisions/index.js
@@ -593,7 +593,7 @@ const Revisions = ({ appContext }) => {
             )
             // Don't show the edit button next to an edit if it's expired and not writable
             if (
-              editInvitation.expdate &&
+              editInvitation?.expdate &&
               editInvitation.expdate < Date.now() &&
               !editInvitation.details?.writable
             ) {


### PR DESCRIPTION
this pr should fix the issue reading editInvitation.expdate when editInvitaiton is undefined in revisions page.
