### PR TITLE
Fix/Profile view duplicated key

### DIFF
--- a/components/profile/BasicProfileView.js
+++ b/components/profile/BasicProfileView.js
@@ -169,7 +169,11 @@ const BasicProfileView = ({
               .filter((email) => !email.hidden)
               .flatMap((email, i) => [
                 i > 0 ? <span key={i}>, </span> : null,
-                <ProfileEmail key={email.email} email={email} publicProfile={publicProfile} />,
+                <ProfileEmail
+                  key={`${email.email}-${i}`}
+                  email={email}
+                  publicProfile={publicProfile}
+                />,
               ])}
           </div>
         </ProfileViewSection>


### PR DESCRIPTION
when a profile is viewed as guest and the profile has multiple emails of the same domain
using email as key will cause it to be duplicated (****@domain)and the emails may not render correctly

this pr should update the key so that there's no duplicate

