### PR TITLE
Fix/SAC console - error when SAC is reviewer of paper not assigned

### DIFF
--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -198,6 +198,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                 (key) => paperAnonReviewerGroups[key] === member
               )
             }
+            if (!anonymizedGroup) return []
             return {
               reviewerProfileId: deanonymizedGroup,
               anonymizedGroup,


### PR DESCRIPTION
an error will be thrown in
>anonymousId: getIndentifierFromGroup(anonymizedGroup, anonReviewerName)

when anonymizedGroup is undefined
this happens when the SAC is a reviewer of a paper which is not assigned to the SAC

for example paper 123 has the SAC as a reviewer but is assigned to another SAC
so the SAC can only see it's own anonymous group papers123/Reviewer_abcd and can't see the anonymous groups of other reviewers of paper 123 and this will cause anonymizedGroup to be undefined when it loop through reviewer group members of paper 123.

this pr should fix this issue