### PR TITLE
Fix/SAC console - notes loading logic and notes filtering function

### DIFF
--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -96,7 +96,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                     return (
                       noteVenueId !== withdrawnVenueId &&
                       venueId !== deskRejectedVenueId &&
-                      ((filterFunction && Function('note', filterFunction)(note)) ?? true) &&
+                      ((filterFunction && Function('note', filterFunction)(note)) ?? true) && // eslint-disable-line no-new-func
                       noteNumbers.includes(note.number)
                     )
                   })


### PR DESCRIPTION
currently SAC console will load all notes by submission invitation which are visible to an SAC.
This will be wrong when the SAC is also PC, it should just load the papers assigned to this user (as SAC).

this pr should:
1. fix the above issue by loading groups then papers
2. add a filterFunction config to filter notes loaded
filterFunction config is a function string which has one parameter "note" and it should return a boolean value. this function is required to filter notes by tracks because each track has it's own SAC console but when the SAC is also PC the user will see papers of other tracks too (if assigned)
example:
```js
...
filterFunction:`return note.content?.track?.value==="Track 5: Qur'an QA"`
...
```