### PR TITLE
Feature/ Venue homepage: support multiple submission invitations

### DIFF
--- a/components/webfield/VenueHomepage.js
+++ b/components/webfield/VenueHomepage.js
@@ -18,18 +18,9 @@ import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
 import { referrerLink, venueHomepageLink } from '../../lib/banner-links'
 
-function ConsolesList({
-  venueId,
-  submissionInvitationId,
-  authorsGroupId,
-  setHidden,
-  shouldReload,
-  options = {},
-}) {
+function ConsolesList({ venueId, setHidden, shouldReload }) {
   const [userConsoles, setUserConsoles] = useState(null)
   const { user, accessToken, userLoading } = useUser()
-
-  const defaultAuthorsGroupId = `${venueId}/Authors`
 
   useEffect(() => {
     if (userLoading) return
@@ -60,7 +51,7 @@ function ConsolesList({
         setUserConsoles([])
         promptError(error.message)
       })
-  }, [user, accessToken, userLoading, venueId, submissionInvitationId, shouldReload])
+  }, [user, accessToken, userLoading, venueId, shouldReload])
 
   useEffect(() => {
     if (!userConsoles || typeof setHidden !== 'function') return
@@ -138,9 +129,6 @@ export default function VenueHomepage({ appContext }) {
       return (
         <ConsolesList
           venueId={group.id}
-          submissionInvitationId={submissionId}
-          authorsGroupId={tabConfig.authorsGroupId}
-          options={tabConfig.options}
           shouldReload={shouldReload}
           setHidden={(newHidden) => {
             if (newHidden === tabConfig.hidden) return


### PR DESCRIPTION
This PR adds a new optional config param to the venue homepage component, `submissionIds`. If submissionIds is set to an array of invitation ids, the homepage will display all the submission buttons one below another. This is required for some ARR venues.

For example:

```js
return {
  component: 'VenueHomepage',
  version: 1,
  properties: {
    header: {
      title: domain.content.title?.value,
      subtitle: domain.content.subtitle?.value,
      website: domain.content.website?.value,
      contact: domain.content.contact?.value,
      location: domain.content.location.value,
      instructions: domain.content.instructions.value,
      date: domain.content.start_date.value,
      deadline: domain.content.date.value
    },
    submissionIds: [domain.content.submission_id?.value, domain.content.alt_submission_id?.value],
    parentGroupId: domain.parent,
    apiVersion: 2,
    tabs: tabs
  }
}
```