### PR TITLE
Fix/Revisions page - handle deleted license

### DIFF
--- a/components/Edit/EditValue.js
+++ b/components/Edit/EditValue.js
@@ -4,7 +4,11 @@ import Icon from '../Icon'
 const EditValue = ({ name, value }) => {
   if (!Array.isArray(value)) {
     if (value instanceof Object) {
-      return <pre>{prettyContentValue(value)}</pre>
+      return (
+        <div className={name}>
+          <span className="line_heading">{name}:</span> <pre>{prettyContentValue(value)}</pre>
+        </div>
+      )
     }
     return (
       <div className={name}>

--- a/styles/pages/revisions.scss
+++ b/styles/pages/revisions.scss
@@ -265,7 +265,7 @@ main.revisions {
 
   #update-modal {
     .modal-body {
-      padding: .5rem;
+      padding: 0.5rem;
       margin-bottom: -1.875rem;
 
       hr {
@@ -321,6 +321,11 @@ main.revisions {
         padding-right: 0.25rem;
       }
       .edit_value {
+        font-size: 0.75rem;
+      }
+      pre {
+        margin-bottom: 0;
+        padding: 0.375rem;
         font-size: 0.75rem;
       }
     }


### PR DESCRIPTION
when an edit has deleted license field ({delete:true}), it will cause the revisions page to break because EditValue expects only string and array.

this pr should handle the case that edit license is deleted, similar to edit.note value