### PR TITLE
Feature/Notes - show description from presentation

### DIFF
--- a/components/NoteContent.js
+++ b/components/NoteContent.js
@@ -183,12 +183,15 @@ export const NoteContentV2 = ({
         if (omittedFields.includes(fieldName) || fieldName.startsWith('_')) return null
 
         let rawFieldValue = presentation?.[i]?.description
-        if (rawFieldValue && Array.isArray(rawFieldValue))
-          rawFieldValue = rawFieldValue.filter((p) => p)
+        if (Array.isArray(rawFieldValue)) {
+          rawFieldValue = rawFieldValue.filter(Boolean)
+          if (rawFieldValue.length === 0) rawFieldValue = null
+        }
 
-        if (Array.isArray(rawFieldValue) ? !rawFieldValue.length : !rawFieldValue)
+        if (!rawFieldValue) {
           rawFieldValue =
             fieldName === 'Submission_Number' ? number : content[fieldName]?.value
+        }
         const fieldValue = prettyContentValue(rawFieldValue)
 
         if (!fieldValue) return null


### PR DESCRIPTION
this pr should show description in presentation for a content field if it's available
currently this is only for forum and forum replies

Edit does not have presentation so it will not show description in activity list

another place we can show this is the paper summary in consoles as shown below
<img width="426" alt="image" src="https://github.com/openreview/openreview-web/assets/60613434/e4c053c7-8255-43ab-b2d7-8eedc5dd7a6f">
I'm not sure how useful it is though 
if we need to add this, consoles need get presentation info of notes
