### PR TITLE
Fix/PC Console - Non anonymous venue not displayed correctly

### DIFF
--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -311,6 +311,42 @@ export const AcPcConsoleReviewerStatusRow = ({
   )
 }
 
+// reviewers info might not be visible so only show info of reviews
+export const AcPcConsoleReviewStatusRow = ({
+  review,
+  note,
+  referrerUrl,
+  reviewRatingName,
+  showRatingConfidence = true,
+}) => {
+  const hasConfidence = review?.confidence !== null
+
+  return (
+    <div className="review-row">
+      {showRatingConfidence && (
+        <div>
+          {(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName])
+            .flatMap((ratingName, index) => {
+              const rating = review[ratingName]
+              if (rating !== null) return `${upperFirst(ratingName)}: ${rating}`
+              return []
+            })
+            .join(' / ')}
+          {hasConfidence && ` / Confidence: ${review.confidence}`}
+        </div>
+      )}
+      {review.reviewLength && <span>Review length: {review.reviewLength}</span>}
+      <a
+        href={`/forum?id=${note.forum}&noteId=${review.id}&referrer=${referrerUrl}`}
+        target="_blank"
+        rel="nofollow noreferrer"
+      >
+        Read Review
+      </a>
+    </div>
+  )
+}
+
 // modified from noteReviewers.hbs handlebar template
 // shared by AC and PC console
 export const AcPcConsoleNoteReviewStatus = ({
@@ -328,9 +364,6 @@ export const AcPcConsoleNoteReviewStatus = ({
     numReviewsDone,
     numReviewersAssigned,
     replyCount,
-    // ratingMax,
-    // ratingMin,
-    // ratingAvg,
     ratings,
     confidenceMax,
     confidenceMin,
@@ -340,6 +373,58 @@ export const AcPcConsoleNoteReviewStatus = ({
     'edges/browse?',
     `edges/browse?start=staticList,type:head,ids:${note.id}&`
   )
+
+  // reviewers group not visible
+  if (reviewers.length === 0 && numReviewsDone > 0)
+    return (
+      <div className="console-reviewer-progress">
+        <h4>{numReviewsDone} Reviews Submitted</h4>
+        <Collapse
+          showLabel="Show reviews"
+          hideLabel="Hide reviews"
+          className="assigned-reviewers"
+        >
+          {officialReviews.map((review) => (
+            <AcPcConsoleReviewStatusRow
+              key={review.id}
+              review={review}
+              note={note}
+              referrerUrl={referrerUrl}
+              reviewRatingName={reviewRatingName}
+            />
+          ))}
+        </Collapse>
+        {(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
+          (ratingName, index) => {
+            const { ratingAvg, ratingMin, ratingMax } = ratings[ratingName]
+            return (
+              <span key={index}>
+                <strong>Average {upperFirst(ratingName)}:</strong> {ratingAvg} (Min:{' '}
+                {ratingMin}, Max: {ratingMax})
+              </span>
+            )
+          }
+        )}
+        <span>
+          <strong>Average Confidence:</strong> {confidenceAvg} (Min: {confidenceMin}, Max:{' '}
+          {confidenceMax})
+        </span>
+        <span>
+          <strong>Number of Forum replies:</strong> {replyCount}
+        </span>
+        {paperManualReviewerAssignmentUrl && (
+          <div className="mt-3">
+            <a
+              href={`${paperManualReviewerAssignmentUrl}&referrer=${referrerUrl}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Edit Reviewer Assignments
+            </a>
+          </div>
+        )}
+      </div>
+    )
 
   return (
     <div className="console-reviewer-progress">

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -299,7 +299,9 @@ const ProgramChairConsole = ({ appContext }) => {
         } else if (p.id.includes(anonReviewerName)) {
           const number = getNumberFromGroup(p.id, submissionName)
           if (!(number in anonReviewerGroups)) anonReviewerGroups[number] = {}
-          if (p.members.length) anonReviewerGroups[number][p.members[0]] = p.id
+          if (p.members.length) {
+            anonReviewerGroups[number][p.members[0]] = p.id
+          }
         } else if (p.id.endsWith(`/${areaChairName}`)) {
           areaChairGroups.push({
             noteNumber: getNumberFromGroup(p.id, submissionName),
@@ -358,6 +360,17 @@ const ProgramChairConsole = ({ appContext }) => {
         const profileEmails = profile.content.emails.filter((p) => p)
         usernames.concat(profileEmails).forEach((key) => {
           allProfilesMap.set(key, profile)
+        })
+      })
+      Object.entries(anonReviewerGroups).forEach(([noteNumber, anonReviewerGroup]) => {
+        Object.entries(anonReviewerGroup).forEach(([anonReviewerId, anonReviewerGroupId]) => {
+          const profile = allProfilesMap.get(anonReviewerId)
+          if (!profile) return
+          const usernames = profile.content.names.flatMap((p) => p.username ?? [])
+          const profileEmails = profile.content.emails.filter((p) => p)
+          usernames.concat(profileEmails).forEach((key) => {
+            anonReviewerGroups[noteNumber][key] = anonReviewerGroupId
+          })
         })
       })
 

--- a/styles/pages/group.scss
+++ b/styles/pages/group.scss
@@ -485,6 +485,12 @@ main.invitation {
             font-size: 0.75rem;
           }
         }
+
+        .review-row {
+          display: flex;
+          flex-direction: column;
+          font-size: 0.75rem;
+        }
       }
     }
 


### PR DESCRIPTION
this pr should fix the following 2 issues:
1. when pc is author of a submission, the pc can't see the reviewers group so the number of reviewers assigned is displayed as 0 and no review info are displayed.
2. for non-anonymous venue, when a review is signed using tilde id but the reviewer is added to per paper reviewers group and all reviewers group using email. currently logic can't link the review to the reviewer so it will show all reviews are completed but show send reminder link under the reviewer in paper status tab.