### PR TITLE
SAC Console: hide AC tab when there is no assignment invitation

### DIFF
--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -643,6 +643,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             id="areachair-status"
             active={activeTabId === '#areachair-status' ? true : undefined}
             onClick={() => setActiveTabId('#areachair-status')}
+            hidden={assignmentInvitation ? false : true}
           >
             Area Chair Status
           </Tab>


### PR DESCRIPTION
We now allow SACs to be directly assigned to papers instead of to ACs. When the webfield does not contain the `assignmentInvitation`, then we should hide the 'Area Chair Status' tab.