### PR TITLE
Fix/Textbox widget - render non-string existing value correctly

### DIFF
--- a/components/EditorComponents/TextboxWidget.js
+++ b/components/EditorComponents/TextboxWidget.js
@@ -21,7 +21,11 @@ const TextboxWidget = () => {
   const isHiddenField = field[fieldName].value?.param?.hidden
   const shouldSaveDraft = true
 
-  const [displayValue, setDisplayValue] = useState(isArrayType ? value?.join(',') : value)
+  let initialValue = isNil(value) ? value : value.toString()
+  if (isArrayType) {
+    initialValue = value?.join(',')
+  }
+  const [displayValue, setDisplayValue] = useState(initialValue)
 
   const getInputValue = (rawInputValue) => {
     if (!isArrayType) {

--- a/unitTests/TextboxWidget.test.js
+++ b/unitTests/TextboxWidget.test.js
@@ -183,6 +183,50 @@ describe('TextboxWidget', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  test('show value of differernt type correctly editing existing note (integer)', () => {
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          year: {
+            value: {
+              param: { type: 'integer' },
+            },
+          },
+        },
+        value: 2023,
+        onChange,
+      },
+    }
+    renderWithEditorComponentContext(<TextboxWidget />, providerProps)
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ value: 2023 }))
+    expect(screen.getByDisplayValue('2023')).toBeInTheDocument()
+  })
+
+  test('show value of differernt type correctly editing existing note (integer[])', () => {
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          year: {
+            value: {
+              param: { type: 'integer[]' },
+            },
+          },
+        },
+        value: [2023, 2024, 2025],
+        onChange,
+      },
+    }
+    renderWithEditorComponentContext(<TextboxWidget />, providerProps)
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ value: [2023, 2024, 2025] })
+    )
+    expect(screen.getByDisplayValue('2023,2024,2025')).toBeInTheDocument()
+  })
+
   test("don't show default value or invoke onChange editing existing note (array field)", () => {
     const onChange = jest.fn()
     const defaultValue = ['keyword one', 'keyword two', 'keyword three']


### PR DESCRIPTION
this pr should fix the issue that editing a note with integer value (for example year which is rendered as a textbox) will throw an error calling trim() 
by adding a string conversion for non-array value 