### PR TITLE
Fix/ Note editor: error with fields of type string

### DIFF
--- a/client/view-v2.js
+++ b/client/view-v2.js
@@ -2360,7 +2360,7 @@ module.exports = (function () {
           if (
             valueObj.param?.input === 'text' ||
             valueObj.param?.input === 'textarea' ||
-            (valueObj.param?.type === 'string' && !value.param?.enum)
+            (valueObj.param?.type === 'string' && !valueObj.param?.enum)
           ) {
             newVal = newVal?.trim()
           }


### PR DESCRIPTION
Fixed a typo in constructEdit function that was causing a JS error in certain circumstances.