### PR TITLE
Fix/ Error impersonating user with no linked email

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -66,7 +66,7 @@ export default class OpenReviewApp extends App {
     window.Webfield2.setToken(userAccessToken)
 
     if (authenticatedUser.id !== process.env.SUPER_USER) {
-      this.loadUnreadNotificationCount(authenticatedUser.profile.emails[0], userAccessToken)
+      this.loadUnreadNotificationCount(authenticatedUser.profile.emails?.[0], userAccessToken)
     }
 
     // Automatically refresh the accessToken 1m before it's set to expire.


### PR DESCRIPTION
when impersonating a pre-created dblp profile with no email, the page will show an error reading from undefined value (impersonation still works)

this pr should fix the error