### PR TITLE
Fix/ Only use string for title tag

### DIFF
--- a/pages/group/edit.js
+++ b/pages/group/edit.js
@@ -99,7 +99,7 @@ export default function GroupEdit({ appContext }) {
   return (
     <>
       <Head>
-        <title key="title">Edit {prettyId(group?.id)} Group | OpenReview</title>
+        <title key="title">{`Edit ${prettyId(router.query.id)} Group | OpenReview`}</title>
       </Head>
 
       <div id="header">

--- a/pages/group/info.js
+++ b/pages/group/info.js
@@ -77,7 +77,7 @@ const GroupInfo = ({ appContext }) => {
   return (
     <>
       <Head>
-        <title key="title">{prettyId(group?.id)} Group Info | OpenReview</title>
+        <title key="title">{`${prettyId(router.query.id)} Group Info | OpenReview`}</title>
       </Head>
 
       <div id="header">

--- a/pages/group/revisions.js
+++ b/pages/group/revisions.js
@@ -80,7 +80,7 @@ export default function GroupRevisions({ appContext }) {
   return (
     <>
       <Head>
-        <title key="title">{prettyId(group?.id)} Group Edit History | OpenReview</title>
+        <title key="title">{`${prettyId(router.query.id)} Group Edit History | OpenReview`}</title>
       </Head>
 
       <div id="header">

--- a/pages/invitation/edit.js
+++ b/pages/invitation/edit.js
@@ -103,7 +103,7 @@ const InvitationEdit = ({ appContext }) => {
   return (
     <>
       <Head>
-        <title key="title">Edit {prettyId(invitation?.id)} Invitation | OpenReview</title>
+        <title key="title">{`Edit ${prettyId(router.query.id)} Invitation | OpenReview`}</title>
       </Head>
 
       <div id="header">

--- a/pages/invitation/info.js
+++ b/pages/invitation/info.js
@@ -119,7 +119,7 @@ const InvitationInfo = ({ appContext }) => {
   return (
     <>
       <Head>
-        <title key="title">{prettyId(invitation?.id)} Invitation Info | OpenReview</title>
+        <title key="title">{`${prettyId(router.query.id)} Invitation Info | OpenReview`}</title>
       </Head>
 
       <div id="header">

--- a/pages/invitation/revisions.js
+++ b/pages/invitation/revisions.js
@@ -85,7 +85,7 @@ export default function InvitationRevisions({ appContext }) {
     <>
       <Head>
         <title key="title">
-          {prettyId(invitation?.id)} Invitation Edit History | OpenReview
+          {`${prettyId(router.query.id)} Invitation Edit History | OpenReview`}
         </title>
       </Head>
 

--- a/pages/revisions/compare.js
+++ b/pages/revisions/compare.js
@@ -188,7 +188,7 @@ const CompareRevisions = ({ appContext }) => {
   return (
     <>
       <Head>
-        <title key="title">Revisions | OpenReview</title>
+        <title key="title">Compare Revisions | OpenReview</title>
       </Head>
 
       <header>


### PR DESCRIPTION
If the title tag contains anything other than a single text node Next.js 13 shows a warning. This PR fixes those warnings.