### PR TITLE
Fix/ Empty history error in test setup

### DIFF
--- a/tests/utils/api-helper.js
+++ b/tests/utils/api-helper.js
@@ -297,6 +297,14 @@ export async function createProfile(fullname, email, tildeId, superUserToken) {
           username: tildeId,
         },
       ],
+      history: [
+        {
+          position: 'Postdoc',
+          start: 2000,
+          end: new Date().getFullYear(),
+          institution: { domain: 'umass.edu', name: 'University of Massachusetts, Amherst' },
+        },
+      ],
     },
   }
   await api.post('/profiles', profileJson, { accessToken: superUserToken })
@@ -330,6 +338,14 @@ export async function createEmptyProfile(fullname, tildeId, superUserToken) {
         {
           fullname,
           username: tildeId,
+        },
+      ],
+      history: [
+        {
+          position: 'Postdoc',
+          start: 2000,
+          end: new Date().getFullYear(),
+          institution: { domain: 'umass.edu', name: 'University of Massachusetts, Amherst' },
         },
       ],
     },


### PR DESCRIPTION
There's a new validation in API to disallow empty history when creating a profile
this pr should change the test setup so that test can pass