### PR TITLE
Fix/Profile search widget - filter out profiles with no email

### DIFF
--- a/components/EditorComponents/ProfileSearchWidget.js
+++ b/components/EditorComponents/ProfileSearchWidget.js
@@ -200,7 +200,7 @@ const ProfileSearchFormAndResults = ({
   const [profileSearchResults, setProfileSearchResults] = useState(null)
   const [showCustomAuthorForm, setShowCustomAuthorForm] = useState(false)
   const { accessToken } = useUser()
-  const pageSize = 15
+  const pageSize = 20
 
   // eslint-disable-next-line no-shadow
   const searchProfiles = async (searchTerm, pageNumber, showLoadingSpinner = true) => {
@@ -227,7 +227,7 @@ const ProfileSearchFormAndResults = ({
         { accessToken }
       )
       setTotalCount(results.count)
-      setProfileSearchResults(results.profiles.filter((p) => p?.content?.emails?.length))
+      setProfileSearchResults(results.profiles.filter((p) => p.content.emails?.length))
     } catch (apiError) {
       promptError(apiError.message)
     }

--- a/unitTests/ProfileSearchWidget.test.js
+++ b/unitTests/ProfileSearchWidget.test.js
@@ -360,7 +360,7 @@ describe('ProfileSearchWidget for authors+authorids field', () => {
     await userEvent.click(screen.getByText('Search'))
     expect(getProfile).toHaveBeenCalledWith(
       '/profiles/search',
-      { email: 'test@email.com', es: true, limit: 15, offset: 0 },
+      { email: 'test@email.com', es: true, limit: 20, offset: 0 },
       expect.anything()
     )
   })
@@ -396,7 +396,7 @@ describe('ProfileSearchWidget for authors+authorids field', () => {
     await userEvent.click(screen.getByText('Search'))
     expect(getProfile).toHaveBeenCalledWith(
       '/profiles/search',
-      { id: '~Test_User1', es: true, limit: 15, offset: 0 },
+      { id: '~Test_User1', es: true, limit: 20, offset: 0 },
       expect.anything()
     )
   })


### PR DESCRIPTION
currently profile search widget will also show profiles with no email
this will cause process function to fail

this pr should filter out profiles with no email.