### PR TITLE
Fix/ Profile activation - update data for new api validation

### DIFF
--- a/pages/profile/activate.js
+++ b/pages/profile/activate.js
@@ -34,13 +34,10 @@ const ActivateProfile = ({ appContext }) => {
   }
 
   const saveProfile = async (newProfileData) => {
-    const dataToSubmit = {
-      id: profile.id,
-      content: newProfileData,
-      signatures: [profile.id],
-    }
     try {
-      const { user, token } = await api.put(`/activate/${activateToken}`, dataToSubmit)
+      const { user, token } = await api.put(`/activate/${activateToken}`, {
+        content: newProfileData,
+      })
       if (token) {
         promptMessage('Your OpenReview profile has been successfully created', {
           scrollToTop: false,

--- a/tests/utils/api-helper.js
+++ b/tests/utils/api-helper.js
@@ -207,21 +207,6 @@ export async function createUser({
     institution: { domain: 'umass.edu', name: 'University of Massachusetts, Amherst' },
   }
   const activateJson = {
-    names: [
-      {
-        fullname,
-        preferred: true,
-        username: tildeId,
-        altUsernames: [],
-      },
-    ],
-    emails: [email],
-    links: [],
-    id: tildeId,
-    gender: '',
-    preferredName: fullname,
-    preferredEmail: email,
-    currentInstitution: null,
     content: {
       names: [
         {


### PR DESCRIPTION
api validation of /activate/{token}: has been updated to allow only content field

this pr should fix activate page and test setup to pass only content field