### PR TITLE
Feature/ Consoles - Support fallback rating names

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -159,7 +159,8 @@ const AreaChairConsole = ({ appContext }) => {
 
   const getReviewerName = (reviewerProfile) => {
     const name =
-      reviewerProfile.content.names.find((t) => t.preferred) || reviewerProfile.content.names[0]
+      reviewerProfile.content.names.find((t) => t.preferred) ||
+      reviewerProfile.content.names[0]
     return name ? name.fullname : prettyId(reviewerProfile.id)
   }
 
@@ -348,10 +349,17 @@ const AreaChairConsole = ({ appContext }) => {
               confidence: parseNumberField(q.content[reviewConfidenceName]?.value),
               ...Object.fromEntries(
                 (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
-                  (ratingName) => [
-                    [ratingName],
-                    parseNumberField(q.content[ratingName]?.value),
-                  ]
+                  (ratingName) => {
+                    const ratingDisplayName =
+                      typeof ratingName === 'object' ? Object.keys(ratingName)[0] : ratingName
+                    const ratingValue =
+                      typeof ratingName === 'object'
+                        ? Object.values(ratingName)[0]
+                            .map((r) => q.content[r]?.value)
+                            .find((s) => s !== undefined)
+                        : q.content[ratingName]?.value
+                    return [[ratingDisplayName], parseNumberField(ratingValue)]
+                  }
                 )
               ),
               reviewLength: reviewValue?.length,
@@ -361,7 +369,9 @@ const AreaChairConsole = ({ appContext }) => {
         const ratings = Object.fromEntries(
           (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
             (ratingName) => {
-              const ratingValues = officialReviews.map((p) => p[ratingName])
+              const displayRatingName =
+                typeof ratingName === 'object' ? Object.keys(ratingName)[0] : ratingName
+              const ratingValues = officialReviews.map((p) => p[displayRatingName])
               const validRatingValues = ratingValues.filter((p) => p !== null)
               const ratingAvg = validRatingValues.length
                 ? (
@@ -375,7 +385,7 @@ const AreaChairConsole = ({ appContext }) => {
               const ratingMax = validRatingValues.length
                 ? Math.max(...validRatingValues)
                 : 'N/A'
-              return [ratingName, { ratingAvg, ratingMin, ratingMax }]
+              return [displayRatingName, { ratingAvg, ratingMin, ratingMax }]
             }
           )
         )

--- a/components/webfield/AreaChairConsoleMenuBar.js
+++ b/components/webfield/AreaChairConsoleMenuBar.js
@@ -27,13 +27,14 @@ const AreaChairConsoleMenuBar = ({
     numReviewersAssigned: ['reviewProgressData.numReviewersAssigned'],
     numReviewsDone: ['reviewProgressData.numReviewsDone'],
     ...Object.fromEntries(
-      (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).flatMap(
-        (ratingName) => [
-          [`${ratingName}Avg`, [`reviewProgressData.ratings.${ratingName}.ratingAvg`]],
-          [`${ratingName}Max`, [`reviewProgressData.ratings.${ratingName}.ratingMax`]],
-          [`${ratingName}Min`, [`reviewProgressData.ratings.${ratingName}.ratingMin`]],
-        ]
-      )
+      (Array.isArray(reviewRatingName)
+        ? reviewRatingName.map((p) => (typeof p === 'object' ? Object.keys(p)[0] : p))
+        : [reviewRatingName]
+      ).flatMap((ratingName) => [
+        [`${ratingName}Avg`, [`reviewProgressData.ratings.${ratingName}.ratingAvg`]],
+        [`${ratingName}Max`, [`reviewProgressData.ratings.${ratingName}.ratingMax`]],
+        [`${ratingName}Min`, [`reviewProgressData.ratings.${ratingName}.ratingMin`]],
+      ])
     ),
     confidenceAvg: ['reviewProgressData.confidenceAvg'],
     confidenceMax: ['reviewProgressData.confidenceMax'],
@@ -79,22 +80,23 @@ const AreaChairConsoleMenuBar = ({
       getValue: (p) =>
         p.reviewers.map((q) => `${q.preferredName}<${q.preferredEmail}>`).join(','),
     },
-    ...(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).flatMap(
-      (ratingName) => [
-        {
-          header: `min ${ratingName}`,
-          getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMin,
-        },
-        {
-          header: `max ${ratingName}`,
-          getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMax,
-        },
-        {
-          header: `average ${ratingName}`,
-          getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg,
-        },
-      ]
-    ),
+    ...(Array.isArray(reviewRatingName)
+      ? reviewRatingName.map((p) => (typeof p === 'object' ? Object.keys(p)[0] : p))
+      : [reviewRatingName]
+    ).flatMap((ratingName) => [
+      {
+        header: `min ${ratingName}`,
+        getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMin,
+      },
+      {
+        header: `max ${ratingName}`,
+        getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMax,
+      },
+      {
+        header: `average ${ratingName}`,
+        getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg,
+      },
+    ]),
     { header: 'min confidence', getValue: (p) => p.reviewProgressData?.confidenceMin },
     { header: 'max confidence', getValue: (p) => p.reviewProgressData?.confidenceMax },
     { header: 'average confidence', getValue: (p) => p.reviewProgressData?.confidenceAvg },
@@ -128,34 +130,35 @@ const AreaChairConsoleMenuBar = ({
         (p.reviewProgressData?.numReviewersAssigned ?? 0) -
         (p.reviewProgressData?.numReviewsDone ?? 0),
     },
-    ...(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).flatMap(
-      (ratingName) => [
-        {
-          label: `Average ${prettyField(ratingName)}`,
-          value: `Average ${ratingName}`,
-          getValue: (p) =>
-            p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg === 'N/A'
-              ? 0
-              : p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg,
-        },
-        {
-          label: `Max ${prettyField(ratingName)}`,
-          value: `Max ${ratingName}`,
-          getValue: (p) =>
-            p.reviewProgressData?.ratings?.[ratingName]?.ratingMax === 'N/A'
-              ? 0
-              : p.reviewProgressData?.ratings?.[ratingName]?.ratingMax,
-        },
-        {
-          label: `Min ${prettyField(ratingName)}`,
-          value: `Min ${ratingName}`,
-          getValue: (p) =>
-            p.reviewProgressData?.ratings?.[ratingName]?.ratingMin === 'N/A'
-              ? 0
-              : p.reviewProgressData?.ratings?.[ratingName]?.ratingMin,
-        },
-      ]
-    ),
+    ...(Array.isArray(reviewRatingName)
+      ? reviewRatingName.map((p) => (typeof p === 'object' ? Object.keys(p)[0] : p))
+      : [reviewRatingName]
+    ).flatMap((ratingName) => [
+      {
+        label: `Average ${prettyField(ratingName)}`,
+        value: `Average ${ratingName}`,
+        getValue: (p) =>
+          p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg === 'N/A'
+            ? 0
+            : p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg,
+      },
+      {
+        label: `Max ${prettyField(ratingName)}`,
+        value: `Max ${ratingName}`,
+        getValue: (p) =>
+          p.reviewProgressData?.ratings?.[ratingName]?.ratingMax === 'N/A'
+            ? 0
+            : p.reviewProgressData?.ratings?.[ratingName]?.ratingMax,
+      },
+      {
+        label: `Min ${prettyField(ratingName)}`,
+        value: `Min ${ratingName}`,
+        getValue: (p) =>
+          p.reviewProgressData?.ratings?.[ratingName]?.ratingMin === 'N/A'
+            ? 0
+            : p.reviewProgressData?.ratings?.[ratingName]?.ratingMin,
+      },
+    ]),
     {
       label: 'Average Confidence',
       value: 'Average Confidence',

--- a/components/webfield/AuthorConsole.js
+++ b/components/webfield/AuthorConsole.js
@@ -48,9 +48,18 @@ const ReviewSummary = ({
   const ratings = Object.fromEntries(
     (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
       (ratingName) => {
-        const ratingValues = noteCompletedReviews.map((p) =>
-          parseNumberField(isV2Note ? p.content?.[ratingName]?.value : p.content?.[ratingName])
-        )
+        const ratingDisplayName =
+          typeof ratingName === 'object' ? Object.keys(ratingName)[0] : ratingName
+        const ratingValues = noteCompletedReviews.map((p) => {
+          if (!isV2Note) return parseNumberField(p.content?.[ratingName])
+          if (typeof ratingName === 'object') {
+            const ratingValue = Object.values(ratingName)[0]
+              .map((q) => p.content?.[q]?.value)
+              .find((r) => r !== undefined)
+            return parseNumberField(ratingValue)
+          }
+          return parseNumberField(p.content?.[ratingName]?.value)
+        })
         const validRatingValues = ratingValues.filter((p) => p !== null)
         const ratingAvg = validRatingValues.length
           ? (
@@ -60,7 +69,7 @@ const ReviewSummary = ({
           : 'N/A'
         const ratingMin = validRatingValues.length ? Math.min(...validRatingValues) : 'N/A'
         const ratingMax = validRatingValues.length ? Math.max(...validRatingValues) : 'N/A'
-        return [ratingName, { ratingAvg, ratingMin, ratingMax }]
+        return [ratingDisplayName, { ratingAvg, ratingMin, ratingMax }]
       }
     )
   )
@@ -84,10 +93,22 @@ const ReviewSummary = ({
           const reviewRatingValues = (
             Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]
           ).flatMap((ratingName) => {
-            const ratingValue = parseNumberField(
-              isV2Note ? review.content?.[ratingName]?.value : review.content?.[ratingName]
-            )
-            return ratingValue ? { [ratingName]: ratingValue } : []
+            let ratingDisplayName = ratingName
+            let ratingValue = null
+            if (isV2Note) {
+              if (typeof ratingName === 'object') {
+                const ratingFieldValue = Object.values(ratingName)[0]
+                  .map((p) => review.content?.[p]?.value)
+                  .find((q) => q !== undefined)
+                ratingDisplayName = Object.keys(ratingName)[0]
+                ratingValue = parseNumberField(ratingFieldValue)
+              } else {
+                ratingValue = parseNumberField(review.content?.[ratingName]?.value)
+              }
+            } else {
+              ratingValue = parseNumberField(review.content?.[ratingName])
+            }
+            return ratingValue ? { [ratingDisplayName]: ratingValue } : []
           })
 
           const reviewConfidenceValue = isV2Note
@@ -120,10 +141,12 @@ const ReviewSummary = ({
       <div>
         {(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
           (ratingName, index) => {
-            const { ratingAvg, ratingMin, ratingMax } = ratings[ratingName]
+            const ratingDisplayName =
+              typeof ratingName === 'object' ? Object.keys(ratingName)[0] : ratingName
+            const { ratingAvg, ratingMin, ratingMax } = ratings[ratingDisplayName]
             return (
               <span key={index}>
-                <strong>Average {prettyField(ratingName)}:</strong> {ratingAvg} (Min:{' '}
+                <strong>Average {prettyField(ratingDisplayName)}:</strong> {ratingAvg} (Min:{' '}
                 {ratingMin}, Max: {ratingMax})<br />
               </span>
             )

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -207,7 +207,6 @@ export const AcPcConsoleReviewerStatusRow = ({
 }) => {
   const [updateLastSent, setUpdateLastSent] = useState(true)
   const completedReview = officialReviews.find((p) => p.anonymousId === reviewer.anonymousId)
-  // const hasRating = completedReview?.rating !== null
   const hasConfidence = completedReview?.confidence !== null
   const lastReminderSent = localStorage.getItem(
     `https://openreview.net/forum?id=${note.forum}&noteId=${note.id}&invitationId=${venueId}/${submissionName}${note.number}/-/${officialReviewName}|${reviewer.reviewerProfileId}`
@@ -236,9 +235,7 @@ export const AcPcConsoleReviewerStatusRow = ({
                     let ratingDisplayName
                     if (typeof ratingName === 'object') {
                       ratingDisplayName = Object.keys(ratingName)[0]
-                      ratingValue = Object.values(ratingName)[0]
-                        .map((p) => completedReview[p])
-                        .find((q) => q !== undefined)
+                      ratingValue = completedReview[ratingDisplayName]
                     } else {
                       ratingDisplayName = ratingName
                       ratingValue = completedReview[ratingName]

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -232,8 +232,19 @@ export const AcPcConsoleReviewerStatusRow = ({
               <div>
                 {(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName])
                   .flatMap((ratingName, index) => {
-                    const rating = completedReview[ratingName]
-                    if (rating !== null) return `${prettyField(ratingName)}: ${rating}`
+                    let ratingValue
+                    let ratingDisplayName
+                    if (typeof ratingName === 'object') {
+                      ratingDisplayName = Object.keys(ratingName)[0]
+                      ratingValue = Object.values(ratingName)[0]
+                        .map((p) => completedReview[p])
+                        .find((q) => q !== undefined)
+                    } else {
+                      ratingDisplayName = ratingName
+                      ratingValue = completedReview[ratingName]
+                    }
+                    if (ratingValue !== null)
+                      return `${prettyField(ratingDisplayName)}: ${ratingValue}`
                     return []
                   })
                   .join(' / ')}
@@ -323,8 +334,19 @@ export const AcPcConsoleReviewStatusRow = ({
         <div>
           {(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName])
             .flatMap((ratingName, index) => {
-              const rating = review[ratingName]
-              if (rating !== null) return `${prettyField(ratingName)}: ${rating}`
+              let ratingValue
+              let ratingDisplayName
+              if (typeof ratingName === 'object') {
+                ratingDisplayName = Object.keys(ratingName)[0]
+                ratingValue = Object.values(ratingName)[0]
+                  .map((p) => review[p])
+                  .find((q) => q !== undefined)
+              } else {
+                ratingDisplayName = ratingName
+                ratingValue = review[ratingName]
+              }
+              if (ratingValue !== null)
+                return `${prettyField(ratingDisplayName)}: ${ratingValue}`
               return []
             })
             .join(' / ')}
@@ -449,17 +471,18 @@ export const AcPcConsoleNoteReviewStatus = ({
           ))}
         </div>
       </Collapse>
-      {(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
-        (ratingName, index) => {
-          const { ratingAvg, ratingMin, ratingMax } = ratings[ratingName]
-          return (
-            <span key={index}>
-              <strong>Average {prettyField(ratingName)}:</strong> {ratingAvg} (Min: {ratingMin}
-              , Max: {ratingMax})
-            </span>
-          )
-        }
-      )}
+      {(Array.isArray(reviewRatingName)
+        ? reviewRatingName.map((p) => (typeof p === 'object' ? Object.keys(p)[0] : p))
+        : [reviewRatingName]
+      ).map((ratingName, index) => {
+        const { ratingAvg, ratingMin, ratingMax } = ratings[ratingName]
+        return (
+          <span key={index}>
+            <strong>Average {prettyField(ratingName)}:</strong> {ratingAvg} (Min: {ratingMin},
+            Max: {ratingMax})
+          </span>
+        )
+      })}
       <span>
         <strong>Average Confidence:</strong> {confidenceAvg} (Min: {confidenceMin}, Max:{' '}
         {confidenceMax})

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -587,7 +587,17 @@ const ProgramChairConsole = ({ appContext }) => {
             confidence: parseNumberField(q.content[reviewConfidenceName]?.value),
             ...Object.fromEntries(
               (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
-                (ratingName) => [[ratingName], parseNumberField(q.content[ratingName]?.value)]
+                (ratingName) => {
+                  const displayRatingName =
+                    typeof ratingName === 'object' ? Object.keys(ratingName)[0] : ratingName
+                  const ratingValue =
+                    typeof ratingName === 'object'
+                      ? Object.values(ratingName)[0]
+                          .map((r) => q.content[r]?.value)
+                          .find((s) => s !== undefined)
+                      : q.content[ratingName]?.value
+                  return [[displayRatingName], parseNumberField(ratingValue)]
+                }
               )
             ),
             reviewLength: reviewValue?.length,
@@ -598,19 +608,9 @@ const ProgramChairConsole = ({ appContext }) => {
       const ratings = Object.fromEntries(
         (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
           (ratingName) => {
-            let displayName
-            let ratingCandidates
-            if (typeof ratingName === 'object') {
-              // eslint-disable-next-line prefer-destructuring
-              displayName = Object.keys(ratingName)[0]
-              ratingCandidates = Object.values(ratingName)[0]
-            } else {
-              displayName = ratingName
-              ratingCandidates = [ratingName]
-            }
-            const ratingValues = officialReviews.map((p) =>
-              ratingCandidates.map((candidate) => p[candidate]).find((q) => q !== undefined)
-            )
+            const ratingDisplayName =
+              typeof ratingName === 'object' ? Object.keys(ratingName)[0] : ratingName
+            const ratingValues = officialReviews.map((p) => p[ratingDisplayName])
 
             const validRatingValues = ratingValues.filter((p) => p !== null)
             const ratingAvg = validRatingValues.length
@@ -621,7 +621,7 @@ const ProgramChairConsole = ({ appContext }) => {
               : 'N/A'
             const ratingMin = validRatingValues.length ? Math.min(...validRatingValues) : 'N/A'
             const ratingMax = validRatingValues.length ? Math.max(...validRatingValues) : 'N/A'
-            return [displayName, { ratingAvg, ratingMin, ratingMax }]
+            return [ratingDisplayName, { ratingAvg, ratingMin, ratingMax }]
           }
         )
       )

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -193,9 +193,7 @@ const ProgramChairConsole = ({ appContext }) => {
       // #region get Reviewer, AC, SAC members
       const committeeMemberResultsP = Promise.all(
         [reviewersId, areaChairsId, seniorAreaChairsId].map((id) =>
-          id
-            ? api.getGroupById(id, accessToken, { select: 'members' })
-            : Promise.resolve([])
+          id ? api.getGroupById(id, accessToken, { select: 'members' }) : Promise.resolve([])
         )
       )
       // #endregion
@@ -600,7 +598,20 @@ const ProgramChairConsole = ({ appContext }) => {
       const ratings = Object.fromEntries(
         (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
           (ratingName) => {
-            const ratingValues = officialReviews.map((p) => p[ratingName])
+            let displayName
+            let ratingCandidates
+            if (typeof ratingName === 'object') {
+              // eslint-disable-next-line prefer-destructuring
+              displayName = Object.keys(ratingName)[0]
+              ratingCandidates = Object.values(ratingName)[0]
+            } else {
+              displayName = ratingName
+              ratingCandidates = [ratingName]
+            }
+            const ratingValues = officialReviews.map((p) =>
+              ratingCandidates.map((candidate) => p[candidate]).find((q) => q !== undefined)
+            )
+
             const validRatingValues = ratingValues.filter((p) => p !== null)
             const ratingAvg = validRatingValues.length
               ? (
@@ -610,7 +621,7 @@ const ProgramChairConsole = ({ appContext }) => {
               : 'N/A'
             const ratingMin = validRatingValues.length ? Math.min(...validRatingValues) : 'N/A'
             const ratingMax = validRatingValues.length ? Math.max(...validRatingValues) : 'N/A'
-            return [ratingName, { ratingAvg, ratingMin, ratingMax }]
+            return [displayName, { ratingAvg, ratingMin, ratingMax }]
           }
         )
       )

--- a/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
@@ -35,13 +35,14 @@ const PaperStatusMenuBar = ({
     numReviewersAssigned: ['reviewProgressData.numReviewersAssigned'],
     numReviewsDone: ['reviewProgressData.numReviewsDone'],
     ...Object.fromEntries(
-      (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).flatMap(
-        (ratingName) => [
-          [`${ratingName}Avg`, [`reviewProgressData.ratings.${ratingName}.ratingAvg`]],
-          [`${ratingName}Max`, [`reviewProgressData.ratings.${ratingName}.ratingMax`]],
-          [`${ratingName}Min`, [`reviewProgressData.ratings.${ratingName}.ratingMin`]],
-        ]
-      )
+      (Array.isArray(reviewRatingName)
+        ? reviewRatingName.map((p) => (typeof p === 'object' ? Object.keys(p)[0] : p))
+        : [reviewRatingName]
+      ).flatMap((ratingName) => [
+        [`${ratingName}Avg`, [`reviewProgressData.ratings.${ratingName}.ratingAvg`]],
+        [`${ratingName}Max`, [`reviewProgressData.ratings.${ratingName}.ratingMax`]],
+        [`${ratingName}Min`, [`reviewProgressData.ratings.${ratingName}.ratingMin`]],
+      ])
     ),
     confidenceAvg: ['reviewProgressData.confidenceAvg'],
     confidenceMax: ['reviewProgressData.confidenceMax'],
@@ -106,22 +107,23 @@ const PaperStatusMenuBar = ({
       getValue: (p) =>
         p.reviewers.map((q) => `${q.preferredName}<${q.preferredEmail}>`).join(','),
     },
-    ...(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).flatMap(
-      (ratingName) => [
-        {
-          header: `min ${ratingName}`,
-          getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMin,
-        },
-        {
-          header: `max ${ratingName}`,
-          getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMax,
-        },
-        {
-          header: `average ${ratingName}`,
-          getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg,
-        },
-      ]
-    ),
+    ...(Array.isArray(reviewRatingName)
+      ? reviewRatingName.map((p) => (typeof p === 'object' ? Object.keys(p)[0] : p))
+      : [reviewRatingName]
+    ).flatMap((ratingName) => [
+      {
+        header: `min ${ratingName}`,
+        getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMin,
+      },
+      {
+        header: `max ${ratingName}`,
+        getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingMax,
+      },
+      {
+        header: `average ${ratingName}`,
+        getValue: (p) => p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg,
+      },
+    ]),
     { header: 'min confidence', getValue: (p) => p.reviewProgressData?.confidenceMin },
     { header: 'max confidence', getValue: (p) => p.reviewProgressData?.confidenceMax },
     { header: 'average confidence', getValue: (p) => p.reviewProgressData?.confidenceAvg },
@@ -209,35 +211,36 @@ const PaperStatusMenuBar = ({
         getValueWithDefault(p.reviewProgressData?.numReviewsDone),
       initialDirection: 'desc',
     },
-    ...(Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).flatMap(
-      (ratingName) => [
-        {
-          label: `Average ${prettyField(ratingName)}`,
-          value: `Average ${ratingName}`,
-          getValue: (p) =>
-            getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg),
-        },
-        {
-          label: `Max ${prettyField(ratingName)}`,
-          value: `Max ${ratingName}`,
-          getValue: (p) =>
-            getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMax),
-        },
-        {
-          label: `Min ${prettyField(ratingName)}`,
-          value: `Min ${ratingName}`,
-          getValue: (p) =>
-            getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMin),
-        },
-        {
-          label: `${prettyField(ratingName)} Range`,
-          value: `${ratingName} Range`,
-          getValue: (p) =>
-            getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMax) -
-            getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMin),
-        },
-      ]
-    ),
+    ...(Array.isArray(reviewRatingName)
+      ? reviewRatingName.map((p) => (typeof p === 'object' ? Object.keys(p)[0] : p))
+      : [reviewRatingName]
+    ).flatMap((ratingName) => [
+      {
+        label: `Average ${prettyField(ratingName)}`,
+        value: `Average ${ratingName}`,
+        getValue: (p) =>
+          getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg),
+      },
+      {
+        label: `Max ${prettyField(ratingName)}`,
+        value: `Max ${ratingName}`,
+        getValue: (p) =>
+          getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMax),
+      },
+      {
+        label: `Min ${prettyField(ratingName)}`,
+        value: `Min ${ratingName}`,
+        getValue: (p) =>
+          getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMin),
+      },
+      {
+        label: `${prettyField(ratingName)} Range`,
+        value: `${ratingName} Range`,
+        getValue: (p) =>
+          getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMax) -
+          getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingMin),
+      },
+    ]),
     {
       label: 'Average Confidence',
       value: 'Average Confidence',

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -104,11 +104,21 @@ const ReviewerProgress = ({ rowData, referrerUrl, reviewRatingName }) => {
                           ? reviewRatingName
                           : [reviewRatingName]
                         ).map((ratingName, index) => {
-                          const ratingValue = officialReview[ratingName]
+                          let ratingValue
+                          let ratingDisplayName
+                          if (typeof ratingName === 'object') {
+                            ratingDisplayName = Object.keys(ratingName)[0]
+                            ratingValue = Object.values(ratingName)[0]
+                              .map((p) => officialReview[p])
+                              .find((q) => q !== undefined)
+                          } else {
+                            ratingDisplayName = ratingName
+                            ratingValue = officialReview[ratingName]
+                          }
                           if (!ratingValue) return null
                           return (
                             <span key={ratingName}>
-                              {prettyField(ratingName)}: {ratingValue}{' '}
+                              {prettyField(ratingDisplayName)}: {ratingValue}{' '}
                               {index < reviewRatingName.length - 1 && '/'}{' '}
                             </span>
                           )

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -160,7 +160,20 @@ const AssignedPaperRow = ({
   const areaChairIds = areaChairMap[note.number]
   const paperRatingValues = (
     Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]
-  ).map((ratingName) => ({ [ratingName]: officialReview?.content?.[ratingName]?.value }))
+  ).map((ratingName) => {
+    let ratingDisplayName
+    let ratingValue
+    if (typeof ratingName === 'object') {
+      ratingDisplayName = Object.keys(ratingName)[0]
+      ratingValue = Object.values(ratingName)[0]
+        .map((p) => officialReview.content?.[p]?.value)
+        .find((q) => q !== undefined)
+    } else {
+      ratingDisplayName = ratingName
+      ratingValue = officialReview?.content?.[ratingName]?.value
+    }
+    return { [ratingDisplayName]: ratingValue }
+  })
   const review = officialReview?.content?.review?.value
 
   return (

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -312,10 +312,19 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                     (Array.isArray(reviewRatingName)
                       ? reviewRatingName
                       : [reviewRatingName]
-                    ).map((ratingName) => [
-                      [ratingName],
-                      parseNumberField(review.content[ratingName]?.value),
-                    ])
+                    ).map((ratingName) => {
+                      const displayRatingName =
+                        typeof ratingName === 'object'
+                          ? Object.keys(ratingName)[0]
+                          : ratingName
+                      const ratingValue =
+                        typeof ratingName === 'object'
+                          ? Object.values(ratingName)[0]
+                              .map((r) => review.content[r]?.value)
+                              .find((s) => s !== undefined)
+                          : review.content[ratingName]?.value
+                      return [[displayRatingName], parseNumberField(ratingValue)]
+                    })
                   ),
                   reviewLength: reviewValue?.length,
                   forum: review.forum,
@@ -326,7 +335,9 @@ const SeniorAreaChairConsole = ({ appContext }) => {
           const ratings = Object.fromEntries(
             (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
               (ratingName) => {
-                const ratingValues = officialReviews.map((p) => p[ratingName])
+                const ratingDisplayName =
+                  typeof ratingName === 'object' ? Object.keys(ratingName)[0] : ratingName
+                const ratingValues = officialReviews.map((p) => p[ratingDisplayName])
                 const validRatingValues = ratingValues.filter((p) => p !== null)
                 const ratingAvg = validRatingValues.length
                   ? (
@@ -340,7 +351,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                 const ratingMax = validRatingValues.length
                   ? Math.max(...validRatingValues)
                   : 'N/A'
-                return [ratingName, { ratingAvg, ratingMin, ratingMax }]
+                return [ratingDisplayName, { ratingAvg, ratingMin, ratingMax }]
               }
             )
           )


### PR DESCRIPTION
this pr should support fallback rating names in consoles, for example the following review rating setting
```
"review_rating": {
    "value": [
      {
        "overall_rating": [
          "final_rating",
          "preliminary_rating"
        ]
      },
      "overall_recommendation",
    ]
  }
``` 

should display 2 ratings:

- Overall Rating
   it's value will be final_rating field, when final_rating field is not available, it will take the next available value defined in the array, in this example it will take "preliminary_rating"
- Overall Recommendation
