### PR TITLE
Fix/Edge browser - domain query param

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -544,11 +544,15 @@ export default function Column(props) {
         getWritable,
         sort,
         promise: api
-          .getAll('/edges', {...apiQuery, domain: version === '2' && invitation.domain }, {
-            accessToken,
-            version,
-            ...(isCountQuery && { resultsKey: 'groupedEdges' }),
-          })
+          .getAll(
+            '/edges',
+            { ...apiQuery, ...(version === 2 && { domain: invitation.domain }) },
+            {
+              accessToken,
+              version,
+              ...(isCountQuery && { resultsKey: 'groupedEdges' }),
+            }
+          )
           .then((result) =>
             isCountQuery
               ? result?.map((p) => ({
@@ -669,10 +673,14 @@ export default function Column(props) {
       }
       const { apiQuery } = buildQuery(startInvitation.id, startInvitation.query, false)
       api
-        .getAll('/edges', { ...apiQuery, domain: version === '2' && startInvitation.domain }, {
-          accessToken,
-          version,
-        })
+        .getAll(
+          '/edges',
+          { ...apiQuery, ...(version === 2 && { domain: startInvitation.domain }) },
+          {
+            accessToken,
+            version,
+          }
+        )
         .then((startEdges) => {
           if (!startEdges) {
             setItems([])

--- a/pages/edges/browse.js
+++ b/pages/edges/browse.js
@@ -77,7 +77,11 @@ const Browse = ({ appContext }) => {
     try {
       const apiRes = await api.get(
         '/invitations',
-        { ids: idsToLoad.join(','), expired: true, type: apiVersion === '2' ? 'edge' : 'edges' },
+        {
+          ids: idsToLoad.join(','),
+          expired: true,
+          type: apiVersion === 2 ? 'edge' : 'edges',
+        },
         { accessToken, version: apiVersion }
       )
       if (!apiRes.invitations?.length) {


### PR DESCRIPTION
this pr should fix the following issues:

1. current way of passing domain may cause domain to have value false
2. version in edge browser has been parsed to be integer so update comparison to be with number instead of string