### PR TITLE
Fix/ Invitation editor - date process start/end date pass delete:true

### DIFF
--- a/components/invitation/DateProcessesEditor.js
+++ b/components/invitation/DateProcessesEditor.js
@@ -398,8 +398,8 @@ const DateProcessesEditor = ({
           }),
           ...(p.type === 'cron' && {
             cron: p.cron,
-            startDate: p.startDate.trim().length > 0 ? p.startDate.trim() : null,
-            endDate: p.endDate.trim().length > 0 ? p.endDate.trim() : null,
+            startDate: p.startDate.trim().length > 0 ? p.startDate.trim() : { delete: true },
+            endDate: p.endDate.trim().length > 0 ? p.endDate.trim() : { delete: true },
           }),
         }
       })


### PR DESCRIPTION
currently invitation editor pass null when a date process cron job has no startDate and endDate
which is not allowed by invitation edit schema.

this pr should change it to pass {delete:true} instead