### PR TITLE
Fix/Profile search widget - some issues

### DIFF
--- a/components/EditorComponents/ProfileSearchWidget.js
+++ b/components/EditorComponents/ProfileSearchWidget.js
@@ -539,7 +539,7 @@ const ProfileSearchWidget = ({ multiple = false }) => {
       return
     }
     onChange({ fieldName, value: displayAuthors }) // update the value in the editor context to contain both id and name
-    getProfiles(multiple ? value.map((p) => p.authorId) : [value.authorId])
+    if (allowAddRemove) getProfiles(multiple ? value.map((p) => p.authorId) : [value.authorId])
   }, [])
 
   useEffect(() => {

--- a/unitTests/ProfileSearchWidget.test.js
+++ b/unitTests/ProfileSearchWidget.test.js
@@ -413,7 +413,7 @@ describe('ProfileSearchWidget for authors+authorids field', () => {
     )
   })
 
-  test('auto update author name if preferred name has changed since submission', async () => {
+  test('auto update author name if preferred name has changed since submission (invitation allows)', async () => {
     const initialGetProfile = jest.fn(() =>
       Promise.resolve({
         profiles: [
@@ -468,6 +468,56 @@ describe('ProfileSearchWidget for authors+authorids field', () => {
         'data-original-title',
         '~test_id_preferred1'
       )
+    })
+  })
+
+  test('not to auto update author name if preferred name has changed since submission (invitation is const)', async () => {
+    const initialGetProfile = jest.fn(() =>
+      Promise.resolve({
+        profiles: [
+          {
+            id: '~test_id_preferred1',
+            content: {
+              names: [
+                { first: 'Test First', last: 'Test Last', username: '~test_id1' },
+                {
+                  // user updated preferred name after submission
+                  first: 'Test First Preferred',
+                  last: 'Test Last Preferred',
+                  username: '~test_id_preferred1',
+                  preferred: true,
+                },
+              ],
+              emails: ['test@email.com', 'anothertest@email.com'],
+            },
+          },
+        ],
+      })
+    )
+
+    api.post = initialGetProfile
+    const onChange = jest.fn()
+    const clearError = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          authorids: {
+            value: ['~test_id1'], // revision invitation may only allow reorder
+          },
+        },
+        value: [{ authorId: '~test_id1', authorName: 'Test First Test Last' }],
+        onChange,
+        clearError,
+      },
+    }
+
+    renderWithEditorComponentContext(<ProfileSearchWidget multiple={true} />, providerProps)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test First Test Last')).toBeInTheDocument()
+      expect(
+        screen.queryByText('Test First Preferred Test Last Preferred')
+      ).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
this pr should fix/add the following issues/functions:
1. profile search should show the preferred id of the user in search results when user add a new name and set the new name as preferred (moved from #1642 )
2. add to the note user's preferred id instead of profile.id (the id that user first signed up with)
3. update the name and tilde id to an author's preferred and tilde id when editing an existing note if allowed by invitation
(this requires searching of profiles when editing a note which is currently not the cause because the note already have name and id which is all the info required to display author)
if it's non-authorids field tilde ids array will be rendered as tags so it's fine
4. disable add button in profile search results. (currently the same author can be added after a preferred name change)
