### PR TITLE
Fix/ Group info: add search to members list

### DIFF
--- a/components/PaginatedList.js
+++ b/components/PaginatedList.js
@@ -15,6 +15,7 @@ export default function PaginatedList({
   searchItems,
   ListItem,
   emptyMessage,
+  searchPlaceholder,
   itemsPerPage = 15,
   shouldReload,
   className,
@@ -85,7 +86,7 @@ export default function PaginatedList({
             <input
               type="text"
               className="form-control"
-              placeholder="Search submissions by title and metadata"
+              placeholder={searchPlaceholder || 'Search submissions by title and metadata'}
               autoComplete="off"
               onChange={(e) => {
                 const term = e.target.value.trim()

--- a/components/group/info/GroupMembersInfo.js
+++ b/components/group/info/GroupMembersInfo.js
@@ -12,11 +12,38 @@ const GroupMembersInfo = ({ group }) => {
     count: group.members.length,
   })
 
-  const memberCount = group.members?.length > 0 ? `(${group.members.length})` : ''
+  const searchMembers = (term, limit, offset) => {
+    const termLower = term.toLowerCase()
+    const filteredMembers = group.members.filter((member) => {
+      const memberLower = member.toLowerCase()
+      return (
+        memberLower.includes(termLower) || memberLower.replace(/_|-/g, ' ').includes(termLower)
+      )
+    })
+    return {
+      items: filteredMembers.slice(offset, offset + limit).map((member) => ({
+        id: member,
+        title: member,
+        href: urlFromGroupId(member, true),
+      })),
+      count: filteredMembers.length,
+    }
+  }
+
+  const memberCount = group.members?.length ?? 0
 
   return (
-    <EditorSection title={`Group Members ${memberCount}`} className="members">
-      <PaginatedList loadItems={loadMembers} emptyMessage="No members to display" />
+    <EditorSection
+      title={`Group Members ${memberCount > 0 ? ` (${memberCount})` : ''}`}
+      className="members"
+    >
+      <PaginatedList
+        loadItems={loadMembers}
+        searchItems={memberCount > 20 ? searchMembers : null}
+        emptyMessage="No members to display"
+        searchPlaceholder="Search members by username"
+        itemsPerPage={20}
+      />
     </EditorSection>
   )
 }


### PR DESCRIPTION
Add search bar to group info page members list. Search box will only be shown if there is more than 1 page of members. Searches the user name and the name with spaces, so you don't have to type the name with underscores to get a match.