### PR TITLE
Fix/Profile search widget - not to show loading animation

### DIFF
--- a/components/EditorComponents/ProfileSearchWidget.js
+++ b/components/EditorComponents/ProfileSearchWidget.js
@@ -380,6 +380,7 @@ const CustomAuthorForm = ({
       )
       if (results.profiles.length) {
         setProfileSearchResults(results.profiles)
+        setIsLoading(false)
         return
       }
     } catch (error) {

--- a/unitTests/ProfileSearchWidget.test.js
+++ b/unitTests/ProfileSearchWidget.test.js
@@ -41,7 +41,9 @@ describe('ProfileSearchWidget for authors+authorids field', () => {
     renderWithEditorComponentContext(<ProfileSearchWidget />, providerProps)
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('search profiles by email or name')).toBeInTheDocument()
+      expect(
+        screen.getByPlaceholderText('search profiles by email or name')
+      ).toBeInTheDocument()
       expect(screen.getByText('Search')).toHaveAttribute('disabled')
     })
   })
@@ -961,6 +963,7 @@ describe('ProfileSearchWidget for authors+authorids field', () => {
       '~search_result1'
     )
     expect(onChange).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Add').childElementCount).toEqual(0) // not to show loading icon
 
     await userEvent.click(screen.getByRole('button', { name: 'plus' }))
     expect(onChange).toHaveBeenNthCalledWith(


### PR DESCRIPTION
this pr should fix the following issue:
when user add a custom author using an email which is associated with a profile in the search results, the "Add" button is showing the loading status spinner.

this pr should remove the loading spinner.
