### PR TITLE
Fix/ Author console - show confidence mark only

### DIFF
--- a/components/webfield/AuthorConsole.js
+++ b/components/webfield/AuthorConsole.js
@@ -90,9 +90,11 @@ const ReviewSummary = ({
             return ratingValue ? { [ratingName]: ratingValue } : []
           })
 
-          const reviewConfidenceValue = isV2Note
-            ? review.content?.[reviewConfidenceName]?.value
-            : review.content?.[reviewConfidenceName]
+          const reviewConfidenceValue = parseNumberField(
+            isV2Note
+              ? review.content?.[reviewConfidenceName]?.value
+              : review.content?.[reviewConfidenceName]
+          )
           return (
             <li key={review.id}>
               <strong>{prettyId(review.signatures[0].split('/')?.pop())}:</strong>
@@ -105,7 +107,7 @@ const ReviewSummary = ({
                   </span>
                 )
               })}
-              {reviewConfidenceValue ? `/ Confidence: ${reviewConfidenceValue}` : ''}
+              {reviewConfidenceValue !== null ? `/ Confidence: ${reviewConfidenceValue}` : ''}
               <br />
               <Link
                 href={`/forum?id=${review.forum}&noteId=${review.id}&referrer=${referrerUrl}`}


### PR DESCRIPTION
Emilia mentioned in the daily meeting that author console should show only the confidence number

this pr should update the author console to show only the confidence number