### PR TITLE
Feature/ PC console: load registration notes for reviewers, ACs, and SACs

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -176,20 +176,16 @@ const ProgramChairConsole = ({ appContext }) => {
       const prefixes = [reviewersId, areaChairsId, seniorAreaChairsId]
       const getRegistrationFormPs = prefixes.map((prefix) =>
         prefix
-          ? api
-              .getAll(
-                '/notes',
-                {
-                  invitation: `${prefix}/-/.*`,
-                  signature: venueId,
-                  select: 'id,invitation,invitations,content.title',
-                  domain: venueId,
-                },
-                { accessToken }
-              )
-              .then((notes) =>
-                notes.filter((note) => note.invitations.some((p) => p.includes('Form')))
-              )
+          ? api.getAll(
+              '/notes',
+              {
+                invitation: `${prefix}/-/.*`,
+                signature: venueId,
+                select: 'id,invitation,invitations,content.title',
+                domain: venueId,
+              },
+              { accessToken }
+            )
           : Promise.resolve(null)
       )
       const getRegistrationFormResultsP = Promise.all(getRegistrationFormPs)
@@ -287,6 +283,7 @@ const ProgramChairConsole = ({ appContext }) => {
       ])
       const invitationResults = results[0]
       const requestForm = results[1]
+      // includes forum notes and replies
       const registrationForms = results[2].flatMap((p) => p ?? [])
       const committeeMemberResults = results[3]
       const notes = results[4].flatMap((note) => {

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -67,8 +67,8 @@ const ProgramChairConsole = ({ appContext }) => {
     customStageInvitations,
     assignmentUrls,
     emailReplyTo,
-    reviewerFilterFuncs,
-    acFilterFuncs,
+    reviewerEmailFuncs,
+    acEmailFuncs,
   } = useContext(WebFieldContext)
   const { setBannerContent } = appContext
   const { user, accessToken, userLoading } = useUser()

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -67,6 +67,8 @@ const ProgramChairConsole = ({ appContext }) => {
     customStageInvitations,
     assignmentUrls,
     emailReplyTo,
+    reviewerFilterFuncs,
+    acFilterFuncs,
   } = useContext(WebFieldContext)
   const { setBannerContent } = appContext
   const { user, accessToken, userLoading } = useUser()

--- a/components/webfield/ProgramChairConsole/AreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatus.js
@@ -292,6 +292,7 @@ const AreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaReviewDat
           })
         })
         // #endregion
+        // TODO: Use pcConsoleData to add registration forms to tableRow
         const tableRows = pcConsoleData.areaChairs.map((areaChairProfileId, index) => {
           let sacId = null
           let sacProfile = null

--- a/components/webfield/ProgramChairConsole/AreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatus.js
@@ -6,11 +6,13 @@ import PaginationLinks from '../../PaginationLinks'
 import Table from '../../Table'
 import WebFieldContext from '../../WebFieldContext'
 import AreaChairStatusMenuBar from './AreaChairStatusMenuBar'
+import { NoteContentV2 } from '../../NoteContent'
 import { buildEdgeBrowserUrl, getProfileLink } from '../../../lib/webfield-utils'
 import { getNoteContentValues } from '../../../lib/forum-utils'
 
 const CommitteeSummary = ({ rowData, bidEnabled, recommendationEnabled, invitations }) => {
-  const { id, preferredName, preferredEmail } = rowData.areaChairProfile ?? {}
+  const { id, preferredName, preferredEmail, registrationNotes } =
+    rowData.areaChairProfile ?? {}
   const { sacProfile, seniorAreaChairId } = rowData.seniorAreaChair ?? {}
   const { areaChairsId, reviewersId, bidName, scoresName, recommendationName } =
     useContext(WebFieldContext)
@@ -102,6 +104,19 @@ const CommitteeSummary = ({ rowData, bidEnabled, recommendationEnabled, invitati
               </>
             )}
           </div>
+        </>
+      )}
+      {registrationNotes?.length > 0 && (
+        <>
+          <strong className="paper-label">Registration Notes:</strong>
+          {registrationNotes.map((note) => (
+            <NoteContentV2
+              key={note.id}
+              id={note.id}
+              content={note.content}
+              noteReaders={note.readers}
+            />
+          ))}
         </>
       )}
     </>

--- a/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
@@ -172,7 +172,7 @@ const AreaChairStatusMenuBar = ({
     shortPhrase,
     seniorAreaChairsId,
     enableQuerySearch,
-    acFilterFuncs,
+    acEmailFuncs,
     areaChairStatusExportColumns: exportColumnsConfig,
     filterOperators: filterOperatorsConfig,
     propertiesAllowed: propertiesAllowedConfig,
@@ -212,7 +212,7 @@ const AreaChairStatusMenuBar = ({
       label: 'Area Chairs with 0 assignments',
       value: 'missingAssignments',
     },
-    ...(acFilterFuncs ?? []),
+    ...(acEmailFuncs ?? []),
   ]
   const exportColumns = [
     { header: 'id', getValue: (p) => p.areaChairProfileId },

--- a/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
@@ -50,7 +50,7 @@ const MessageAreaChairsModal = ({
   const getRecipientRows = () => {
     if (Object.keys(messageOption).includes('filterFunc')) {
       const customFunc = Function('row', messageOption.filterFunc) // eslint-disable-line no-new-func
-      return tableRows.filter(row => customFunc(row));
+      return tableRows.filter((row) => customFunc(row))
     }
 
     switch (messageOption.value) {

--- a/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
@@ -48,6 +48,11 @@ const MessageAreaChairsModal = ({
   }
 
   const getRecipientRows = () => {
+    if (Object.keys(messageOption).includes('filterFunc')) {
+      const customFunc = Function('row', messageOption.filterFunc) // eslint-disable-line no-new-func
+      return tableRows.filter(row => customFunc(row));
+    }
+
     switch (messageOption.value) {
       case 'noBids':
         return tableRows.filter((row) => row.completedBids === 0)
@@ -167,6 +172,7 @@ const AreaChairStatusMenuBar = ({
     shortPhrase,
     seniorAreaChairsId,
     enableQuerySearch,
+    acFilterFuncs,
     areaChairStatusExportColumns: exportColumnsConfig,
     filterOperators: filterOperatorsConfig,
     propertiesAllowed: propertiesAllowedConfig,
@@ -206,6 +212,7 @@ const AreaChairStatusMenuBar = ({
       label: 'Area Chairs with 0 assignments',
       value: 'missingAssignments',
     },
+    ...(acFilterFuncs ?? []),
   ]
   const exportColumns = [
     { header: 'id', getValue: (p) => p.areaChairProfileId },

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -10,6 +10,7 @@ import PaginationLinks from '../../PaginationLinks'
 import Table from '../../Table'
 import WebFieldContext from '../../WebFieldContext'
 import ReviewerStatusMenuBar from './ReviewerStatusMenuBar'
+import { NoteContentV2 } from '../../NoteContent'
 
 const ReviewerSummary = ({ rowData, bidEnabled, invitations }) => {
   const { id, preferredName, preferredEmail } = rowData.reviewerProfile ?? {}
@@ -147,8 +148,10 @@ const ReviewerProgress = ({ rowData, referrerUrl, reviewRatingName }) => {
 
 // modified from notesReviewerStatus.hbs
 const ReviewerStatus = ({ rowData }) => {
-  const numPapers = rowData.notesInfo.length
-  const { numOfPapersWhichCompletedReviews, notesInfo } = rowData
+  const { numOfPapersWhichCompletedReviews, notesInfo, reviewerProfile } = rowData
+  const numPapers = notesInfo.length
+  const { registrationNotes } = reviewerProfile
+
   return (
     <div className="status-column">
       <h4>
@@ -177,6 +180,21 @@ const ReviewerStatus = ({ rowData }) => {
           )
         })}
       </div>
+
+      {registrationNotes?.length > 0 && (
+        <>
+          <br />
+          <strong className="paper-label">Registration Notes:</strong>
+          {registrationNotes.map((note) => (
+            <NoteContentV2
+              key={note.id}
+              id={note.id}
+              content={note.content}
+              noteReaders={note.readers}
+            />
+          ))}
+        </>
+      )}
     </div>
   )
 }

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -217,6 +217,7 @@ const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showConten
     shortPhrase,
     reviewerStatusExportColumns,
     reviewRatingName,
+    reviewerFilterFuncs
   } = useContext(WebFieldContext)
   const { accessToken } = useUser()
   const [pageNumber, setPageNumber] = useState(1)
@@ -332,6 +333,7 @@ const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showConten
         })
         // #endregion
 
+        // TODO: Use pcConsoleData to add registration forms to tableRow
         const tableRows = pcConsoleData.reviewers.map((reviewerProfileId, index) => {
           const notesInfo = sortBy(reviewerNotesMap.get(reviewerProfileId) ?? [], 'noteNumber')
           return {
@@ -410,6 +412,7 @@ const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showConten
         exportColumns={reviewerStatusExportColumns}
         bidEnabled={bidEnabled}
         messageParentGroup={reviewersId}
+        reviewerFilterFuncs={reviewerFilterFuncs}
       />
       <Table
         className="console-table table-striped pc-console-reviewer-status"

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -217,7 +217,6 @@ const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showConten
     shortPhrase,
     reviewerStatusExportColumns,
     reviewRatingName,
-    reviewerFilterFuncs
   } = useContext(WebFieldContext)
   const { accessToken } = useUser()
   const [pageNumber, setPageNumber] = useState(1)
@@ -412,7 +411,6 @@ const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showConten
         exportColumns={reviewerStatusExportColumns}
         bidEnabled={bidEnabled}
         messageParentGroup={reviewersId}
-        reviewerFilterFuncs={reviewerFilterFuncs}
       />
       <Table
         className="console-table table-striped pc-console-reviewer-status"

--- a/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
@@ -56,10 +56,23 @@ const MessageReviewersModal = ({
         return tableRows.filter((row) => row.numCompletedReviews > 0)
       case 'noAssignments':
         return tableRows.filter((row) => !row.notesInfo?.length)
+      case 'custom':
+        const customFunc = Function('row', messageOption.filterFunc) // eslint-disable-line no-new-func
+        return tableRows.filter(row => customFunc(row));
       default:
         return []
     }
   }
+  /*
+  example:
+  reviewerFilterFuncs: [
+    {
+    label: 'Reviewer Two', value: 'custom', filterFunc: `
+    return row.reviewerProfileId === '~Reviewer_ARRTwo1'
+    `
+    },
+  ]
+  */
 
   useEffect(() => {
     if (!messageOption) return
@@ -151,6 +164,7 @@ const ReviewerStatusMenuBar = ({
   exportColumns: exportColumnsConfig,
   bidEnabled,
   messageParentGroup,
+  reviewerFilterFuncs
 }) => {
   const messageAreaChairOptions = [
     ...(bidEnabled
@@ -164,6 +178,7 @@ const ReviewerStatusMenuBar = ({
     { label: 'Reviewers with unsubmitted reviews', value: 'missingReviews' },
     { label: 'Reviewers with submitted reviews', value: 'submittedReviews' },
     { label: 'Reviewers with 0 assignments', value: 'noAssignments' },
+    ...(reviewerFilterFuncs ?? [])
   ]
 
   const exportColumns = exportColumnsConfig ?? [

--- a/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
@@ -49,7 +49,7 @@ const MessageReviewersModal = ({
   const getRecipientRows = () => {
     if (Object.keys(messageOption).includes('filterFunc')) {
       const customFunc = Function('row', messageOption.filterFunc) // eslint-disable-line no-new-func
-      return tableRows.filter(row => customFunc(row));
+      return tableRows.filter((row) => customFunc(row))
     }
 
     switch (messageOption.value) {
@@ -157,9 +157,7 @@ const ReviewerStatusMenuBar = ({
   bidEnabled,
   messageParentGroup,
 }) => {
-  const {
-    reviewerEmailFuncs
-  } = useContext(WebFieldContext)
+  const { reviewerEmailFuncs } = useContext(WebFieldContext)
   const messageAreaChairOptions = [
     ...(bidEnabled
       ? [
@@ -172,7 +170,7 @@ const ReviewerStatusMenuBar = ({
     { label: 'Reviewers with unsubmitted reviews', value: 'missingReviews' },
     { label: 'Reviewers with submitted reviews', value: 'submittedReviews' },
     { label: 'Reviewers with 0 assignments', value: 'noAssignments' },
-    ...(reviewerEmailFuncs ?? [])
+    ...(reviewerEmailFuncs ?? []),
   ]
 
   const exportColumns = exportColumnsConfig ?? [

--- a/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
@@ -47,6 +47,11 @@ const MessageReviewersModal = ({
   }
 
   const getRecipientRows = () => {
+    if (Object.keys(messageOption).includes('filterFunc')) {
+      const customFunc = Function('row', messageOption.filterFunc) // eslint-disable-line no-new-func
+      return tableRows.filter(row => customFunc(row));
+    }
+
     switch (messageOption.value) {
       case 'noBids':
         return tableRows.filter((row) => row.completedBids === 0)
@@ -56,23 +61,10 @@ const MessageReviewersModal = ({
         return tableRows.filter((row) => row.numCompletedReviews > 0)
       case 'noAssignments':
         return tableRows.filter((row) => !row.notesInfo?.length)
-      case 'custom':
-        const customFunc = Function('row', messageOption.filterFunc) // eslint-disable-line no-new-func
-        return tableRows.filter(row => customFunc(row));
       default:
         return []
     }
   }
-  /*
-  example:
-  reviewerFilterFuncs: [
-    {
-    label: 'Reviewer Two', value: 'custom', filterFunc: `
-    return row.reviewerProfileId === '~Reviewer_ARRTwo1'
-    `
-    },
-  ]
-  */
 
   useEffect(() => {
     if (!messageOption) return
@@ -164,8 +156,10 @@ const ReviewerStatusMenuBar = ({
   exportColumns: exportColumnsConfig,
   bidEnabled,
   messageParentGroup,
-  reviewerFilterFuncs
 }) => {
+  const {
+    reviewerFilterFuncs
+  } = useContext(WebFieldContext)
   const messageAreaChairOptions = [
     ...(bidEnabled
       ? [

--- a/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatusMenuBar.js
@@ -158,7 +158,7 @@ const ReviewerStatusMenuBar = ({
   messageParentGroup,
 }) => {
   const {
-    reviewerFilterFuncs
+    reviewerEmailFuncs
   } = useContext(WebFieldContext)
   const messageAreaChairOptions = [
     ...(bidEnabled
@@ -172,7 +172,7 @@ const ReviewerStatusMenuBar = ({
     { label: 'Reviewers with unsubmitted reviews', value: 'missingReviews' },
     { label: 'Reviewers with submitted reviews', value: 'submittedReviews' },
     { label: 'Reviewers with 0 assignments', value: 'noAssignments' },
-    ...(reviewerFilterFuncs ?? [])
+    ...(reviewerEmailFuncs ?? [])
   ]
 
   const exportColumns = exportColumnsConfig ?? [


### PR DESCRIPTION
Adds user defined and labeled emailing functions in the PC Console webfield config

Adds registration notes to the reviewer/AC rows to be accessible by custom functions

Example:
```
reviewerFilterFuncs: [
    {
    label: 'Reviewer Two', filterFunc: `
    return row.reviewerProfileId === '~Reviewer_ARRTwo1'
    `
    },
  ]
```

ARR Use Cases from Legacy Webfields:
1) Messaging users without a maximum load reply, this is usually for recruitment that occurs 2-3 weeks before the submission deadline:
```
var loadNote = row.profile.allNames?.flatMap(name => conferenceStatusData.maximumLoadNotes[name])
      .find(note => note.invitation.includes('/Area_Chairs/'));
var regNote = row.profile.allNames?.flatMap(name => conferenceStatusData.registrationNotes[name])
      .find(note => note.invitation.includes('/Area_Chairs/'));
return regNote !== undefined && loadNote === undefined
```
2) Messaging users without assignments but with a maximum load reply that is greater than 0, this is for emergency reviewing and reaching out to users who marked themselves as available for the cycle
```
var loadNote = row.profile.allNames?.flatMap(name => conferenceStatusData.maximumLoadNotes[name])
      .find(note => note.invitation.includes('/Area_Chairs/'));
return !row.reviewProgressData.numPapers && loadNote?.content['maximum_load'] > 0
```
The mapping is because users can sign off their registration notes with their preferred name but their preferred name is not necessarily their profile ID