### PR TITLE
Fix/ Add support for floats to parseNumberField

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1608,17 +1608,13 @@ export function getVenueTabCountMessage(unrepliedCommentCount, notDeployedCount)
 
 export function parseNumberField(value) {
   if (typeof value === 'string') {
-    const regex = /\d*\.?\d+/;
-    const match = value.match(regex);
+    const regex = /\d*\.?\d+/
+    const match = value.match(regex)
     if (match) {
-      const numberString = match[0];
-      if (numberString.includes('.')) {
-        return parseFloat(numberString);
-      } else {
-        return parseInt(numberString, 10);
-      }
+      const numberString = match[0]
+      return numberString.includes('.') ? parseFloat(numberString) : parseInt(numberString, 10)
     }
-    return null;
+    return null
   } else if (typeof value === 'number') {
     return value
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1608,8 +1608,17 @@ export function getVenueTabCountMessage(unrepliedCommentCount, notDeployedCount)
 
 export function parseNumberField(value) {
   if (typeof value === 'string') {
-    const valueString = value.substring(0, value.indexOf(':'))
-    return valueString ? parseInt(valueString, 10) : null
+    const regex = /\d*\.?\d+/;
+    const match = value.match(regex);
+    if (match) {
+      const numberString = match[0];
+      if (numberString.includes('.')) {
+        return parseFloat(numberString);
+      } else {
+        return parseInt(numberString, 10);
+      }
+    }
+    return null;
   } else if (typeof value === 'number') {
     return value
   }


### PR DESCRIPTION
This PR uses a regex to match the first number of a field and parse it as either a float or an integer