### PR TITLE
Fix/ Group editor: allow user to change reply to email

### DIFF
--- a/components/group/GroupMembers.js
+++ b/components/group/GroupMembers.js
@@ -26,13 +26,14 @@ const MessageMemberModal = ({
 
   const sendMessage = async () => {
     const sanitizedMessage = DOMPurify.sanitize(message)
+    const cleanReplytoEmail = replyToEmail.trim()
 
     if (!subject || !sanitizedMessage) {
       setError('Email Subject and Body are required to send messages.')
       return
     }
 
-    if (replyToEmail && !isValidEmail(replyToEmail)) {
+    if (cleanReplytoEmail && !isValidEmail(cleanReplytoEmail)) {
       setError('Reply to email is invalid.')
       return
     }
@@ -45,7 +46,7 @@ const MessageMemberModal = ({
           subject,
           message: sanitizedMessage,
           parentGroup: groupId,
-          replyTo: replyToEmail,
+          ...(cleanReplytoEmail && { replyTo: cleanReplytoEmail }),
           useJob: true,
         },
         { accessToken }


### PR DESCRIPTION
currently the replyto email when sending messages via group editor is set to domain.contact if the domain object has it. usually it is set to the contact of program chairs.

when ethics chairs message ethics reviewers through group editor, the replyto email should be set to email of ethics chairs instead of program chairs.

this pr should allow modification of replyto email in group editor while still setting the default value to domain.contact if it exists
this pr also clear error message when modal is closed