### PR TITLE
Fix/ Update GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.10.0
         with:
           mongodb-version: 6.0
           mongodb-replica-set: rs0
@@ -50,28 +50,28 @@ jobs:
         with:
           stack-version: 7.6.0
       - name: Checkout openreview-py
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: openreview/openreview-py
           path: openreview-py
       - name: Checkout openreview-api-v1
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: openreview/openreview-api-v1
           token: ${{ secrets.OPENREVIEW_ACCESS_TOKEN }}
           path: openreview-api-v1
       - name: Checkout openreview-api
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: openreview/openreview-api
           token: ${{ secrets.OPENREVIEW_ACCESS_TOKEN }}
           path: openreview-api
       - name: Checkout openreview-web
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: openreview-web
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -95,7 +95,7 @@ jobs:
           npm ci
       - name: Cache openreview-web
         id: openreview-web-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # For explanation see https://nextjs.org/docs/advanced-features/ci-build-caching#github-actions
           path: openreview-web/.next/cache
@@ -130,7 +130,7 @@ jobs:
           xvfb-run --server-args="-screen 0 1280x720x24" npm run test
       - name: Upload Test Videos
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: TestCafe Videos
           path: openreview-web/videos/
@@ -153,7 +153,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Add SSH key
         run: |
           mkdir -p /home/runner/.ssh
@@ -163,7 +163,7 @@ jobs:
           chmod 600 /home/runner/.ssh/google_compute_engine.pub
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -171,7 +171,7 @@ jobs:
           cleanup_credentials: true
           export_environment_variables: true
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           skip_install: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,7 +25,7 @@ jobs:
       TAG: ${{ github.event.inputs.tag }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add SSH key
         run: |
           mkdir -p /home/runner/.ssh
@@ -35,7 +35,7 @@ jobs:
           chmod 600 /home/runner/.ssh/google_compute_engine.pub
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -43,7 +43,7 @@ jobs:
           cleanup_credentials: true
           export_environment_variables: true
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           skip_install: true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,7 +25,7 @@ jobs:
       TAG: ${{ github.event.inputs.tag }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add SSH key
         run: |
           mkdir -p /home/runner/.ssh
@@ -35,7 +35,7 @@ jobs:
           chmod 600 /home/runner/.ssh/google_compute_engine.pub
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -43,7 +43,7 @@ jobs:
           cleanup_credentials: true
           export_environment_variables: true
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           skip_install: true


### PR DESCRIPTION
Update github actions to use latest versions with Node.js v20 runners.

Required because of https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 