### PR TITLE
Fix/Group Editor: remove calls to API 1 when the group is created in API 2

### DIFF
--- a/components/group/GroupEditor.js
+++ b/components/group/GroupEditor.js
@@ -37,7 +37,7 @@ const GroupEditor = ({ group, isSuperUser, profileId, accessToken, reloadGroup }
           reloadGroup={reloadGroup}
         />
       )}
-      <GroupSignedNotes groupId={group.id} accessToken={accessToken} />
+      <GroupSignedNotes group={group} accessToken={accessToken} />
       <GroupChildGroups groupId={group.id} accessToken={accessToken} />
       <GroupRelatedInvitations group={group} accessToken={accessToken} />
       <GroupUICode

--- a/components/group/GroupRelatedInvitations.js
+++ b/components/group/GroupRelatedInvitations.js
@@ -17,25 +17,26 @@ const GroupRelatedInvitations = ({ group, accessToken }) => {
   const [totalCount, setTotalCount] = useState(null)
 
   const loadRelatedInvitations = async (limit, offset) => {
-    const result = await api.get(
-      '/invitations',
-      isV1Group
-        ? {
-            regex: `${groupId}/-/.*`,
-            expired: true,
-            type: 'all',
-            limit,
-            offset,
-          }
-        : {
-            prefix: groupId.includes(submissionName) ? `${groupId}/.*` : `${groupId}/-/.*`,
-            expired: true,
-            type: 'all',
-            limit,
-            offset,
-          },
-      { accessToken, ...(isV1Group && { version: 1 }) }
-    )
+    const queryParam = isV1Group
+      ? {
+          regex: `${groupId}/-/.*`,
+          expired: true,
+          type: 'all',
+          limit,
+          offset,
+        }
+      : {
+          prefix: groupId.includes(submissionName) ? `${groupId}/.*` : `${groupId}/-/.*`,
+          expired: true,
+          type: 'all',
+          limit,
+          offset,
+        }
+
+    const result = await api.get('/invitations', queryParam, {
+      accessToken,
+      ...(isV1Group && { version: 1 }),
+    })
 
     if (result.count !== totalCount) {
       setTotalCount(result.count ?? 0)

--- a/components/group/GroupRelatedInvitations.js
+++ b/components/group/GroupRelatedInvitations.js
@@ -11,28 +11,30 @@ const RelatedInvitationRow = ({ item }) => (
 
 const GroupRelatedInvitations = ({ group, accessToken }) => {
   const groupId = group.id
+  const isV1Group = !group.domain
   const submissionName = group.details?.domain?.content?.submission_name?.value
 
   const [totalCount, setTotalCount] = useState(null)
 
   const loadRelatedInvitations = async (limit, offset) => {
-    const result = await api.getCombined(
+    const result = await api.get(
       '/invitations',
-      {
-        regex: `${groupId}/-/.*`,
-        expired: true,
-        type: 'all',
-        limit,
-        offset,
-      },
-      {
-        prefix: groupId.includes(submissionName) ? `${groupId}/.*` : `${groupId}/-/.*`,
-        expired: true,
-        type: 'all',
-        limit,
-        offset,
-      },
-      { accessToken }
+      isV1Group
+        ? {
+            regex: `${groupId}/-/.*`,
+            expired: true,
+            type: 'all',
+            limit,
+            offset,
+          }
+        : {
+            prefix: groupId.includes(submissionName) ? `${groupId}/.*` : `${groupId}/-/.*`,
+            expired: true,
+            type: 'all',
+            limit,
+            offset,
+          },
+      { accessToken, ...(isV1Group && { version: 1 }) }
     )
 
     if (result.count !== totalCount) {

--- a/components/group/GroupSignedNotes.js
+++ b/components/group/GroupSignedNotes.js
@@ -6,7 +6,9 @@ import PaginatedList from '../PaginatedList'
 import api from '../../lib/api-client'
 import { prettyInvitationId } from '../../lib/utils'
 
-const GroupSignedNotes = ({ groupId, accessToken }) => {
+const GroupSignedNotes = ({ group, accessToken }) => {
+  const groupId = group.id
+  const isV1Group = !group.domain
   const [totalCount, setTotalCount] = useState(null)
 
   const processNote = (note) => {
@@ -23,15 +25,14 @@ const GroupSignedNotes = ({ groupId, accessToken }) => {
   }
 
   const loadNotes = async (limit, offset) => {
-    const { notes, count } = await api.getCombined(
+    const { notes, count } = await api.get(
       '/notes',
       {
         'signatures[]': [groupId],
         limit,
         offset,
       },
-      null,
-      { accessToken }
+      { accessToken, ...(isV1Group && { version: 1 }) }
     )
 
     let translatedNotes = []

--- a/pages/group/info.js
+++ b/pages/group/info.js
@@ -90,7 +90,7 @@ const GroupInfo = ({ appContext }) => {
 
           <GroupMembersInfo group={group} />
 
-          <GroupSignedNotes groupId={group.id} accessToken={accessToken} />
+          <GroupSignedNotes group={group} accessToken={accessToken} />
 
           <GroupChildGroups groupId={group.id} accessToken={accessToken} />
 


### PR DESCRIPTION
currently group editor use getCombined to load signed notes and related invitations.
this pr should change it to only load from api which match with the group version by checking group.domain