### PR TITLE
Fix/ Ethics Chair Console: filter out author submissions

### DIFF
--- a/components/webfield/EthicsChairConsole/EthicsChairPaperStatus.js
+++ b/components/webfield/EthicsChairConsole/EthicsChairPaperStatus.js
@@ -80,13 +80,13 @@ const EthicsChairPaperStatus = () => {
         '/notes',
         {
           invitation: submissionId,
-          details: 'replies',
+          details: 'replies,writable',
           select: 'id,number,forum,content,details,invitations,readers',
           sort: 'number:asc',
           domain: venueId,
         },
         { accessToken }
-      )
+      ).then((notes) => notes.filter((note) => !note.details.writable))
 
       const perPaperGroupResultsP = api
         .get(


### PR DESCRIPTION
The Ethics Chair console is still showing the papers submitted by the Ethics Chairs, even though they might not be flagged and shouldn't be visible in the console. This PR filters out the Ethics Chairs' own papers. 