### PR TITLE
Fix/ Group editor: check members before sening messages

### DIFF
--- a/components/group/GroupMembers.js
+++ b/components/group/GroupMembers.js
@@ -49,7 +49,7 @@ const MessageMemberModal = ({
       const newMembers = get(apiRes, 'groups.0.members', [])
       if (!membersToMessage.every((p) => newMembers.includes(p))) {
         throw new Error(
-          'Group members have changed since the page was opened. Please reload and try again.'
+          'The members of this group, including members selected below, have changed since the page was opened. Please reload the page and try again.'
         )
       }
     } catch (e) {


### PR DESCRIPTION
To prevent users from accidentally trying to send messages to users that are no longer members of the group, load the group again immediately before sending and verify that all users selected are still members of the group.