### PR TITLE
Fix/ Don't allow user to import from DBLP with coauthor's persistent URL

### DIFF
--- a/components/DblpImportModal.js
+++ b/components/DblpImportModal.js
@@ -160,8 +160,7 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
       setShowPersistentUrlInput(false)
     } catch (error) {
       if (error instanceof URIError || error instanceof TypeError) {
-        // failed at
-        console.error(error)
+        // failed at getDblpPublicationsFromXmlUrl
         setMessage('')
         setShowPersistentUrlInput(true)
       } else {
@@ -257,7 +256,6 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
           </div>
 
           <div className={`modal-body ${isSavingPublications ? 'disable-scroll' : ''}`}>
-            {console.log('message', message)}
             {message && (
               <ErrorMessage
                 message={message}

--- a/components/DblpImportModal.js
+++ b/components/DblpImportModal.js
@@ -106,11 +106,9 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
         )
 
       if (
-        !allDblpPublications.some((pub) =>
-          profileNames.some((name) =>
-            deburrString(pub.note.content.dblp, false).includes(
-              deburrString(getNameString(name), false)
-            )
+        !possibleNames.some((name) =>
+          profileNames.some((pName) =>
+            deburrString(name, false).includes(deburrString(getNameString(pName), false))
           )
         )
       ) {
@@ -162,7 +160,8 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
       setShowPersistentUrlInput(false)
     } catch (error) {
       if (error instanceof URIError || error instanceof TypeError) {
-        // failed at getDblpPublicationsFromXmlUrl
+        // failed at
+        console.error(error)
         setMessage('')
         setShowPersistentUrlInput(true)
       } else {
@@ -258,6 +257,7 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
           </div>
 
           <div className={`modal-body ${isSavingPublications ? 'disable-scroll' : ''}`}>
+            {console.log('message', message)}
             {message && (
               <ErrorMessage
                 message={message}

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -3,7 +3,7 @@
 
 import _ from 'lodash'
 import api from './api-client'
-import { getNameString } from './utils'
+import { deburrString, getNameString } from './utils'
 
 const superUserSignatures = [process.env.SUPER_USER, '~Super_User1']
 let paperSearchResults = []
@@ -378,9 +378,10 @@ export async function getDblpPublicationsFromXmlUrl(xmlUrl, profileId, profileNa
         const authorNames = Object.values(publicationNode.getElementsByTagName('author')).map(
           (p) => p.textContent
         )
-        const authorIndex = authorNames.findIndex((name) =>
-          profileNames.some((p) => name.includes(p))
-        )
+        const authorIndex = authorNames.findIndex((name) => {
+          const deburredName = deburrString(name, false)
+          return profileNames.some((p) => deburredName.includes(deburrString(p, false)))
+        })
 
         return {
           note: {


### PR DESCRIPTION
currently a use can use a dblp url as long as any of the user's names appear in any of the listed papers
this pr should only allow import if the user's name match with the names specified in dblp xml

this is part of the preparation for auto profile merge