### PR TITLE
Fix/ Note editor: allow signatures to be reader of reply

### DIFF
--- a/components/NoteEditorReaders.js
+++ b/components/NoteEditorReaders.js
@@ -359,6 +359,7 @@ export const NewReplyEditNoteReaders = ({
     return replyReaders.every((p) => {
       if (parentReaders.includes(p)) return true
       if (p.includes('/Reviewer_')) return parentReaders.find((q) => q.includes('/Reviewers'))
+      if (p.includes('/signatures')) return true
       return false
     })
   }


### PR DESCRIPTION
I need a review rating (reply to reviews) to be visible only to PCs and the signature of the review rating. Since we were doing exact string match, this was giving an error: `Can not create note, readers must match parent note`. This should fix it. 

Note: we assume that if the user signing this note can open the note editor, then they can see the parent note, so no need to explicitly check if the signatures is in the readers of the parent note (also the UI does not know what `${3/signatures}` will resolve to)