### PR TITLE
Fix/ Forum reply - don't show reply invitation button when readers won't match

### DIFF
--- a/components/forum/ForumReply.js
+++ b/components/forum/ForumReply.js
@@ -11,12 +11,7 @@ import NoteEditor from '../NoteEditor'
 import ForumReplyContext from './ForumReplyContext'
 import Icon from '../Icon'
 import { getInvitationColors } from '../../lib/forum-utils'
-import {
-  prettyId,
-  prettyInvitationId,
-  forumDate,
-  buildNoteTitle,
-} from '../../lib/utils'
+import { prettyId, prettyInvitationId, forumDate, buildNoteTitle } from '../../lib/utils'
 
 export default function ForumReply({
   note,
@@ -68,6 +63,13 @@ export default function ForumReply({
       setActiveInvitation(null)
       setActiveEditInvitation(activeInvitation ? null : invitation)
     }
+  }
+
+  const isInvitationVisibleToEveryone = (invitation) => {
+    const invitationReaders = Array.isArray(invitation.edit?.note?.readers)
+      ? invitation.edit?.note?.readers
+      : invitation.edit?.note?.readers?.const
+    return invitationReaders?.includes('everyone')
   }
 
   if (collapsed) {
@@ -340,7 +342,11 @@ export default function ForumReply({
           <div className="invitation-buttons">
             <span className="hint">Add:</span>
             {note.replyInvitations.map((inv) => {
-              if (excludedInvitations?.includes(inv.id)) return null
+              if (
+                excludedInvitations?.includes(inv.id) ||
+                (isInvitationVisibleToEveryone(inv) && !note.readers.includes('everyone'))
+              )
+                return null
 
               return (
                 <button

--- a/components/forum/ForumReply.js
+++ b/components/forum/ForumReply.js
@@ -68,7 +68,7 @@ export default function ForumReply({
   const isInvitationVisibleToEveryone = (invitation) => {
     const invitationReaders = Array.isArray(invitation.edit?.note?.readers)
       ? invitation.edit?.note?.readers
-      : invitation.edit?.note?.readers?.const
+      : invitation.edit?.note?.readers?.param?.const
     return invitationReaders?.includes('everyone')
   }
 


### PR DESCRIPTION
this pr should hide reply button in forum replies when
the invitation note reader has everyone but the parent note is not publicly visible

the readers won't match so that the note editor simply fails to load when the invitation button is clicked

an example is public comment invitation on decision reply or review