### PR TITLE
Fix/ Profile edit page - expertise saving error

### DIFF
--- a/components/profile/ExpertiseSection.js
+++ b/components/profile/ExpertiseSection.js
@@ -21,7 +21,9 @@ const ExpertiseSection = ({ profileExpertises, updateExpertise }) => {
           const recordCopy = { ...p }
           if (p.key === action.data.key) {
             recordCopy.keyWordsValue = action.data.value
-            recordCopy.keywords = action.data.value.split(',').map((q) => q.trim())
+            recordCopy.keywords = action.data.value
+              .split(',')
+              .flatMap((q) => (q.trim().length ? q.trim() : []))
           }
           return recordCopy
         })

--- a/tests/profilePage.ts
+++ b/tests/profilePage.ts
@@ -282,6 +282,31 @@ test('add relation', async (t) => {
     .click(saveProfileButton)
 })
 
+test('add expertise', async (t) => {
+  const firstExpertiseRow = Selector('div.expertise').find('div.row').nth(1)
+  const secondExpertiseRow = Selector('div.expertise').find('div.row').nth(2)
+  const thirdExpertiseRow = Selector('div.expertise').find('div.row').nth(3)
+  await t
+    .useRole(userBRole)
+    .navigateTo(`http://localhost:${process.env.NEXT_PORT}/profile/edit`)
+    // add expertise correctly
+    .typeText(firstExpertiseRow.find('div.expertise__value').nth(0).find('input'), 'some,correct,expertise')
+    .typeText(firstExpertiseRow.find('div.expertise__value').nth(1).find('input'), '1999')
+    .typeText(firstExpertiseRow.find('div.expertise__value').nth(2).find('input'), '2000')
+    // add empty expertise
+    .typeText(secondExpertiseRow.find('div.expertise__value').nth(0).find('input'), '   ,   ,   ,   ')
+    .typeText(secondExpertiseRow.find('div.expertise__value').nth(1).find('input'), '1999')
+    // add expertise with empty value
+    .typeText(thirdExpertiseRow.find('div.expertise__value').nth(0).find('input'), 'other expertise,   ')
+    .typeText(thirdExpertiseRow.find('div.expertise__value').nth(1).find('input'), '1999')
+    .click(saveProfileButton)
+    // verify relation is added
+    .expect(Selector('span').withText('other expertise').exists).ok()
+    .expect(Selector('span').withText('some, correct, expertise').exists).ok()
+    .expect(Selector('div.start-end-year').withText('1999 – Present').exists).ok()
+    .expect(Selector('div.start-end-year').withText('1999 – 2000').exists).ok()
+})
+
 test('import paper from dblp', async (t) => {
   const testPersistentUrl = 'https://dblp.org/pid/95/7448-1'
   await t


### PR DESCRIPTION
this pr should fix the issue that
when user enter expertise that ends with comma, the profile can't be saved saying that expertise key can't be empty

by removing the empty expertise