### PR TITLE
Fix/ Some issues in api client and construct edit

### DIFF
--- a/client/view-v2.js
+++ b/client/view-v2.js
@@ -2340,7 +2340,7 @@ module.exports = (function () {
 
       var fieldReader = contentFieldValue.readers
       if (fieldReader) {
-        if (!fieldReader.const) {
+        if (fieldReader.param) {
           content[contentFieldName].readers = noteObj?.content?.[contentFieldName]?.readers
         }
       }

--- a/client/view-v2.js
+++ b/client/view-v2.js
@@ -2339,10 +2339,8 @@ module.exports = (function () {
       }
 
       var fieldReader = contentFieldValue.readers
-      if (fieldReader) {
-        if (fieldReader.param) {
-          content[contentFieldName].readers = noteObj?.content?.[contentFieldName]?.readers
-        }
+      if (fieldReader?.param) {
+        content[contentFieldName].readers = noteObj?.content?.[contentFieldName]?.readers
       }
     })
 

--- a/client/view-v2.js
+++ b/client/view-v2.js
@@ -2339,7 +2339,7 @@ module.exports = (function () {
       }
 
       var fieldReader = contentFieldValue.readers
-      if (fieldReader?.param) {
+      if (fieldReader?.param && !fieldReader.param.const) {
         content[contentFieldName].readers = noteObj?.content?.[contentFieldName]?.readers
       }
     })

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -155,13 +155,33 @@ const getById = async (apiPath, id, accessToken, apiVersion, queryParam, remoteI
   }
 }
 
-const getInvitationById = async (invitationId, accessToken, queryParam1, queryParam2, remoteIp) => {
-  const invitationObj = await getById('invitations', invitationId, accessToken, 2, queryParam1, remoteIp)
+const getInvitationById = async (
+  invitationId,
+  accessToken,
+  queryParam1,
+  queryParam2,
+  remoteIp
+) => {
+  const invitationObj = await getById(
+    'invitations',
+    invitationId,
+    accessToken,
+    2,
+    queryParam1,
+    remoteIp
+  )
   if (invitationObj) {
     return invitationObj
   }
 
-  return getById('invitations', invitationId, accessToken, 1, queryParam1 ?? queryParam2, remoteIp)
+  return getById(
+    'invitations',
+    invitationId,
+    accessToken,
+    1,
+    queryParam2 ?? queryParam1,
+    remoteIp
+  )
 }
 
 const getNoteById = async (noteId, accessToken, queryParam1, queryParam2, remoteIp) => {

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -190,7 +190,7 @@ const getNoteById = async (noteId, accessToken, queryParam1, queryParam2, remote
     return noteObj
   }
 
-  return getById('notes', noteId, accessToken, 1, queryParam1 ?? queryParam2, remoteIp)
+  return getById('notes', noteId, accessToken, 1, queryParam2 ?? queryParam1, remoteIp)
 }
 
 const getGroupById = (groupId, accessToken, queryParam) =>


### PR DESCRIPTION
this pr should fix the following issues:
1. getInvitationById  and getNoteById are passing v2 param to v1 query (https://github.com/openreview/openreview-web/pull/862/files#r930117068)
2. edit.note.content.{field}.readers checking is wrong. 
currently it checks for reader.const which was changed during development of api.
correct check is reader.param, if there's no reader.param it's const array value