### PR TITLE
Fix/Group editor: load all related invitations

### DIFF
--- a/components/group/GroupEditor.js
+++ b/components/group/GroupEditor.js
@@ -39,7 +39,7 @@ const GroupEditor = ({ group, isSuperUser, profileId, accessToken, reloadGroup }
       )}
       <GroupSignedNotes groupId={group.id} accessToken={accessToken} />
       <GroupChildGroups groupId={group.id} accessToken={accessToken} />
-      <GroupRelatedInvitations groupId={group.id} accessToken={accessToken} />
+      <GroupRelatedInvitations group={group} accessToken={accessToken} />
       <GroupUICode
         group={group}
         profileId={profileId}

--- a/components/group/GroupRelatedInvitations.js
+++ b/components/group/GroupRelatedInvitations.js
@@ -9,7 +9,10 @@ const RelatedInvitationRow = ({ item }) => (
   <Link href={`/invitation/edit?id=${item.id}`}>{prettyId(item.id)}</Link>
 )
 
-const GroupRelatedInvitations = ({ groupId, accessToken }) => {
+const GroupRelatedInvitations = ({ group, accessToken }) => {
+  const groupId = group.id
+  const submissionName = group.details?.domain?.content?.submission_name?.value
+
   const [totalCount, setTotalCount] = useState(null)
 
   const loadRelatedInvitations = async (limit, offset) => {
@@ -23,7 +26,7 @@ const GroupRelatedInvitations = ({ groupId, accessToken }) => {
         offset,
       },
       {
-        prefix: `${groupId}/-/.*`,
+        prefix: groupId.includes(submissionName) ? `${groupId}/.*` : `${groupId}/-/.*`,
         expired: true,
         type: 'all',
         limit,

--- a/pages/group/info.js
+++ b/pages/group/info.js
@@ -94,7 +94,7 @@ const GroupInfo = ({ appContext }) => {
 
           <GroupChildGroups groupId={group.id} accessToken={accessToken} />
 
-          <GroupRelatedInvitations groupId={group.id} accessToken={accessToken} />
+          <GroupRelatedInvitations group={group} accessToken={accessToken} />
         </div>
       ) : (
         <LoadingSpinner />


### PR DESCRIPTION
this pr should make group editor related invitations section to use a regex prefix that can load more invitations such as 
>thecvf.com/CVPR/2024/Conference/Submission4/Meta_Review1/-/Final_Revision 

where "-" does not follow group id directly (user is at thecvf.com/CVPR/2024/Conference/Submission4 group)