### PR TITLE
Fix/AC Console - allow extra export columns in csv export

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -134,6 +134,7 @@ const AreaChairConsole = ({ appContext }) => {
     propertiesAllowed,
     enableQuerySearch,
     emailReplyTo,
+    extraExportColumns,
   } = useContext(WebFieldContext)
   const {
     showEdgeBrowserUrl,
@@ -337,6 +338,7 @@ const AreaChairConsole = ({ appContext }) => {
             const anonymousId = getIndentifierFromGroup(q.signatures[0], anonReviewerName)
             const reviewValue = q.content.review?.value
             return {
+              ...q,
               anonymousId,
               confidence: parseNumberField(q.content[reviewConfidenceName]?.value),
               ...Object.fromEntries(
@@ -348,7 +350,6 @@ const AreaChairConsole = ({ appContext }) => {
                 )
               ),
               reviewLength: reviewValue?.length,
-              id: q.id,
             }
           })
 
@@ -471,6 +472,7 @@ const AreaChairConsole = ({ appContext }) => {
             setAcConsoleData={setAcConsoleData}
             shortPhrase={shortPhrase}
             enableQuerySearch={enableQuerySearch}
+            extraExportColumns={extraExportColumns}
             filterOperators={filterOperators}
             propertiesAllowed={propertiesAllowed}
             reviewRatingName={reviewRatingName}
@@ -487,6 +489,7 @@ const AreaChairConsole = ({ appContext }) => {
           setAcConsoleData={setAcConsoleData}
           shortPhrase={shortPhrase}
           enableQuerySearch={enableQuerySearch}
+          extraExportColumns={extraExportColumns}
           filterOperators={filterOperators}
           propertiesAllowed={propertiesAllowed}
           reviewRatingName={reviewRatingName}

--- a/components/webfield/AreaChairConsoleMenuBar.js
+++ b/components/webfield/AreaChairConsoleMenuBar.js
@@ -9,12 +9,13 @@ const AreaChairConsoleMenuBar = ({
   setAcConsoleData,
   shortPhrase,
   enableQuerySearch,
+  extraExportColumns,
   filterOperators: filterOperatorsConfig,
-  propertiesAllowed: propertiesAllowedConfig,
+  propertiesAllowed: extraPropertiesAllowed,
   reviewRatingName,
 }) => {
   const filterOperators = filterOperatorsConfig ?? ['!=', '>=', '<=', '>', '<', '==', '='] // sequence matters
-  const propertiesAllowed = propertiesAllowedConfig ?? {
+  const propertiesAllowed = {
     number: ['note.number'],
     id: ['note.id'],
     title: ['note.content.title.value'],
@@ -37,6 +38,7 @@ const AreaChairConsoleMenuBar = ({
     confidenceMin: ['reviewProgressData.confidenceMin'],
     replyCount: ['reviewProgressData.replyCount'],
     recommendation: ['metaReviewData.recommendation'],
+    ...(typeof extraPropertiesAllowed === 'object' && extraPropertiesAllowed),
   }
   const messageReviewerOptions = [
     { label: 'All Reviewers of selected papers', value: 'allReviewers' },
@@ -95,6 +97,7 @@ const AreaChairConsoleMenuBar = ({
     { header: 'max confidence', getValue: (p) => p.reviewProgressData?.confidenceMax },
     { header: 'average confidence', getValue: (p) => p.reviewProgressData?.confidenceAvg },
     { header: 'ac recommendation', getValue: (p) => p.metaReviewData?.recommendation },
+    ...(extraExportColumns ?? []),
   ]
   const sortOptions = [
     { label: 'Paper Number', value: 'Paper Number', getValue: (p) => p.note?.number },


### PR DESCRIPTION
this pr should fix issue #1573 

for neurips request, the config to add should be:
```javascript
extraExportColumns:[{header:'reviewer info',getValue: `
  return row.reviewers?.
    map((reviewer) => {
      const review = row.officialReviews?.find(
        (review) => review.anonymousId === reviewer.anonymousId
      );
      return \`\${reviewer.preferredName}:rating-\${review?.rating??'N/A'}|confidence-\${review?.confidence??'N/A'}|first time reviewer-\${review?.content?.first_time_reviewer?.value ?? 'N/A'}\`;
    })
    .join(',')
`}]
``` 