### PR TITLE
Fix/TMLR homepage list style

### DIFF
--- a/styles/pages/group.scss
+++ b/styles/pages/group.scss
@@ -37,6 +37,11 @@ main.invitation {
       &.dark p {
         color: constants.$darkBlue;
       }
+
+      li {
+        color: #777777;
+        margin-bottom: 10px;
+      }
     }
     p {
       color: #777777;


### PR DESCRIPTION
currently TMLR homepage has the following structure
```html
<ul>
    <li>
        <p> some text</p>
    </li>
</ul>
```

when this get converted to markdown, it's not possible to keep the p tag inside li unless the whole header use html
p tag in group header has some styles so the component homepage will be rendered differently from existing webfield

this pr should make them look the same