### PR TITLE
Fix/ Forum page: add pdate and odate to formatted notes

### DIFF
--- a/lib/forum-utils.js
+++ b/lib/forum-utils.js
@@ -38,6 +38,8 @@ export function formatNote(
     mdate: note.mdate,
     tmdate: note.tmdate,
     ddate: note.ddate,
+    pdate: note.pdate,
+    odate: note.odate,
     replyto: note.replyto || note.forum,
     content: note.content || {},
     ...(typeof note.number === 'number' ? { number: note.number } : {}),


### PR DESCRIPTION
Fixes the issue where on initial load the correct published date is shown, but then replaced with the regular mdate and cdate.