### PR TITLE
Feature/Email domain validation logic update

### DIFF
--- a/components/profile/EmailsSection.js
+++ b/components/profile/EmailsSection.js
@@ -5,7 +5,7 @@ import { nanoid } from 'nanoid'
 import Icon from '../Icon'
 import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
-import { isValidEmail } from '../../lib/utils'
+import { isInstitutionEmail, isValidEmail } from '../../lib/utils'
 import ProfileMergeModal from '../ProfileMergeModal'
 
 const EmailsButton = ({
@@ -93,7 +93,7 @@ const EmailsSection = ({
   const { accessToken } = useUser()
   const [alreadyConfirmedError, setAlreadyConfirmedError] = useState(null)
   const hasInstitutionEmail = emails.some(
-    (p) => p.confirmed && institutionDomains?.some((q) => p.email.endsWith(q))
+    (p) => p.confirmed && isInstitutionEmail(p.email, institutionDomains)
   )
 
   const handleAddEmail = () => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1650,3 +1650,29 @@ export function stringToObject(prefilledValues) {
   })
   return outputObject
 }
+
+/**
+ * checks whether email has instituion domain or subdomain
+ *
+ * @param {string} email - the email address to check
+ * @param {Array} institutionDomains - the list of institution domains
+ * @returns boolean
+ */
+export function isInstitutionEmail(email, institutionDomains) {
+  const emailDomainTokens = email.split('@').pop()?.trim()?.toLowerCase().split('.')
+  return institutionDomains.some((institutionDomain) => {
+    const institutionDomainTokens = institutionDomain.split('.')
+    if (institutionDomainTokens.length > emailDomainTokens.length) {
+      return false
+    }
+    for (let i = 1; i <= institutionDomainTokens.length; i += 1) {
+      if (
+        institutionDomainTokens[institutionDomainTokens.length - i] !==
+        emailDomainTokens[emailDomainTokens.length - i]
+      ) {
+        return false
+      }
+    }
+    return true
+  })
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1660,7 +1660,7 @@ export function stringToObject(prefilledValues) {
  */
 export function isInstitutionEmail(email, institutionDomains) {
   const emailDomainTokens = email.split('@').pop()?.trim()?.toLowerCase().split('.')
-  return institutionDomains.some((institutionDomain) => {
+  return institutionDomains?.some((institutionDomain) => {
     const institutionDomainTokens = institutionDomain.split('.')
     if (institutionDomainTokens.length > emailDomainTokens.length) {
       return false

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1653,6 +1653,8 @@ export function stringToObject(prefilledValues) {
 
 /**
  * checks whether email has instituion domain or subdomain
+ * e.g. email: test@umass.edu and test@test.umass.edu should return true
+ * while test@testumass.edu or test@umass.com should return false
  *
  * @param {string} email - the email address to check
  * @param {Array} institutionDomains - the list of institution domains
@@ -1665,14 +1667,11 @@ export function isInstitutionEmail(email, institutionDomains) {
     if (institutionDomainTokens.length > emailDomainTokens.length) {
       return false
     }
-    for (let i = 1; i <= institutionDomainTokens.length; i += 1) {
-      if (
-        institutionDomainTokens[institutionDomainTokens.length - i] !==
-        emailDomainTokens[emailDomainTokens.length - i]
-      ) {
-        return false
+    for (let i = 0; i <= emailDomainTokens.length; i += 1) {
+      if (isEqual(emailDomainTokens.slice(i), institutionDomainTokens)) {
+        return true
       }
     }
-    return true
+    return false
   })
 }

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -9,7 +9,7 @@ import UserContext from '../components/UserContext'
 import NoteList from '../components/NoteList'
 import BasicModal from '../components/BasicModal'
 import api from '../lib/api-client'
-import { isValidEmail, isValidPassword } from '../lib/utils'
+import { isInstitutionEmail, isValidEmail, isValidPassword } from '../lib/utils'
 import ProfileMergeModal from '../components/ProfileMergeModal'
 import ErrorAlert from '../components/ErrorAlert'
 import Icon from '../components/Icon'
@@ -553,25 +553,6 @@ const NewProfileForm = ({ id, registerUser, nameConfirmed }) => {
   const [institutionDomains, setInstitutionDomains] = useState([])
   const [nonInstitutionEmail, setNonInstitutionEmail] = useState(null)
 
-  const isInstitutionEmail = (emailToCheck) => {
-    const emailDomainTokens = emailToCheck.split('@').pop()?.trim()?.toLowerCase().split('.')
-    return institutionDomains.some((institutionDomain) => {
-      const institutionDomainTokens = institutionDomain.split('.')
-      if (institutionDomainTokens.length > emailDomainTokens.length) {
-        return false
-      }
-      for (let i = 1; i <= institutionDomainTokens.length; i += 1) {
-        if (
-          institutionDomainTokens[institutionDomainTokens.length - i] !==
-          emailDomainTokens[emailDomainTokens.length - i]
-        ) {
-          return false
-        }
-      }
-      return true
-    })
-  }
-
   const InstitutionErrorMessage = ({ email: invalidEmail }) => (
     <span>
       <strong>{invalidEmail.split('@').pop()}</strong> does not appear in our list of
@@ -595,7 +576,7 @@ const NewProfileForm = ({ id, registerUser, nameConfirmed }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault()
-    if (!isInstitutionEmail(email)) {
+    if (!isInstitutionEmail(email, institutionDomains)) {
       setNonInstitutionEmail(email)
     }
 
@@ -651,10 +632,11 @@ const NewProfileForm = ({ id, registerUser, nameConfirmed }) => {
           }}
           onBlur={(e) => {
             const cleanEmail = e.target.value.trim()
-            if (cleanEmail && !isInstitutionEmail(cleanEmail)) {
+            if (cleanEmail && !isInstitutionEmail(cleanEmail, institutionDomains)) {
               setNonInstitutionEmail(cleanEmail)
             }
-            if (!cleanEmail || isInstitutionEmail(cleanEmail)) setNonInstitutionEmail(null)
+            if (!cleanEmail || isInstitutionEmail(cleanEmail, institutionDomains))
+              setNonInstitutionEmail(null)
           }}
           autoComplete="email"
         />

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -554,8 +554,22 @@ const NewProfileForm = ({ id, registerUser, nameConfirmed }) => {
   const [nonInstitutionEmail, setNonInstitutionEmail] = useState(null)
 
   const isInstitutionEmail = (emailToCheck) => {
-    const emailDomain = emailToCheck.split('@').pop()?.trim()?.toLowerCase()
-    return institutionDomains.includes(emailDomain)
+    const emailDomainTokens = emailToCheck.split('@').pop()?.trim()?.toLowerCase().split('.')
+    return institutionDomains.some((institutionDomain) => {
+      const institutionDomainTokens = institutionDomain.split('.')
+      if (institutionDomainTokens.length > emailDomainTokens.length) {
+        return false
+      }
+      for (let i = 1; i <= institutionDomainTokens.length; i += 1) {
+        if (
+          institutionDomainTokens[institutionDomainTokens.length - i] !==
+          emailDomainTokens[emailDomainTokens.length - i]
+        ) {
+          return false
+        }
+      }
+      return true
+    })
   }
 
   const InstitutionErrorMessage = ({ email: invalidEmail }) => (

--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -107,6 +107,7 @@ test('Set up TestVenue', async (t) => {
       'How did you hear about us?': 'ML conferences',
       'Expected Submissions': '6000',
       'publication_chairs': 'No, our venue does not have Publication Chairs',
+      submission_license: ['CC BY 4.0'],
     },
   }
   const { id: requestForumId, number } = await createNote(requestVenueJson, superUserToken)
@@ -234,6 +235,7 @@ test('Set up AnotherTestVenue', async (t) => {
       'How did you hear about us?': 'ML conferences',
       'Expected Submissions': '6000',
       'publication_chairs': 'No, our venue does not have Publication Chairs',
+      submission_license: ['CC BY 4.0'],
     },
   }
   const { id: requestForumId, number } = await createNote(requestVenueJson, superUserToken)
@@ -333,6 +335,7 @@ test('Set up ICLR', async (t) => {
       'Expected Submissions': '6000',
       reviewer_identity: ['Program Chairs', 'Assigned Area Chair'],
       'publication_chairs': 'No, our venue does not have Publication Chairs',
+      submission_license: ['CC BY 4.0'],
     },
   }
   const { id: requestForumId, number } = await createNote(requestVenueJson, superUserToken)
@@ -452,7 +455,8 @@ test('Set up TestVenue using API 2', async (t) => {
       'How did you hear about us?': 'ML conferences',
       'Expected Submissions': '6000',
       'publication_chairs': 'No, our venue does not have Publication Chairs',
-      'api_version': '2'
+      'api_version': '2',
+      submission_license: ['CC BY 4.0'],
     },
   }
   const { id: requestForumId, number } = await createNote(requestVenueJson, superUserToken)
@@ -488,7 +492,7 @@ test('Set up TestVenue using API 2', async (t) => {
         authorids: { 'value': [hasTaskUserTildeId] },
         abstract: { 'value': 'Paper Abstract' },
         keywords: { 'value': ['keyword1', 'keyword2'] },
-        pdf: { 'value': '/pdf/acef91d0b896efccb01d9d60ed5150433528395a.pdf'},
+        pdf: { 'value': '/pdf/acef91d0b896efccb01d9d60ed5150433528395a.pdf' },
       }
     }
   }
@@ -497,7 +501,7 @@ test('Set up TestVenue using API 2', async (t) => {
   await waitForJobs(editId, superUserToken)
 
   // close deadline
-  const submissionCloseDate = new Date(Date.now() - (28  * 60 * 1000)) // 28 minutes ago
+  const submissionCloseDate = new Date(Date.now() - (28 * 60 * 1000)) // 28 minutes ago
   const year = submissionCloseDate.getUTCFullYear()
   const month = `0${submissionCloseDate.getUTCMonth() + 1}`.slice(-2)
   const day = `0${submissionCloseDate.getUTCDate()}`.slice(-2)

--- a/tests/registerPage.ts
+++ b/tests/registerPage.ts
@@ -56,6 +56,11 @@ test('create new profile', async (t) => {
     .typeText(emailAddressInputSelector, 'validemail@umass.edu')
     .click(signupButtonSelector)
     .expect(Selector('div.activation-message-row').exists).notOk() // no warning
+    // change email to subdomain of institution email
+    .selectText(emailAddressInputSelector).pressKey('delete')
+    .typeText(emailAddressInputSelector, 'validemail@test.umass.edu')
+    .click(signupButtonSelector)
+    .expect(Selector('div.activation-message-row').exists).notOk() // no warning
     .selectText(emailAddressInputSelector).pressKey('delete')
     .typeText(emailAddressInputSelector, 'melisa@test.com')
     .click(signupButtonSelector)

--- a/unitTests/utils.test.js
+++ b/unitTests/utils.test.js
@@ -1,4 +1,4 @@
-import { stringToObject } from '../lib/utils'
+import { isInstitutionEmail, stringToObject } from '../lib/utils'
 
 describe('utils', () => {
   test('convert string to object in stringToObject', () => {
@@ -41,5 +41,30 @@ describe('utils', () => {
         comment: { value: 'some prefilled comment' },
       },
     })
+  })
+
+  test('valid institution email in isInstitutionEmail', () => {
+    const institutionDomains = ['umass.edu', 'cs.umass.edu']
+
+    let validEmail = 'test@umass.edu'
+    expect(isInstitutionEmail(validEmail, institutionDomains)).toEqual(true)
+
+    validEmail = 'test@cs.umass.edu'
+    expect(isInstitutionEmail(validEmail, institutionDomains)).toEqual(true)
+
+    let validSubdomainEmail = 'test@test.umass.edu'
+    expect(isInstitutionEmail(validSubdomainEmail, institutionDomains)).toEqual(true)
+
+    validSubdomainEmail = 'test@a.long.sub.domain.cs.umass.edu'
+    expect(isInstitutionEmail(validSubdomainEmail, institutionDomains)).toEqual(true)
+
+    let invalidEmail = 'test@umass.com'
+    expect(isInstitutionEmail(invalidEmail, institutionDomains)).toEqual(false)
+
+    invalidEmail = 'test@fakeumass.com'
+    expect(isInstitutionEmail(invalidEmail, institutionDomains)).toEqual(false)
+
+    invalidEmail = 'test@fakeumass.edu'
+    expect(isInstitutionEmail(invalidEmail, institutionDomains)).toEqual(false)
   })
 })

--- a/unitTests/utils.test.js
+++ b/unitTests/utils.test.js
@@ -66,5 +66,8 @@ describe('utils', () => {
 
     invalidEmail = 'test@fakeumass.edu'
     expect(isInstitutionEmail(invalidEmail, institutionDomains)).toEqual(false)
+
+    invalidEmail = 'test@cs.edu'
+    expect(isInstitutionEmail(invalidEmail, institutionDomains)).toEqual(false)
   })
 })


### PR DESCRIPTION
currently the institution email validation is using exact match

this pr should change the logic to treat emails having exact match or subdomain of institution domains to be valid institution email

for example umass.edu is an institution email and @eng.umass.edu or @college.eng.umass.edu should be treated as valid institution email

this pr only control whether to show the warning message
the actual change that decides the state of the profile is https://github.com/openreview/openreview-api/pull/332