### PR TITLE
Fix/ PC console - fix completed bids calculation

### DIFF
--- a/components/webfield/ProgramChairConsole/AreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatus.js
@@ -320,7 +320,7 @@ const AreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaReviewDat
             completedRecommendations:
               pcConsoleData.acRecommendationsCount?.[areaChairProfileId] ?? 0,
             completedBids:
-              pcConsoleData.bidCount?.areaChairs?.find(
+              pcConsoleData.bidCounts?.areaChairs?.find(
                 (p) => p.id?.tail === areaChairProfileId
               )?.count ?? 0,
             numCompletedReviews: notes.filter(


### PR DESCRIPTION
PC console is reading the wrong property when calculating completed bids count
this pr should fix this issue which caused the AC status tab to always show 0 for completed bids