### PR TITLE
Feature/ AC Console - support secondary AC in triplet AC assignments tab

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -599,7 +599,7 @@ const AreaChairConsole = ({ appContext }) => {
               key={row.note.id}
               rowData={row}
               venueId={venueId}
-              areaChairName={secondaryAreaChairName}
+              areaChairName={areaChairName}
               officialReviewName={officialReviewName}
               officialMetaReviewName={officialMetaReviewName}
               submissionName={submissionName}

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -699,7 +699,7 @@ const AreaChairConsole = ({ appContext }) => {
               active={activeTabId === '#triplet-ac-assignments' ? true : undefined}
               onClick={() => setActiveTabId('#triplet-ac-assignments')}
             >
-              Triplet AC Assignments
+              Secondary AC Assignments
             </Tab>
           )}
           <Tab

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -204,7 +204,7 @@ const AreaChairConsole = ({ appContext }) => {
       )
       const areaChairGroups = allGroups.filter((p) => p.id.endsWith(areaChairName))
       const secondaryAreaChairGroups = secondaryAreaChairName
-        ? allGroups.filter((p) => p.id.includes(`/${secondaryAreaChairName}_`))
+        ? allGroups.filter((p) => p.id.endsWith(secondaryAreaChairName))
         : []
       const anonymousAreaChairGroups = allGroups.filter((p) => p.id.includes('/Area_Chair_'))
       const areaChairPaperNums = areaChairGroups.flatMap((p) => {

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -202,10 +202,11 @@ const AreaChairConsole = ({ appContext }) => {
         },
         { accessToken }
       )
-      const areaChairGroups = allGroups.filter((p) => p.id.endsWith(areaChairName))
+      const areaChairGroups = allGroups.filter((p) => p.id.endsWith(`/${areaChairName}`))
       const secondaryAreaChairGroups = secondaryAreaChairName
-        ? allGroups.filter((p) => p.id.endsWith(secondaryAreaChairName))
+        ? allGroups.filter((p) => p.id.endsWith(`/${secondaryAreaChairName}`))
         : []
+
       const anonymousAreaChairGroups = allGroups.filter((p) => p.id.includes('/Area_Chair_'))
       const areaChairPaperNums = areaChairGroups.flatMap((p) => {
         const num = getNumberFromGroup(p.id, submissionName)

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -56,6 +56,7 @@ const AssignedPaperRow = ({
   selectedNoteIds,
   setSelectedNoteIds,
   shortPhrase,
+  showCheckbox = true,
 }) => {
   const { note, metaReviewData } = rowData
   const referrerUrl = encodeURIComponent(
@@ -63,19 +64,21 @@ const AssignedPaperRow = ({
   )
   return (
     <tr>
-      <td>
-        <input
-          type="checkbox"
-          checked={selectedNoteIds.includes(note.id)}
-          onChange={(e) => {
-            if (e.target.checked) {
-              setSelectedNoteIds((noteIds) => [...noteIds, note.id])
-              return
-            }
-            setSelectedNoteIds((noteIds) => noteIds.filter((p) => p !== note.id))
-          }}
-        />
-      </td>
+      {showCheckbox && (
+        <td>
+          <input
+            type="checkbox"
+            checked={selectedNoteIds.includes(note.id)}
+            onChange={(e) => {
+              if (e.target.checked) {
+                setSelectedNoteIds((noteIds) => [...noteIds, note.id])
+                return
+              }
+              setSelectedNoteIds((noteIds) => noteIds.filter((p) => p !== note.id))
+            }}
+          />
+        </td>
+      )}
       <td>
         <strong className="note-number">{note.number}</strong>
       </td>
@@ -121,6 +124,7 @@ const AreaChairConsole = ({ appContext }) => {
     submissionInvitationId,
     seniorAreaChairsId,
     areaChairName,
+    secondaryAreaChairName,
     submissionName,
     officialReviewName,
     reviewRatingName,
@@ -147,8 +151,8 @@ const AreaChairConsole = ({ appContext }) => {
   const query = useQuery()
   const { setBannerContent } = appContext
   const [acConsoleData, setAcConsoleData] = useState({})
-  const [activeTabIndex, setActiveTabIndex] = useState(0)
   const [selectedNoteIds, setSelectedNoteIds] = useState([])
+  const [activeTabId, setActiveTabId] = useState(window.location.hash || '#assigned-papers')
 
   const edgeBrowserUrl = proposedAssignmentTitle
     ? edgeBrowserProposedUrl
@@ -159,7 +163,8 @@ const AreaChairConsole = ({ appContext }) => {
 
   const getReviewerName = (reviewerProfile) => {
     const name =
-      reviewerProfile.content.names.find((t) => t.preferred) || reviewerProfile.content.names[0]
+      reviewerProfile.content.names.find((t) => t.preferred) ||
+      reviewerProfile.content.names[0]
     return name ? name.fullname : prettyId(reviewerProfile.id)
   }
 
@@ -198,6 +203,9 @@ const AreaChairConsole = ({ appContext }) => {
         { accessToken }
       )
       const areaChairGroups = allGroups.filter((p) => p.id.endsWith(areaChairName))
+      const secondaryAreaChairGroups = secondaryAreaChairName
+        ? allGroups.filter((p) => p.id.includes(`/${secondaryAreaChairName}_`))
+        : []
       const anonymousAreaChairGroups = allGroups.filter((p) => p.id.includes('/Area_Chair_'))
       const areaChairPaperNums = areaChairGroups.flatMap((p) => {
         const num = getNumberFromGroup(p.id, submissionName)
@@ -207,8 +215,14 @@ const AreaChairConsole = ({ appContext }) => {
         if (anonymousAreaChairGroup) return num
         return []
       })
+      const secondaryAreaChairPaperNums = secondaryAreaChairGroups.map((p) =>
+        getNumberFromGroup(p.id, submissionName)
+      )
 
-      const noteNumbers = [...new Set(areaChairPaperNums)]
+      const noteNumbers = [
+        ...new Set(areaChairPaperNums),
+        ...new Set(secondaryAreaChairPaperNums),
+      ]
       const blindedNotesP = noteNumbers.length
         ? api.getAll(
             '/notes',
@@ -292,7 +306,7 @@ const AreaChairConsole = ({ appContext }) => {
       // #region get assigned reviewer , sac and all reviewer group members profiles
       const allIds = [
         ...new Set([
-          ...result[1].flatMap((p) => p.reviewers).map((p) => p.reviewerProfileId),
+          ...result[1].flatMap((p) => p.reviewers ?? []).map((p) => p.reviewerProfileId),
           ...result[2],
         ]),
       ]
@@ -442,10 +456,19 @@ const AreaChairConsole = ({ appContext }) => {
           p.content.names.some((q) => result[2].includes(q.username)) ||
           p.content.emails.some((r) => result[2].includes(r))
       )
+
+      const assignedPaperRows = tableRows.filter((p) =>
+        areaChairPaperNums.includes(p.note.number)
+      )
+      const tripletACPaperRows = tableRows.filter((p) =>
+        secondaryAreaChairPaperNums.includes(p.note.number)
+      )
+
       // #endregion
       setAcConsoleData({
-        tableRowsAll: tableRows,
-        tableRows,
+        tableRowsAll: assignedPaperRows,
+        tableRows: assignedPaperRows,
+        tripletACtableRows: tripletACPaperRows,
         reviewersInfo: result[1],
         allProfiles,
         sacProfiles: sacProfiles.map((sacProfile) => ({
@@ -541,6 +564,45 @@ const AreaChairConsole = ({ appContext }) => {
     )
   }
 
+  const renderTripletACTable = () => {
+    if (!acConsoleData.tableRows) return <LoadingSpinner />
+    if (acConsoleData.tableRows?.length === 0)
+      return (
+        <p className="empty-message">
+          No assigned papers.Check back later or contact info@openreview.net if you believe
+          this to be an error.
+        </p>
+      )
+    return (
+      <div className="table-container">
+        <Table
+          className="console-table table-striped areachair-console-table"
+          headings={[
+            { id: 'number', content: '#', width: '55px' },
+            { id: 'summary', content: 'Paper Summary', width: '34%' },
+            { id: 'reviewProgress', content: 'Review Progress', width: '34%' },
+            { id: 'metaReviewStatus', content: 'Meta Review Status', width: 'auto' },
+          ]}
+        >
+          {acConsoleData.tripletACtableRows?.map((row) => (
+            <AssignedPaperRow
+              key={row.note.id}
+              rowData={row}
+              venueId={venueId}
+              areaChairName={secondaryAreaChairName}
+              officialReviewName={officialReviewName}
+              officialMetaReviewName={officialMetaReviewName}
+              submissionName={submissionName}
+              metaReviewRecommendationName={metaReviewRecommendationName}
+              shortPhrase={shortPhrase}
+              showCheckbox={false}
+            />
+          ))}
+        </Table>
+      </div>
+    )
+  }
+
   useEffect(() => {
     if (!query) return
 
@@ -614,18 +676,38 @@ const AreaChairConsole = ({ appContext }) => {
 
       <Tabs>
         <TabList>
-          <Tab id="assigned-papers" active>
+          <Tab
+            id="assigned-papers"
+            active={activeTabId === '#assigned-papers' ? true : undefined}
+            onClick={() => setActiveTabId('#assigned-papers')}
+          >
             Assigned Papers
           </Tab>
-          <Tab id="areachair-tasks" onClick={() => setActiveTabIndex(1)}>
+          {secondaryAreaChairName && (
+            <Tab
+              id="triplet-ac-assignments"
+              active={activeTabId === '#triplet-ac-assignments' ? true : undefined}
+              onClick={() => setActiveTabId('#triplet-ac-assignments')}
+            >
+              Triplet AC Assignments
+            </Tab>
+          )}
+          <Tab
+            id="areachair-tasks"
+            active={activeTabId === '#areachair-tasks' ? true : undefined}
+            onClick={() => setActiveTabId('#areachair-tasks')}
+          >
             Area Chair Tasks
           </Tab>
         </TabList>
 
         <TabPanels>
           <TabPanel id="assigned-papers">{renderTable()}</TabPanel>
+          {secondaryAreaChairName && (
+            <TabPanel id="triplet-ac-assignments">{renderTripletACTable()}</TabPanel>
+          )}
           <TabPanel id="areachair-tasks">
-            {activeTabIndex === 1 && (
+            {activeTabId === '#areachair-tasks' && (
               <AreaChairConsoleTasks venueId={venueId} areaChairName={areaChairName} />
             )}
           </TabPanel>


### PR DESCRIPTION
this pr should add support of secondary ac assignments in ac console triplet ac assignments tab

example config:
>secondaryAreaChairName: "Secondary_Area_Chairs"

menu bar is not included in this pr due to time. it requires separating tab data from assigned papers tab because the "tableRowsAll" name in setData is fixed
