### PR TITLE
Fix/Terms page - missing space

### DIFF
--- a/pages/legal/terms.js
+++ b/pages/legal/terms.js
@@ -245,7 +245,7 @@ const Terms = () => (
             rel="nofollow no referrer"
           >
             Creative Commons Attribution 4.0 International (CC BY 4.0)
-          </a>
+          </a>{' '}
           license. By agreeing to these Terms of Use, Submitters also retroactively apply this
           license to such Comments and Configuration Records they submitted in the past. (Note
           that this license does not imply that all Comments or Configuration Records are


### PR DESCRIPTION
terms page is missing a space after a link.

this pr should add a space.