### PR TITLE
Consoles: show secondary ACs

### DIFF
--- a/components/webfield/NoteMetaReviewStatus.js
+++ b/components/webfield/NoteMetaReviewStatus.js
@@ -157,7 +157,7 @@ export const AreaChairConsoleNoteMetaReviewStatus = ({
         <h4>
           {metaReviewInvitation ? (
             <a
-              href={`/forum?id=${note.forum}&noteId=${note.id}&invitationId=${metaReviewData.metaReviewInvitation}&referrer=${referrerUrl}`}
+              href={`/forum?id=${note.forum}&noteId=${note.id}&invitationId=${metaReviewData.metaReviewInvitationId}&referrer=${referrerUrl}`}
               target="_blank"
               rel="nofollow noreferrer"
             >
@@ -180,7 +180,7 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
   metaReviewRecommendationName,
 }) => {
   const { note, metaReviewData, preliminaryDecision } = rowData
-  const { numMetaReviewsDone, areaChairs, metaReviews, seniorAreaChairs } = metaReviewData
+  const { numMetaReviewsDone, areaChairs, metaReviews, seniorAreaChairs, secondaryAreaChairs } = metaReviewData
   const paperManualAreaChairAssignmentUrl = areaChairAssignmentUrl?.replace(
     'edges/browse?',
     `edges/browse?start=staticList,type:head,ids:${note.id}&`
@@ -243,6 +243,25 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
             )
           })}
       </div>
+
+      {secondaryAreaChairs?.length > 0 && (
+        <div>
+          <strong>Secondary Area Chair:</strong>
+          <div>
+           {secondaryAreaChairs.map((areaChair) => (
+              <div key={areaChair.anonymousId} className="meta-review-info">
+                <div className="areachair-contact">
+                  <span>
+                    {areaChair.preferredName}{' '}
+                    <span className="text-muted">&lt;{areaChair.preferredEmail}&gt;</span>
+                  </span>
+                </div>
+              </div>
+          ))}
+          </div>
+        </div>
+      )}
+
 
       {seniorAreaChairs?.length > 0 && (
         <div className="senior-areachair">

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -602,11 +602,16 @@ const ProgramChairConsole = ({ appContext }) => {
         pcConsoleData.paperGroups.areaChairGroups?.find((p) => p.noteNumber === note.number)
           ?.members ?? []
 
+      const assignedAreaChairProfiles = assignedAreaChairs.map((areaChair) => ({
+        id: areaChair.areaChairProfileId,
+        profile: pcConsoleData.allProfilesMap.get(areaChair.areaChairProfileId),
+      }))
+
       const secondaryAreaChairs =
         pcConsoleData.paperGroups.areaChairGroups?.find((p) => p.noteNumber === note.number)
           ?.secondaries ?? []
 
-      const assignedAreaChairProfiles = assignedAreaChairs.map((areaChair) => ({
+      const secondaryAreaChairProfiles = secondaryAreaChairs.map((areaChair) => ({
         id: areaChair.areaChairProfileId,
         profile: pcConsoleData.allProfilesMap.get(areaChair.areaChairProfileId),
       }))
@@ -760,7 +765,7 @@ const ProgramChairConsole = ({ appContext }) => {
             }
           }),
           secondaryAreaChairs: secondaryAreaChairs.map((areaChair) => {
-            const profile = assignedAreaChairProfiles.find(
+            const profile = secondaryAreaChairProfiles.find(
               (p) => p.id === areaChair.areaChairProfileId
             )?.profile
             return {

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -686,7 +686,8 @@ const ProgramChairConsole = ({ appContext }) => {
       const metaReviews = (
         pcConsoleData.metaReviewsByPaperNumberMap?.get(note.number) ?? []
       ).map((metaReview) => {
-        const metaReviewAgreement = customStageReviews.find((p) => p.replyto === metaReview.id || p.forum === metaReview.forum)
+        const metaReviewAgreement = customStageReviews.find((p) => p.replyto === metaReview.id
+        || p.forum === metaReview.forum)
         const metaReviewAgreementConfig = metaReviewAgreement
           ? customStageInvitations.find((p) =>
               metaReviewAgreement.invitations.some((q) => q.includes(`/-/${p.name}`))

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -33,6 +33,8 @@ const SeniorAreaChairConsole = ({ appContext }) => {
     anonReviewerName,
     areaChairName = 'Area_Chairs',
     anonAreaChairName,
+    secondaryAreaChairName,
+    secondaryAnonAreaChairName,
     seniorAreaChairName = 'Senior_Area_Chairs',
     reviewRatingName,
     reviewConfidenceName,
@@ -147,6 +149,8 @@ const SeniorAreaChairConsole = ({ appContext }) => {
       const anonReviewerGroups = {}
       let areaChairGroups = []
       const anonAreaChairGroups = {}
+      const secondaryAreaChairGroups = []
+      const secondaryAnonAreaChairGroups = {}
       const seniorAreaChairGroups = []
       let allGroupMembers = []
       perPaperGroupResults.groups?.forEach((p) => {
@@ -175,17 +179,35 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             if (!(number in anonAreaChairGroups)) anonAreaChairGroups[number] = {}
             if (
               !(member in anonAreaChairGroups[number]) &&
-              member.includes(anonAreaChairName)
+              member.includes(`/${anonAreaChairName}`)
             ) {
               anonAreaChairGroups[number][member] = member
             }
           })
-        } else if (p.id.includes(anonAreaChairName)) {
+        } else if (p.id.includes(`/${anonAreaChairName}`)) {
           if (!(number in anonAreaChairGroups)) anonAreaChairGroups[number] = {}
           if (p.members.length) anonAreaChairGroups[number][p.id] = p.members[0]
           allGroupMembers = allGroupMembers.concat(p.members)
         } else if (p.id.endsWith(seniorAreaChairName)) {
           seniorAreaChairGroups.push(p)
+        } else if (secondaryAreaChairName && p.id.endsWith(`/${secondaryAreaChairName}`)) {
+          secondaryAreaChairGroups.push({
+            noteNumber: getNumberFromGroup(p.id, submissionName),
+            ...p,
+          })
+          p.members.forEach((member) => {
+            if (!(number in secondaryAnonAreaChairGroups)) secondaryAnonAreaChairGroups[number] = {}
+            if (
+              !(member in secondaryAnonAreaChairGroups[number]) &&
+              member.includes(`/${secondaryAnonAreaChairName}`)
+            ) {
+              secondaryAnonAreaChairGroups[number][member] = member
+            }
+          })
+        } else if (secondaryAreaChairName && p.id.includes(`/${secondaryAnonAreaChairName}`)) {
+          if (!(number in secondaryAnonAreaChairGroups)) secondaryAnonAreaChairGroups[number] = {}
+          if (p.members.length) secondaryAnonAreaChairGroups[number][p.id] = p.members[0]
+          allGroupMembers = allGroupMembers.concat(p.members)
         }
       })
 
@@ -216,7 +238,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
         const paperAnonAreaChairGroups = anonAreaChairGroups[areaChairGroup.noteNumber]
         return {
           ...areaChairGroup,
-          members: areaChairGroup.members.map((member) => {
+          members: areaChairGroup.members.flatMap((member) => {
             let deanonymizedGroup = paperAnonAreaChairGroups?.[member]
             let anonymizedGroup = member
             if (!deanonymizedGroup) {
@@ -225,6 +247,9 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                 (key) => paperAnonAreaChairGroups[key] === member
               )
             }
+            if (secondaryAreaChairName && member.endsWith(`/${secondaryAreaChairName}`)) {
+              return []
+            }
             return {
               areaChairProfileId: deanonymizedGroup,
               anonymizedGroup,
@@ -232,6 +257,24 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                 ? getIndentifierFromGroup(anonymizedGroup, anonAreaChairName)
                 : null,
             }
+          }),
+          secondaries: areaChairGroup.members.flatMap((member) => {
+
+            if (secondaryAreaChairName && member.endsWith(`/${secondaryAreaChairName}`)) {
+              const secondaryAreaChairGroup = secondaryAreaChairGroups.find(
+                (p) => p.noteNumber === areaChairGroup.noteNumber
+              )
+              if (secondaryAreaChairGroup) {
+                return secondaryAreaChairGroup.members.map((secondaryMember) => ({
+                    areaChairProfileId: secondaryAnonAreaChairGroups[areaChairGroup.noteNumber]?.[secondaryMember]
+                    ?? secondaryMember,
+                    anonymizedGroup: secondaryMember,
+                    anonymousId: getIndentifierFromGroup(secondaryMember, secondaryAnonAreaChairName),
+                  }
+                ))
+              }
+            }
+            return []
           }),
         }
       })
@@ -296,6 +339,8 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             reviewerGroups?.find((p) => p.noteNumber === note.number)?.members ?? []
           const assignedAreaChairs =
             areaChairGroups?.find((p) => p.noteNumber === note.number)?.members ?? []
+          const secondaryAreaChairs =
+            areaChairGroups?.find((p) => p.noteNumber === note.number)?.secondaries ?? []
           const officialReviews =
             note.details.replies
               .filter((p) => {
@@ -384,7 +429,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             }))
             .map((metaReview) => {
               const metaReviewAgreement = customStageReviews.find(
-                (p) => p.replyto === metaReview.id
+                (p) => p.replyto === metaReview.id || p.forum === metaReview.forum
               )
               const metaReviewAgreementConfig = metaReviewAgreement
                 ? customStageInvitations.find((p) =>
@@ -469,6 +514,18 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             metaReviewData: {
               numAreaChairsAssigned: assignedAreaChairs.length,
               areaChairs: assignedAreaChairs.map((areaChair) => {
+                const profile = allProfilesMap.get(areaChair.areaChairProfileId)
+                return {
+                  ...areaChair,
+                  preferredName: profile
+                    ? getProfileName(profile)
+                    : areaChair.areaChairProfileId,
+                  preferredEmail: profile
+                    ? profile.content.preferredEmail ?? profile.content.emails[0]
+                    : areaChair.areaChairProfileId,
+                }
+              }),
+              secondaryAreaChairs: secondaryAreaChairs.map((areaChair) => {
                 const profile = allProfilesMap.get(areaChair.areaChairProfileId)
                 return {
                   ...areaChair,

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -196,7 +196,8 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             ...p,
           })
           p.members.forEach((member) => {
-            if (!(number in secondaryAnonAreaChairGroups)) secondaryAnonAreaChairGroups[number] = {}
+            if (!(number in secondaryAnonAreaChairGroups))
+              secondaryAnonAreaChairGroups[number] = {}
             if (
               !(member in secondaryAnonAreaChairGroups[number]) &&
               member.includes(`/${secondaryAnonAreaChairName}`)
@@ -205,7 +206,8 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             }
           })
         } else if (secondaryAreaChairName && p.id.includes(`/${secondaryAnonAreaChairName}`)) {
-          if (!(number in secondaryAnonAreaChairGroups)) secondaryAnonAreaChairGroups[number] = {}
+          if (!(number in secondaryAnonAreaChairGroups))
+            secondaryAnonAreaChairGroups[number] = {}
           if (p.members.length) secondaryAnonAreaChairGroups[number][p.id] = p.members[0]
           allGroupMembers = allGroupMembers.concat(p.members)
         }
@@ -259,22 +261,26 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             }
           }),
           secondaries: areaChairGroup.members.flatMap((member) => {
-
-            if (secondaryAreaChairName && member.endsWith(`/${secondaryAreaChairName}`)) {
-              const secondaryAreaChairGroup = secondaryAreaChairGroups.find(
-                (p) => p.noteNumber === areaChairGroup.noteNumber
-              )
-              if (secondaryAreaChairGroup) {
-                return secondaryAreaChairGroup.members.map((secondaryMember) => ({
-                    areaChairProfileId: secondaryAnonAreaChairGroups[areaChairGroup.noteNumber]?.[secondaryMember]
-                    ?? secondaryMember,
-                    anonymizedGroup: secondaryMember,
-                    anonymousId: getIndentifierFromGroup(secondaryMember, secondaryAnonAreaChairName),
-                  }
-                ))
-              }
+            if (!secondaryAreaChairName || !member.endsWith(`/${secondaryAreaChairName}`)) {
+              return []
             }
-            return []
+
+            const acGroupNoteNum = areaChairGroup.noteNumber
+            const secondaryAreaChairGroup = secondaryAreaChairGroups.find(
+              (p) => p.noteNumber === acGroupNoteNum
+            )
+            if (secondaryAreaChairGroup) return []
+
+            return secondaryAreaChairGroup.members.map((secondaryMember) => ({
+              areaChairProfileId:
+                secondaryAnonAreaChairGroups[acGroupNoteNum]?.[secondaryMember] ??
+                secondaryMember,
+              anonymizedGroup: secondaryMember,
+              anonymousId: getIndentifierFromGroup(
+                secondaryMember,
+                secondaryAnonAreaChairName
+              ),
+            }))
           }),
         }
       })

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -269,7 +269,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             const secondaryAreaChairGroup = secondaryAreaChairGroups.find(
               (p) => p.noteNumber === acGroupNoteNum
             )
-            if (secondaryAreaChairGroup) return []
+            if (!secondaryAreaChairGroup) return []
 
             return secondaryAreaChairGroup.members.map((secondaryMember) => ({
               areaChairProfileId:


### PR DESCRIPTION
Show secondary ACs in the AC Status column for the SAC console:

- Add new property to enable secondary area chairs
- Read the secondary area chairs groups
- Assign them to secondary area chairs data and show them in the UI

<img width="380" alt="Screen Shot 2024-02-12 at 2 32 22 PM" src="https://github.com/openreview/openreview-web/assets/545506/1e234679-93f4-444d-88a9-d027fcbe1d59">

PC console changes are pending. 
