### PR TITLE
Feature/ PC/SAC/AC console - support display and search or additional meta review fields

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -57,6 +57,7 @@ const AssignedPaperRow = ({
   setSelectedNoteIds,
   shortPhrase,
   showCheckbox = true,
+  additionalMetaReviewFields,
 }) => {
   const { note, metaReviewData } = rowData
   const referrerUrl = encodeURIComponent(
@@ -101,6 +102,7 @@ const AssignedPaperRow = ({
           metaReviewData={metaReviewData}
           metaReviewRecommendationName={metaReviewRecommendationName}
           referrerUrl={referrerUrl}
+          additionalMetaReviewFields={additionalMetaReviewFields}
         />
       </td>
     </tr>
@@ -112,12 +114,14 @@ const AreaChairConsoleTasks = ({ venueId, areaChairName }) => {
     `[Area Chair Console](/group?id=${venueId}/${areaChairName}#areachair-tasks)`
   )
 
-  return <ConsoleTaskList
-    venueId={venueId}
-    roleName={areaChairName}
-    filterAssignedInvitation={true}
-    referrer={referrer}
-  />
+  return (
+    <ConsoleTaskList
+      venueId={venueId}
+      roleName={areaChairName}
+      filterAssignedInvitation={true}
+      referrer={referrer}
+    />
+  )
 }
 
 const AreaChairConsole = ({ appContext }) => {
@@ -138,6 +142,7 @@ const AreaChairConsole = ({ appContext }) => {
     reviewerName = 'Reviewers',
     anonReviewerName = 'Reviewer_',
     metaReviewRecommendationName = 'recommendation',
+    additionalMetaReviewFields = [],
     shortPhrase,
     filterOperators,
     propertiesAllowed,
@@ -460,6 +465,10 @@ const AreaChairConsole = ({ appContext }) => {
           metaReviewData: {
             [metaReviewRecommendationName]:
               metaReview?.content[metaReviewRecommendationName]?.value ?? 'N/A',
+            ...additionalMetaReviewFields.reduce((prev, curr) => {
+              const additionalMetaReviewFieldValue = metaReview?.content[curr]?.value ?? 'N/A'
+              return { ...prev, [curr]: additionalMetaReviewFieldValue }
+            }, {}),
             metaReviewInvitationId: `${venueId}/${submissionName}${note.number}/-/${officialMetaReviewName}`,
             metaReview,
           },
@@ -520,6 +529,7 @@ const AreaChairConsole = ({ appContext }) => {
             propertiesAllowed={propertiesAllowed}
             reviewRatingName={reviewRatingName}
             metaReviewRecommendationName={metaReviewRecommendationName}
+            additionalMetaReviewFields={additionalMetaReviewFields}
           />
           <p className="empty-message">No assigned papers matching search criteria.</p>
         </div>
@@ -538,6 +548,7 @@ const AreaChairConsole = ({ appContext }) => {
           propertiesAllowed={propertiesAllowed}
           reviewRatingName={reviewRatingName}
           metaReviewRecommendationName={metaReviewRecommendationName}
+          additionalMetaReviewFields={additionalMetaReviewFields}
         />
         <Table
           className="console-table table-striped areachair-console-table"
@@ -572,6 +583,7 @@ const AreaChairConsole = ({ appContext }) => {
               selectedNoteIds={selectedNoteIds}
               setSelectedNoteIds={setSelectedNoteIds}
               shortPhrase={shortPhrase}
+              additionalMetaReviewFields={additionalMetaReviewFields}
             />
           ))}
         </Table>
@@ -611,6 +623,7 @@ const AreaChairConsole = ({ appContext }) => {
               metaReviewRecommendationName={metaReviewRecommendationName}
               shortPhrase={shortPhrase}
               showCheckbox={false}
+              additionalMetaReviewFields={additionalMetaReviewFields}
             />
           ))}
         </Table>

--- a/components/webfield/AreaChairConsoleMenuBar.js
+++ b/components/webfield/AreaChairConsoleMenuBar.js
@@ -1,3 +1,4 @@
+import { camelCase, upperFirst } from 'lodash'
 import { prettyField } from '../../lib/utils'
 import BaseMenuBar from './BaseMenuBar'
 import MessageReviewersModal from './MessageReviewersModal'
@@ -15,6 +16,7 @@ const AreaChairConsoleMenuBar = ({
   propertiesAllowed: extraPropertiesAllowed,
   reviewRatingName,
   metaReviewRecommendationName,
+  additionalMetaReviewFields,
 }) => {
   const filterOperators = filterOperatorsConfig ?? ['!=', '>=', '<=', '>', '<', '==', '='] // sequence matters
   const propertiesAllowed = {
@@ -41,6 +43,14 @@ const AreaChairConsoleMenuBar = ({
     confidenceMin: ['reviewProgressData.confidenceMin'],
     replyCount: ['reviewProgressData.replyCount'],
     [metaReviewRecommendationName]: [`metaReviewData.${metaReviewRecommendationName}`],
+    ...(additionalMetaReviewFields?.length > 0 &&
+      additionalMetaReviewFields.reduce(
+        (prev, curr) => ({
+          ...prev,
+          [`MetaReview${upperFirst(camelCase(curr))}`]: [`metaReviewData.${curr}`],
+        }),
+        {}
+      )),
     ...(typeof extraPropertiesAllowed === 'object' && extraPropertiesAllowed),
   }
   const messageReviewerOptions = [

--- a/components/webfield/NoteMetaReviewStatus.js
+++ b/components/webfield/NoteMetaReviewStatus.js
@@ -108,6 +108,7 @@ export const AreaChairConsoleNoteMetaReviewStatus = ({
   metaReviewData,
   metaReviewRecommendationName,
   referrerUrl,
+  additionalMetaReviewFields,
 }) => {
   const [metaReviewInvitation, setMetaReviewInvitation] = useState(null)
   const { accessToken } = useUser()
@@ -143,10 +144,18 @@ export const AreaChairConsoleNoteMetaReviewStatus = ({
     <div className="areachair-console-meta-review">
       {metaReviewData[metaReviewRecommendationName] !== 'N/A' ? (
         <>
-          <h4 className="title">{`AC ${prettyField(metaReviewRecommendationName)}:`}</h4>
+          <h4 className="title">{prettyField(metaReviewRecommendationName)}:</h4>
           <p>
             <strong>{metaReviewData[metaReviewRecommendationName]}</strong>
           </p>
+          {additionalMetaReviewFields.map((additionalMetaReviewField) => {
+            const fieldValue = metaReviewData[additionalMetaReviewField]
+            return (
+              <p key={additionalMetaReviewField}>
+                <strong>{prettyField(additionalMetaReviewField)}:</strong> {fieldValue}
+              </p>
+            )
+          })}
           <p>
             <a href={editUrl} target="_blank" rel="nofollow noreferrer">{`Read${
               metaReviewInvitation ? '/Edit' : ''
@@ -178,9 +187,16 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
   referrerUrl,
   areaChairAssignmentUrl,
   metaReviewRecommendationName,
+  additionalMetaReviewFields,
 }) => {
   const { note, metaReviewData, preliminaryDecision } = rowData
-  const { numMetaReviewsDone, areaChairs, metaReviews, seniorAreaChairs, secondaryAreaChairs } = metaReviewData
+  const {
+    numMetaReviewsDone,
+    areaChairs,
+    metaReviews,
+    seniorAreaChairs,
+    secondaryAreaChairs,
+  } = metaReviewData
   const paperManualAreaChairAssignmentUrl = areaChairAssignmentUrl?.replace(
     'edges/browse?',
     `edges/browse?start=staticList,type:head,ids:${note.id}&`
@@ -199,7 +215,7 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
         {areaChairs.length !== 0 &&
           areaChairs.map((areaChair) => {
             const metaReview = metaReviews.find((p) => p.anonId === areaChair.anonymousId)
-            const recommendation = metaReview?.content?.[metaReviewRecommendationName]?.value
+            const recommendation = metaReview?.[metaReviewRecommendationName]
             const { metaReviewAgreement } = metaReview ?? {}
             return (
               <div key={areaChair.anonymousId} className="meta-review-info">
@@ -211,16 +227,32 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
                 </div>
                 {metaReview && (
                   <div>
-                    <span className="recommendation">Recommendation: {recommendation}</span>
-                    <div>
-                      <a
-                        href={`/forum?id=${metaReview.forum}&noteId=${metaReview.id}&referrer=${referrerUrl}`}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Read Meta Review
-                      </a>
-                    </div>
+                    <span className="recommendation">
+                      {prettyField(metaReviewRecommendationName)}: {recommendation}
+                    </span>
+                  </div>
+                )}
+                {additionalMetaReviewFields &&
+                  additionalMetaReviewFields.map((additionalMetaReviewField) => {
+                    const fieldValue = metaReview?.[additionalMetaReviewField]?.value
+                    if (!fieldValue) return null
+                    return (
+                      <div key={additionalMetaReviewField}>
+                        <span className="recommendation">
+                          {prettyField(additionalMetaReviewField)}: {fieldValue}
+                        </span>
+                      </div>
+                    )
+                  })}
+                {metaReview && (
+                  <div>
+                    <a
+                      href={`/forum?id=${metaReview.forum}&noteId=${metaReview.id}&referrer=${referrerUrl}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Read Meta Review
+                    </a>
                   </div>
                 )}
                 {metaReviewAgreement?.value && (
@@ -248,7 +280,7 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
         <div>
           <strong>Secondary Area Chair:</strong>
           <div>
-           {secondaryAreaChairs.map((areaChair) => (
+            {secondaryAreaChairs.map((areaChair) => (
               <div key={areaChair.anonymousId} className="meta-review-info">
                 <div className="areachair-contact">
                   <span>
@@ -257,11 +289,10 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
                   </span>
                 </div>
               </div>
-          ))}
+            ))}
           </div>
         </div>
       )}
-
 
       {seniorAreaChairs?.length > 0 && (
         <div className="senior-areachair">

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -38,6 +38,7 @@ const ProgramChairConsole = ({ appContext }) => {
     bidName,
     recommendationName, // to get ac recommendation edges
     metaReviewRecommendationName = 'recommendation', // recommendation field in meta review
+    additionalMetaReviewFields = [],
     requestFormId,
     submissionId,
     submissionVenueId,
@@ -709,6 +710,16 @@ const ProgramChairConsole = ({ appContext }) => {
         return {
           [metaReviewRecommendationName]:
             metaReview?.content[metaReviewRecommendationName]?.value,
+          ...additionalMetaReviewFields?.reduce((prev, curr) => {
+            const additionalMetaReviewFieldValue = metaReview?.content[curr]?.value
+            return {
+              ...prev,
+              [curr]: {
+                value: additionalMetaReviewFieldValue,
+                searchValue: additionalMetaReviewFieldValue ?? 'N/A',
+              },
+            }
+          }, {}),
           ...metaReview,
           metaReviewAgreement: metaReviewAgreement
             ? {
@@ -801,6 +812,13 @@ const ProgramChairConsole = ({ appContext }) => {
           metaReviewAgreementSearchValue: metaReviews
             .map((p) => p.metaReviewAgreement.searchValue)
             .join(' '),
+          ...additionalMetaReviewFields?.reduce((prev, curr) => {
+            const additionalMetaReviewValues = metaReviews.map((p) => p[curr]?.searchValue)
+            return {
+              ...prev,
+              [`${curr}SearchValue`]: additionalMetaReviewValues.join(' '),
+            }
+          }, {}),
         },
 
         decision,

--- a/components/webfield/ProgramChairConsole/PaperStatus.js
+++ b/components/webfield/ProgramChairConsole/PaperStatus.js
@@ -44,6 +44,7 @@ const PaperRow = ({
     shortPhrase,
     submissionName,
     metaReviewRecommendationName = 'recommendation',
+    additionalMetaReviewFields = [],
   } = useContext(WebFieldContext)
   const { note, metaReviewData } = rowData
   const referrerUrl = encodeURIComponent(
@@ -94,6 +95,7 @@ const PaperRow = ({
             referrerUrl={referrerUrl}
             areaChairAssignmentUrl={getManualAssignmentUrl('Area_Chairs')}
             metaReviewRecommendationName={metaReviewRecommendationName}
+            additionalMetaReviewFields={additionalMetaReviewFields}
           />
         </td>
       )}

--- a/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { camelCase } from 'lodash'
+import { camelCase, startCase, upperFirst } from 'lodash'
 import WebFieldContext from '../../WebFieldContext'
 import BaseMenuBar from '../BaseMenuBar'
 import MessageReviewersModal from '../MessageReviewersModal'
@@ -23,6 +23,7 @@ const PaperStatusMenuBar = ({
     filterOperators: filterOperatorsConfig,
     propertiesAllowed: extraPropertiesAllowed,
     customStageInvitations = [],
+    additionalMetaReviewFields = [],
   } = useContext(WebFieldContext)
   const filterOperators = filterOperatorsConfig ?? ['!=', '>=', '<=', '>', '<', '==', '=']
   const propertiesAllowed = {
@@ -53,6 +54,14 @@ const PaperStatusMenuBar = ({
     ...(metaReviewRecommendationName && {
       [metaReviewRecommendationName]: ['metaReviewData.metaReviewsSearchValue'],
     }),
+    ...(additionalMetaReviewFields?.length > 0 &&
+      additionalMetaReviewFields.reduce(
+        (prev, curr) => ({
+          ...prev,
+          [`MetaReview${upperFirst(camelCase(curr))}`]: [`metaReviewData.${curr}SearchValue`],
+        }),
+        {}
+      )),
     ...(customStageInvitations?.length > 0 &&
       customStageInvitations.reduce(
         (prev, curr) => ({

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -43,6 +43,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
     decisionName = 'Decision',
     preliminaryDecisionName,
     metaReviewRecommendationName = 'recommendation',
+    additionalMetaReviewFields = [],
     edgeBrowserDeployedUrl,
     customStageInvitations,
     withdrawnVenueId,
@@ -448,6 +449,16 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                 [metaReviewRecommendationName]:
                   metaReview?.content[metaReviewRecommendationName]?.value,
                 ...metaReview,
+                ...additionalMetaReviewFields?.reduce((prev, curr) => {
+                  const additionalMetaReviewFieldValue = metaReview?.content[curr]?.value
+                  return {
+                    ...prev,
+                    [curr]: {
+                      value: additionalMetaReviewFieldValue,
+                      searchValue: additionalMetaReviewFieldValue ?? 'N/A',
+                    },
+                  }
+                }, {}),
                 metaReviewAgreement: metaReviewAgreement
                   ? {
                       searchValue: metaReviewAgreementValue,
@@ -551,6 +562,13 @@ const SeniorAreaChairConsole = ({ appContext }) => {
               metaReviewAgreementSearchValue: metaReviews
                 .map((p) => p.metaReviewAgreement?.searchValue)
                 .join(' '),
+              ...additionalMetaReviewFields?.reduce((prev, curr) => {
+                const additionalMetaReviewValues = metaReviews.map((p) => p[curr]?.searchValue)
+                return {
+                  ...prev,
+                  [`${curr}SearchValue`]: additionalMetaReviewValues.join(' '),
+                }
+              }, {}),
             },
             decision,
             preliminaryDecision,

--- a/components/webfield/SeniorAreaChairConsole/PaperStatus.js
+++ b/components/webfield/SeniorAreaChairConsole/PaperStatus.js
@@ -37,6 +37,7 @@ const PaperRow = ({ rowData, selectedNoteIds, setSelectedNoteIds, decision, venu
     seniorAreaChairName,
     submissionName,
     metaReviewRecommendationName = 'recommendation',
+    additionalMetaReviewFields = [],
   } = useContext(WebFieldContext)
   const { note } = rowData
   const referrerUrl = encodeURIComponent(
@@ -84,6 +85,7 @@ const PaperRow = ({ rowData, selectedNoteIds, setSelectedNoteIds, decision, venu
           rowData={rowData}
           referrerUrl={referrerUrl}
           metaReviewRecommendationName={metaReviewRecommendationName}
+          additionalMetaReviewFields={additionalMetaReviewFields}
         />
       </td>
       <td className="console-decision">


### PR DESCRIPTION
this pr should support a new config 
>additionalMetaReviewFields
in PC/SAC/AC console 

example config
>additionalMetaReviewFields:["final_recommendation"]

this pr should show the additionalMetaReviewFields values of meta review in paper status tab if available (apart from recommendation value) .

the additionalMetaReviewFields should also be query filterable