### PR TITLE
Fix/Year of birth test

### DIFF
--- a/tests/profilePage.ts
+++ b/tests/profilePage.ts
@@ -158,7 +158,7 @@ test('add and delete year of birth', async (t) => {
     .typeText(yearOfBirthInput, '0000')
     .click(saveProfileButton)
     .expect(errorMessageSelector.innerText)
-    .contains('yearOfBirth must be >= 1923')
+    .contains(`yearOfBirth must be >= ${new Date().getFullYear() - 100}`)
     // add valid year of birth
     .typeText(yearOfBirthInput, '2000')
     .click(saveProfileButton)


### PR DESCRIPTION
current the test error message is set to 1923 and cause the test to fail
this pr should make it to match error returned by api