### PR TITLE
Fix/Assignment page - check for comma in config note title

### DIFF
--- a/pages/assignments/index.js
+++ b/pages/assignments/index.js
@@ -228,6 +228,12 @@ const NewNoteEditorModal = ({
         errorMessage: 'The configuration title must be unique within the conference',
       }
     }
+    if (formData.title?.includes(',')) {
+      return {
+        isValid: false,
+        errorMessage: 'The configuration title should not contain comma',
+      }
+    }
     return { isValid: true }
   }
 


### PR DESCRIPTION
assignment config note title may be used as "label" in edge browser url
if the title contains comma, it will be seen as multiple parameter and passing the wrong label to api
which will lead to 0 edges being returned.

this pr should fix this issue by checking that the config note title does not contain comma