### PR TITLE
Fix/DBLP import - Allow importing from venues that is hosted by openreview

### DIFF
--- a/components/DblpPublicationTable.js
+++ b/components/DblpPublicationTable.js
@@ -282,7 +282,11 @@ const DblpPublicationRow = ({
           <div className="publication-title">
             {category === 'existing-publication' ||
             category === 'existing-different-profile' ? (
-              <a href={`/forum?id=${openReviewId}`} target="_blank" rel="noreferrer">
+              <a
+                href={`/forum?id=${openReviewId}&referrer=[profile](/profile/edit)`}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {title}
               </a>
             ) : (

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -413,7 +413,7 @@ export async function getAllPapersByGroupId(profileId, accessToken) {
   try {
     const notesList = await api.get(
       '/notes',
-      { 'content.authorids': profileId },
+      { 'content.authorids': profileId, invitation: 'dblp.org/-/record' },
       { accessToken, version: 1 }
     )
     return notesList.notes.map((note) => ({

--- a/tests/profilePage.ts
+++ b/tests/profilePage.ts
@@ -412,6 +412,16 @@ test('import paper from dblp', async (t) => {
     .eql(2) // imported 2 papers are removable/unlinkable
 })
 
+test('imported paper has banner back to profile edit', async (t) => {
+  await t
+    .useRole(userBRole)
+    .navigateTo(`http://localhost:${process.env.NEXT_PORT}/profile/edit`)
+    .click(addDBLPPaperToProfileButton)
+    .expect(Selector('div.publication-title').nth(0).find(
+      'a'
+    ).getAttribute('href')).contains('referrer=[profile](/profile/edit)')
+})
+
 test('unlink paper', async (t) => {
   await t
     .useRole(userBRole)


### PR DESCRIPTION
currently dblp import of papers from venues hosted on openreview is not allowed if the venue in dblp and in openreview is the same.

this pr should change it to only check for previously imported dblp papers instead of all papers associated with authors (those submitted to a venue) so that the dblp paper can be imported

this pr should also add referrer param to papers imported from dblp so that the banner can navigate back to user's profile edit page which currently navigates to non-existing group