### PR TITLE
Fix/Console tasks - filter singular role name

### DIFF
--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -228,9 +228,10 @@ export function filterAssignedInvitations(inv, roleName, submissionName, submiss
     // submissionNumbers could be string
     // eslint-disable-next-line eqeqeq
     !(number && submissionNumbers) || submissionNumbers.find((p) => p == number)
+  const roleNames = [roleName, ...(roleName.endsWith('s') ? [roleName.slice(0, -1)] : [])]
   return (
-    (inv.id.includes(roleName) || inv.invitees?.some((p) => p.includes(roleName))) &&
-    invMatchesNumber
+    roleNames.some((p) => inv.id.includes(p)) ||
+    (inv.invitees?.some((p) => roleNames.find((q) => p.includes(q))) && invMatchesNumber)
   )
 }
 


### PR DESCRIPTION
some invitations may not have the complete role name and are filtered out in tasks by filterAssignedInvitations

for example a review revision invitation which should be shown in reviewer console tasks
is filtered out because both id (review_revision) and invitee(review anon id) do not have role name "Reviewers"

this pr should update the filtering to include singular role name too