### PR TITLE
Fix/ Add Secondary AC or AC in missing readers

### DIFF
--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -357,12 +357,21 @@ const NoteEditor = ({
         }
       } else {
         const acIndex = signatureId.indexOf('Area_Chair_')
+        const secondaryAcIndex = signatureId.indexOf('Secondary_Area_Chair_')
 
         const acGroupId =
           acIndex >= 0 ? signatureId.slice(0, acIndex).concat('Area_Chairs') : signatureId
+        const secondaryAcGroupId =
+          secondaryAcIndex >= 0
+            ? signatureId.slice(0, secondaryAcIndex).concat('Area_Chairs')
+            : signatureId
 
-        return readersDefinedInInvitation?.includes(acGroupId)
-          ? [...new Set([...readersSelected, acGroupId])]
+        const groupToAdd = [acGroupId, secondaryAcGroupId].filter((p) =>
+          readersDefinedInInvitation?.includes(p)
+        )
+
+        return groupToAdd.length
+          ? [...new Set([...readersSelected, ...groupToAdd])]
           : readersSelected
       }
     }


### PR DESCRIPTION
currently when secondary ac post a note when secondary ac group is not in note readers, the secondary ac won't be added as note readers

this pr should fix this issue by adding secondary ac group or ac group in note readers
this pr assumes that secondary ac group is member of ac group