### PR TITLE
Feature/ AC Console - change referrer url to specific tab

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -58,10 +58,11 @@ const AssignedPaperRow = ({
   shortPhrase,
   showCheckbox = true,
   additionalMetaReviewFields,
+  activeTabId,
 }) => {
   const { note, metaReviewData } = rowData
   const referrerUrl = encodeURIComponent(
-    `[Area Chair Console](/group?id=${venueId}/${areaChairName}#assigned-papers)`
+    `[Area Chair Console](/group?id=${venueId}/${areaChairName}${activeTabId})`
   )
   return (
     <tr>
@@ -585,6 +586,7 @@ const AreaChairConsole = ({ appContext }) => {
               setSelectedNoteIds={setSelectedNoteIds}
               shortPhrase={shortPhrase}
               additionalMetaReviewFields={additionalMetaReviewFields}
+              activeTabId={activeTabId}
             />
           ))}
         </Table>
@@ -625,6 +627,7 @@ const AreaChairConsole = ({ appContext }) => {
               shortPhrase={shortPhrase}
               showCheckbox={false}
               additionalMetaReviewFields={additionalMetaReviewFields}
+              activeTabId={activeTabId}
             />
           ))}
         </Table>


### PR DESCRIPTION
currently the referrer url always use #assigned-papers tab
this pr should make the links to go back to the specific tab

for example user click the read review link in secondary reviewers tab and click the go back to AC console link in banner of forum page, it should display secondary reviewers tab instead of assigned papers tab