### PR TITLE
ConsoleTasks: fix typo and filter by assigned task in the AC console

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -112,7 +112,7 @@ const AreaChairConsoleTasks = ({ venueId, areaChairName }) => {
     `[Area Chair Console](/group?id=${venueId}/${areaChairName}#areachair-tasks)`
   )
 
-  return <ConsoleTaskList venueId={venueId} roleName={areaChairName} referrer={referrer} />
+  return <ConsoleTaskList venueId={venueId} roleName={areaChairName} filterAssignedInvitation={true} referrer={referrer} />
 }
 
 const AreaChairConsole = ({ appContext }) => {

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -112,7 +112,12 @@ const AreaChairConsoleTasks = ({ venueId, areaChairName }) => {
     `[Area Chair Console](/group?id=${venueId}/${areaChairName}#areachair-tasks)`
   )
 
-  return <ConsoleTaskList venueId={venueId} roleName={areaChairName} filterAssignedInvitation={true} referrer={referrer} />
+  return <ConsoleTaskList
+    venueId={venueId}
+    roleName={areaChairName}
+    filterAssignedInvitation={true}
+    referrer={referrer}
+  />
 }
 
 const AreaChairConsole = ({ appContext }) => {

--- a/components/webfield/AuthorConsole.js
+++ b/components/webfield/AuthorConsole.js
@@ -272,7 +272,7 @@ const AuthorConsoleTasks = () => {
       venueId={venueId}
       roleName={authorName}
       referrer={referrer}
-      filterAssignedInvitaiton={true}
+      filterAssignedInvitation={true}
       submissionName={submissionName}
       apiVersion={apiVersion}
     />

--- a/components/webfield/ConsoleTaskList.js
+++ b/components/webfield/ConsoleTaskList.js
@@ -11,7 +11,7 @@ const ConsoleTaskList = ({
   venueId,
   roleName,
   referrer,
-  filterAssignedInvitaiton = false,
+  filterAssignedInvitation = false,
   submissionName,
   submissionNumbers,
   apiVersion = 2,
@@ -65,11 +65,13 @@ const ConsoleTaskList = ({
           .concat(tagInvitations.map((inv) => ({ ...inv, tagInvitation: true, apiVersion })))
       )
 
+      console.log(allInvitations)
       allInvitations = allInvitations.filter((p) =>
-        filterAssignedInvitaiton
+        filterAssignedInvitation
           ? filterAssignedInvitations(p, roleName, submissionName, submissionNumbers)
           : p.invitees.some((q) => q.includes(roleName))
       )
+      console.log(allInvitations)
 
       setInvitations(formatTasksData([allInvitations, [], []], true))
     } catch (error) {

--- a/components/webfield/ConsoleTaskList.js
+++ b/components/webfield/ConsoleTaskList.js
@@ -65,13 +65,11 @@ const ConsoleTaskList = ({
           .concat(tagInvitations.map((inv) => ({ ...inv, tagInvitation: true, apiVersion })))
       )
 
-      console.log(allInvitations)
       allInvitations = allInvitations.filter((p) =>
         filterAssignedInvitation
           ? filterAssignedInvitations(p, roleName, submissionName, submissionNumbers)
           : p.invitees.some((q) => q.includes(roleName))
       )
-      console.log(allInvitations)
 
       setInvitations(formatTasksData([allInvitations, [], []], true))
     } catch (error) {

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -239,7 +239,7 @@ const ReviewerConsoleTasks = ({ venueId, reviewerName, submissionName, noteNumbe
       venueId={venueId}
       roleName={reviewerName}
       referrer={referrer}
-      filterAssignedInvitaiton={true}
+      filterAssignedInvitation={true}
       submissionName={submissionName}
       submissionNumbers={noteNumbers}
     />

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1275,7 +1275,7 @@ export function prettyTasksInvitationId(invitationId) {
   const invMatches = invitationId.match(/\/(Paper\d+|Submission\d+)\//)
   if (invMatches) {
     paperStr = invMatches[1]
-    const anonReviewerMatches = invitationId.match(/\/(AnonReviewer\d+|Reviewer_\w+|Official_Review\d+)\//)
+    const anonReviewerMatches = invitationId.match(/\/(AnonReviewer\d+|Reviewer_\w+|Official_Review\d+|Meta_Review\d+)\//)
     if (anonReviewerMatches) {
       paperStr = `${paperStr} ${anonReviewerMatches[1].replace('_', ' ')}`
     }

--- a/unitTests/ConsoleTaskList.test.js
+++ b/unitTests/ConsoleTaskList.test.js
@@ -673,6 +673,26 @@ describe('ConsoleTaskList', () => {
           repliedNotes: [],
         },
       },
+      {
+        id: `${venueId}/${submissionName}5/Meta_Review1/-/Revision`,
+        duedate: now + oneDay,
+        edit: {
+          note: {
+            id: 'metareview1Id',
+            forum: 'paper5Id',
+            replyto: 'paper5Id',
+          },
+        },
+        invitees: [`${venueId}/${submissionName}5/${authorName}`],
+        details: {
+          replytoNote: {
+            id: 'metareview1Id',
+            forum: 'paper5Id',
+            replyto: 'paper5Id',
+          },
+          repliedNotes: [],
+        },
+      },
     ]
     edgeInvitations = [
       {
@@ -830,6 +850,7 @@ describe('ConsoleTaskList', () => {
       const rebuttalSingleReplyLink = screen.getByText('Submission5 Rebuttal Single Reply')
       const rebuttalMultiReplyLink = screen.getByText('Submission5 Rebuttal Multi Reply')
       const reviewRatingLink = screen.getByText('Submission5 Official Review1 Rating')
+      const metaReviewRevisionLink = screen.getByText('Submission5 Meta Review1 Revision')
 
       expect(noReplyLink).not.toBeInTheDocument()
 
@@ -899,6 +920,14 @@ describe('ConsoleTaskList', () => {
       expect(reviewRatingLink).toHaveAttribute(
         'href',
         expect.stringContaining('id=paper5Id&noteId=review1Id')
+      )
+
+      expect(metaReviewRevisionLink).toBeInTheDocument()
+      expect(metaReviewRevisionLink.parentElement.parentElement).not.toHaveClass('completed')
+      expect(metaReviewRevisionLink.nextElementSibling).toHaveClass('warning')
+      expect(metaReviewRevisionLink).toHaveAttribute(
+        'href',
+        expect.stringContaining('id=paper5Id&noteId=paper5Id&invitationId=ICML.cc/2023/Conference/Submission5/Meta_Review1/-/Revision')
       )
       // #endregion
 

--- a/unitTests/ConsoleTaskList.test.js
+++ b/unitTests/ConsoleTaskList.test.js
@@ -69,7 +69,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={authorName}
         referrer={authorConsoleReferrer}
-        filterAssignedInvitaiton={true}
+        filterAssignedInvitation={true}
         submissionName={submissionName}
         apiVersion={1}
       />
@@ -87,7 +87,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={authorName}
         referrer={authorConsoleReferrer}
-        filterAssignedInvitaiton={false}
+        filterAssignedInvitation={false}
         submissionName={undefined}
         apiVersion={2}
       />
@@ -337,7 +337,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={authorName}
         referrer={authorConsoleReferrer}
-        filterAssignedInvitaiton={true}
+        filterAssignedInvitation={true}
         submissionName={submissionName}
         apiVersion={1}
       />
@@ -811,7 +811,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={authorName}
         referrer={authorConsoleReferrer}
-        filterAssignedInvitaiton={true}
+        filterAssignedInvitation={true}
         submissionName={submissionName}
         apiVersion={2}
       />
@@ -1081,7 +1081,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={reviewerName}
         referrer={reviewerConsoleReferrer}
-        filterAssignedInvitaiton={true}
+        filterAssignedInvitation={true}
         submissionName={submissionName}
         submissionNumbers={submissionNumbers}
         apiVersion={1}
@@ -1340,7 +1340,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={reviewerName}
         referrer={reviewerConsoleReferrer}
-        filterAssignedInvitaiton={true}
+        filterAssignedInvitation={true}
         submissionName={submissionName}
         submissionNumbers={submissionNumbers}
       />
@@ -1543,7 +1543,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={areaChairName}
         referrer={areaChairConsoleReferrer}
-        filterAssignedInvitaiton={false}
+        filterAssignedInvitation={false}
         submissionName={undefined}
         submissionNumbers={undefined}
       />
@@ -1702,7 +1702,7 @@ describe('ConsoleTaskList', () => {
         venueId={venueId}
         roleName={seniorAreaChairName}
         referrer={seniorAreaChairConsoleReferrer}
-        filterAssignedInvitaiton={false}
+        filterAssignedInvitation={false}
         submissionName={undefined}
         submissionNumbers={undefined}
       />


### PR DESCRIPTION
- fix typo in property
- enable `filterAssignedInvitation` in the AC console tasks
- support "Meta_Review" in the pretty invitation id

the AC console should render the following task: 

thecvf.com/CVPR/2024/Conference/Submission4/Meta_Review1/-/Revision

as "Submission4 Meta Review1 Revision"