### PR TITLE
Feature/Consoles - Add profile link

### DIFF
--- a/components/ProfileListWithBidWidget.js
+++ b/components/ProfileListWithBidWidget.js
@@ -25,7 +25,7 @@ const BasicProfileSummary = ({ profile, setSearchTerm }) => {
   return (
     <div className="profile-summary">
       <h4 className="profile-name">
-        <a href={getProfileLink(profile.id, profile.id)} target="_blank" rel="noreferrer">
+        <a href={getProfileLink(profile.id)} target="_blank" rel="noreferrer">
           {profileName}
         </a>
       </h4>

--- a/components/webfield/NoteMetaReviewStatus.js
+++ b/components/webfield/NoteMetaReviewStatus.js
@@ -223,7 +223,7 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
                 <div className="areachair-contact">
                   <span>
                     <a
-                      href={getProfileLink(null, areaChair.areaChairProfileId)}
+                      href={getProfileLink(areaChair.areaChairProfileId)}
                       target="_blank"
                       rel="noreferrer"
                     >
@@ -292,7 +292,7 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
                 <div className="areachair-contact">
                   <span>
                     <a
-                      href={getProfileLink(null, areaChair.areaChairProfileId)}
+                      href={getProfileLink(areaChair.areaChairProfileId)}
                       target="_blank"
                       rel="noreferrer"
                     >
@@ -315,7 +315,7 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
               <div className="seniorareachair-contact">
                 <span>
                   <a
-                    href={getProfileLink(null, seniorAreaChair.preferredId)}
+                    href={getProfileLink(seniorAreaChair.preferredId)}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/components/webfield/NoteMetaReviewStatus.js
+++ b/components/webfield/NoteMetaReviewStatus.js
@@ -7,6 +7,7 @@ import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
 import { inflect, prettyField } from '../../lib/utils'
 import { getNoteContentValues } from '../../lib/forum-utils'
+import { getProfileLink } from '../../lib/webfield-utils'
 
 const IEEECopyrightForm = ({ note, isV2Note }) => {
   const { showIEEECopyright, IEEEPublicationTitle, IEEEArtSourceCode } =
@@ -221,7 +222,13 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
               <div key={areaChair.anonymousId} className="meta-review-info">
                 <div className="areachair-contact">
                   <span>
-                    {areaChair.preferredName}{' '}
+                    <a
+                      href={getProfileLink(null, areaChair.areaChairProfileId)}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {areaChair.preferredName}
+                    </a>{' '}
                     <span className="text-muted">&lt;{areaChair.preferredEmail}&gt;</span>
                   </span>
                 </div>
@@ -284,7 +291,13 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
               <div key={areaChair.anonymousId} className="meta-review-info">
                 <div className="areachair-contact">
                   <span>
-                    {areaChair.preferredName}{' '}
+                    <a
+                      href={getProfileLink(null, areaChair.areaChairProfileId)}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {areaChair.preferredName}
+                    </a>{' '}
                     <span className="text-muted">&lt;{areaChair.preferredEmail}&gt;</span>
                   </span>
                 </div>
@@ -301,7 +314,13 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
             <div key={index} className="meta-review-info">
               <div className="seniorareachair-contact">
                 <span>
-                  {seniorAreaChair.preferredName}{' '}
+                  <a
+                    href={getProfileLink(null, seniorAreaChair.preferredId)}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {seniorAreaChair.preferredName}
+                  </a>{' '}
                   <span className="text-muted">&lt;{seniorAreaChair.preferredEmail}&gt;</span>
                 </span>
               </div>

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -13,6 +13,7 @@ import LoadingSpinner from '../LoadingSpinner'
 import NoteList from '../NoteList'
 import WebFieldContext from '../WebFieldContext'
 import { prettyField } from '../../lib/utils'
+import { getProfileLink } from '../../lib/webfield-utils'
 
 // modified from noteReviewStatus.hbs handlebar template
 export const ReviewerConsoleNoteReviewStatus = ({
@@ -231,7 +232,13 @@ export const AcPcConsoleReviewerStatusRow = ({
       <strong className="assigned-reviewer-id">{reviewer.anonymousId}</strong>
       <div className="assigned-reviewer-action">
         <span>
-          {reviewer.preferredName}{' '}
+          <a
+            href={getProfileLink(null, reviewer.reviewerProfileId)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {reviewer.preferredName}
+          </a>{' '}
           <span className="text-muted">&lt;{reviewer.preferredEmail}&gt;</span>
         </span>
         {completedReview ? (

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -233,7 +233,7 @@ export const AcPcConsoleReviewerStatusRow = ({
       <div className="assigned-reviewer-action">
         <span>
           <a
-            href={getProfileLink(null, reviewer.reviewerProfileId)}
+            href={getProfileLink(reviewer.reviewerProfileId)}
             target="_blank"
             rel="noreferrer"
           >

--- a/components/webfield/ProgramChairConsole/AreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatus.js
@@ -38,7 +38,7 @@ const CommitteeSummary = ({ rowData, bidEnabled, recommendationEnabled, invitati
           <>
             <h4>
               <a
-                href={getProfileLink(id, rowData.areaChairProfileId)}
+                href={getProfileLink(id ?? rowData.areaChairProfileId)}
                 target="_blank"
                 rel="noreferrer"
               >
@@ -91,7 +91,7 @@ const CommitteeSummary = ({ rowData, bidEnabled, recommendationEnabled, invitati
               <>
                 <h4>
                   <a
-                    href={getProfileLink(sacProfile?.id, seniorAreaChairId)}
+                    href={getProfileLink(sacProfile?.id ?? seniorAreaChairId)}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -27,7 +27,7 @@ const ReviewerSummary = ({ rowData, bidEnabled, invitations }) => {
       {preferredName ? (
         <>
           <h4>
-            <a href={getProfileLink(id, reviewerProfileId)} target="_blank" rel="noreferrer">
+            <a href={getProfileLink(id ?? reviewerProfileId)} target="_blank" rel="noreferrer">
               {preferredName}
             </a>
           </h4>
@@ -35,7 +35,7 @@ const ReviewerSummary = ({ rowData, bidEnabled, invitations }) => {
         </>
       ) : (
         <h4>
-          <a href={getProfileLink(id, reviewerProfileId)} target="_blank" rel="noreferrer">
+          <a href={getProfileLink(id ?? reviewerProfileId)} target="_blank" rel="noreferrer">
             {reviewerProfileId}
           </a>
         </h4>

--- a/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
@@ -12,7 +12,7 @@ const BasicProfileSummary = ({ profile, profileId }) => {
       {preferredName ? (
         <>
           <h4>
-            <a href={getProfileLink(id, profileId)} target="_blank" rel="noreferrer">
+            <a href={getProfileLink(id ?? profileId)} target="_blank" rel="noreferrer">
               {preferredName}
             </a>
           </h4>

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -23,9 +23,9 @@ import { getProfileLink } from '../../lib/webfield-utils'
 
 const AreaChairInfo = ({ areaChairName, areaChairIds }) => (
   <div className="note-area-chairs">
-    <strong>{prettyField(areaChairName)}:</strong> {/* <div> */}
+    <strong>{prettyField(areaChairName)}:</strong>
     {areaChairIds.map((areaChairId) => (
-      <Link key={areaChairId} href={getProfileLink(null, areaChairId)}>
+      <Link key={areaChairId} href={getProfileLink(areaChairId)}>
         <div>{prettyId(areaChairId)}</div>
       </Link>
     ))}

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -25,9 +25,9 @@ const AreaChairInfo = ({ areaChairName, areaChairIds }) => (
   <div className="note-area-chairs">
     <strong>{prettyField(areaChairName)}:</strong>
     {areaChairIds.map((areaChairId) => (
-      <Link key={areaChairId} href={getProfileLink(areaChairId)}>
-        <div>{prettyId(areaChairId)}</div>
-      </Link>
+      <div key={areaChairId}>
+        <Link href={getProfileLink(areaChairId)}>{prettyId(areaChairId)}</Link>
+      </div>
     ))}
   </div>
 )

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -19,17 +19,16 @@ import ErrorDisplay from '../ErrorDisplay'
 import ReviewerConsoleMenuBar from './ReviewerConsoleMenuBar'
 import LoadingSpinner from '../LoadingSpinner'
 import ConsoleTaskList from './ConsoleTaskList'
+import { getProfileLink } from '../../lib/webfield-utils'
 
 const AreaChairInfo = ({ areaChairName, areaChairIds }) => (
   <div className="note-area-chairs">
-    <p>
-      <strong>{prettyField(areaChairName)}:</strong>{' '}
-      {areaChairIds.map((areaChairId) => (
-        <Link key={areaChairId} href={`/profile?id=${areaChairId}`}>
-          {prettyId(areaChairId)}{' '}
-        </Link>
-      ))}
-    </p>
+    <strong>{prettyField(areaChairName)}:</strong> {/* <div> */}
+    {areaChairIds.map((areaChairId) => (
+      <Link key={areaChairId} href={getProfileLink(null, areaChairId)}>
+        <div>{prettyId(areaChairId)}</div>
+      </Link>
+    ))}
   </div>
 )
 

--- a/components/webfield/SeniorAreaChairConsole/AreaChairStatus.js
+++ b/components/webfield/SeniorAreaChairConsole/AreaChairStatus.js
@@ -21,7 +21,7 @@ const CommitteeSummary = ({ rowData }) => {
           <>
             <h4>
               <a
-                href={getProfileLink(id, rowData.areaChairProfileId)}
+                href={getProfileLink(id ?? rowData.areaChairProfileId)}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -625,14 +625,13 @@ export function buildEdgeBrowserUrl(
 }
 
 /**
- * get a link to user profile for webfield console
+ * get a link to user profile or group page for webfield console
  *
- * @param {string} profileId
  * @param {string} id could be tilde id or email or group id
  * @returns string
  */
-export function getProfileLink(profileId, id) {
-  if (profileId) return `/profile?id=${profileId}`
+export function getProfileLink(id) {
+  if (!id) return null
   if (id.startsWith('~')) return `/profile?id=${id}`
   if (utils.isValidEmail(id)) return `/profile?email=${id}`
   return `/group?id=${id}`

--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -628,12 +628,14 @@ export function buildEdgeBrowserUrl(
  * get a link to user profile for webfield console
  *
  * @param {string} profileId
- * @param {string} id could be tilde id or email
+ * @param {string} id could be tilde id or email or group id
  * @returns string
  */
 export function getProfileLink(profileId, id) {
   if (profileId) return `/profile?id=${profileId}`
-  return id.startsWith('~') ? `/profile?id=${id}` : `/profile?email=${id}`
+  if (id.startsWith('~')) return `/profile?id=${id}`
+  if (utils.isValidEmail(id)) return `/profile?email=${id}`
+  return `/group?id=${id}`
 }
 
 /**

--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -157,7 +157,7 @@ test('Set up TestVenue', async (t) => {
     readers: ['TestVenue/2020/Conference/Program_Chairs', 'openreview.net/Support'],
     referent: requestForumId,
     replyto: requestForumId,
-    signatures: ['openreview.net/Support'],
+    signatures: ['~Super_User1'],
     writers: [],
   }
   const { id: postSubmissionId } = await createNote(postSubmissionJson, superUserToken)
@@ -183,7 +183,7 @@ test('Set up TestVenue', async (t) => {
     readers: ['TestVenue/2020/Conference/Program_Chairs', 'openreview.net/Support'],
     referent: requestForumId,
     replyto: requestForumId,
-    signatures: ['openreview.net/Support'],
+    signatures: ['~Super_User1'],
     writers: [],
   }
   const { id: reviewStageId } = await createNote(reviewStageJson, superUserToken)
@@ -289,7 +289,7 @@ test('Set up AnotherTestVenue', async (t) => {
     readers: ['AnotherTestVenue/2020/Conference/Program_Chairs', 'openreview.net/Support'],
     referent: requestForumId,
     replyto: requestForumId,
-    signatures: ['openreview.net/Support'],
+    signatures: ['~Super_User1'],
     writers: [],
   }
   const { id: postSubmissionId } = await createNote(postSubmissionJson, superUserToken)
@@ -389,7 +389,7 @@ test('Set up ICLR', async (t) => {
     readers: ['ICLR.cc/2021/Conference/Program_Chairs', 'openreview.net/Support'],
     referent: requestForumId,
     replyto: requestForumId,
-    signatures: ['openreview.net/Support'],
+    signatures: ['~Super_User1'],
     writers: [],
   }
 
@@ -552,7 +552,7 @@ test('Set up TestVenue using API 2', async (t) => {
     readers: ['TestVenue/2023/Conference/Program_Chairs', 'openreview.net/Support'],
     referent: requestForumId,
     replyto: requestForumId,
-    signatures: ['openreview.net/Support'],
+    signatures: ['~Super_User1'],
     writers: [],
   }
 


### PR DESCRIPTION
this pr should fix the following 2 issues:
1. add a link to profile for reviewers/ACs/Secondary ACs/SACs
2. correct the link to secondary AC group page instead of the non-existing profile page in reviewer console
currently the group member hierarchy is :
- per paper ACs
   - AC anon group
   - secondary ACs
      - secondary AC anon group

so "secondary ACs" group is rendered in reviewer console
CVPR 24 reviewer console can be used as example