### PR TITLE
Fix/ Note editor: render ProfileSearchWidget for profile/profile[]

### DIFF
--- a/components/webfield/EditorWidget.js
+++ b/components/webfield/EditorWidget.js
@@ -76,8 +76,10 @@ const EditorWidget = () => {
       case 'string[]':
         return value.param?.enum ? <DropdownWidget /> : <TextboxWidget />
       case 'group':
+      case 'profile':
         return <ProfileSearchWidget />
       case 'group[]':
+      case 'profile[]':
         return <ProfileSearchWidget multiple={true} />
       case 'note':
       case 'note[]':

--- a/unitTests/EditorWidget.test.js
+++ b/unitTests/EditorWidget.test.js
@@ -334,6 +334,18 @@ describe('EditorWidget', () => {
     expect(screen.getByText('profile')).toBeInTheDocument()
   })
 
+  test('render ProfileSearchWidget for type profile/profile[]', async () => {
+    const providerProps = typeProviderProps
+
+    providerProps.value.field.field_name.value.param.type = 'profile'
+    const { rerender } = renderWithEditorComponentContext(<EditorWidget />, providerProps)
+    expect(screen.getByText('profile')).toBeInTheDocument()
+
+    providerProps.value.field.field_name.value.param.type = 'profile[]'
+    reRenderWithEditorComponentContext(rerender, <EditorWidget />, providerProps)
+    expect(screen.getByText('profile')).toBeInTheDocument()
+  })
+
   test('render nothing for type note/edit/edge/tag/note[]/edit[]/edge[]/tag[]', async () => {
     const providerProps = typeProviderProps
 


### PR DESCRIPTION
There is a new `profile` type validation that we are using for the `authorids` field. When using type `profile/profile[]`, we should render the ProfileSearchWidget.