### PR TITLE
Feature/ Add archived group webfield component

### DIFF
--- a/components/webfield/ArchivedConsole.js
+++ b/components/webfield/ArchivedConsole.js
@@ -1,0 +1,57 @@
+import { useContext, useEffect } from 'react'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+import WebFieldContext from '../WebFieldContext'
+import VenueHeader from './VenueHeader'
+import MarkdownContent from './MarkdownContent'
+import { referrerLink, venueHomepageLink } from '../../lib/banner-links'
+import { prettyId } from '../../lib/utils'
+
+export default function ArchivedConsole({ appContext }) {
+  const {
+    entity: group,
+    venueId,
+    parentGroupId,
+    header,
+    message,
+  } = useContext(WebFieldContext)
+  const router = useRouter()
+  const { setBannerContent } = appContext
+
+  useEffect(() => {
+    // Set referrer banner
+    if (!router.isReady) return
+
+    if (router.query.referrer) {
+      setBannerContent(referrerLink(router.query.referrer))
+    } else if (parentGroupId) {
+      setBannerContent(venueHomepageLink(parentGroupId))
+    }
+  }, [router.isReady, router.query])
+
+  return (
+    <div className="text-center row">
+      <div className="col-lg-8 col-lg-offset-2">
+        <VenueHeader headerInfo={{ ...header, instructions: ' ' }} />
+
+        <hr className="small" />
+
+        <div id="notes">
+          <h4 className="mt-4">This {prettyId(group.id, true)} Console has been archived.</h4>{' '}
+          <p>
+            To request access, please contact OpenReview Support at{' '}
+            <a href="mailto:info@openreview.net" target="_blank" rel="noreferrer">
+              info@openreview.net
+            </a>
+            .
+          </p>
+          <p>
+            Return to the{' '}
+            <Link href={`/group?id=${venueId}`}>{prettyId(venueId)} homepage</Link>.
+          </p>
+          {message && <MarkdownContent content={message} />}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Add a basic new component for old consoles that have been migrated from API v1.

<img width="1224" alt="Screen Shot 2023-11-21 at 5 31 56 PM" src="https://github.com/openreview/openreview-web/assets/86174/f672043d-1b69-448c-af87-cf27e22269ff">

Example config:

```js
// Webfield component
return {
  component: 'ArchivedConsole',
  properties: {
    header: {
      title: domain.content.subtitle?.value,
    },
    parentGroupId: domain.id,
    apiVersion: 2,
    venueId: domain.id,
  }
}
```

Fixes #1685 