### PR TITLE
Fix/Remove edit license from revisions page

### DIFF
--- a/components/Edit/Edit.js
+++ b/components/Edit/Edit.js
@@ -152,7 +152,6 @@ export default function Edit({ edit, type, className, showContents }) {
       <div className="edit_info">
         <h4>Edit Info</h4>
         <hr className="small" />
-        {edit.license && <EditValue name="License" value={edit.license} />}
         <EditValue name="Readers" value={prettyList(edit.readers, 'long', 'unit')} />
         <EditValue name="Writers" value={prettyList(edit.writers, 'long', 'unit')} />
         <EditValue name="Signatures" value={prettyList(edit.signatures, 'long', 'unit')} />


### PR DESCRIPTION
this pr should remove license field from edit component
because license field will be removed from edit entity