### PR TITLE
Fix/ Note Editor: don't show extra space around hidden fields

### DIFF
--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -182,6 +182,7 @@ const NoteEditor = ({
     if (!fieldNameOverwrite) {
       fieldNameOverwrite = fieldName === 'authorids' ? 'Authors' : undefined
     }
+    const isHiddenField = fieldDescription?.value?.param?.hidden
 
     const error = errors.find((e) => e.fieldName === fieldName)
 
@@ -196,7 +197,7 @@ const NoteEditor = ({
     if (fieldName === 'authors' && Array.isArray(fieldDescription?.value)) return null
 
     return (
-      <div key={fieldName} className={styles.fieldContainer}>
+      <div key={fieldName} className={isHiddenField ? null : styles.fieldContainer}>
         <EditorComponentContext.Provider
           value={{
             invitation,


### PR DESCRIPTION
Currently when the note editor displays a hidden field the container element still has some padding, leading to the form looking like it has inconsistent spacing between fields. This PR removes that extra padding.

For example, the submission form for http://localhost:3030/group?id=DeepLearningIndaba.com/2023/Workshop/WSCV 