### PR TITLE
Fix/API 2 Email deletion link to profile

### DIFF
--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -1102,7 +1102,7 @@ const EmailDeletionTab = ({ accessToken, isActive }) => {
                   </span>
                   <span className="col-profile">
                     <a
-                      href={`/profile?id=${note.content.profile_id}`}
+                      href={`/profile?id=${note.content.profile_id.value}`}
                       target="_blank"
                       rel="noreferrer"
                     >


### PR DESCRIPTION
this change is missed from #1741
to read profile_id.value as the link to profile in email deletion tab