### PR TITLE
Fix/Reviewer console - Url too long when too many papers assigned to the same reviewer

### DIFF
--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -2,7 +2,7 @@
 import { useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
-import { chunk, concat } from 'lodash'
+import { chunk } from 'lodash'
 import api from '../../lib/api-client'
 import Table from '../Table'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '../Tabs'
@@ -412,7 +412,7 @@ const ReviewerConsole = ({ appContext }) => {
             .then((result) => result.invitations)
         })
         return Promise.all(officalReviewInvitationPs)
-          .then((invitationChunks) => concat(...invitationChunks))
+          .then((invitationChunks) => invitationChunks.flat())
           .then((officialReviewInvitationsResult) => [
             notes,
             paperRankingInvitation,


### PR DESCRIPTION
Reviewer console has a call to get official review invitations of assigned papers with a GET call.
when the reviewer was assigned too many papers (over about 150), the call may fail because the url is too long.

this pr should group the calls in batch of 50 invitations ids so that reviewer console does not fail.

