### PR TITLE
Fix/Ethics Chair console - anonymous group data loading logic update

### DIFF
--- a/components/webfield/EthicsChairConsole/EthicsChairMenuBar.js
+++ b/components/webfield/EthicsChairConsole/EthicsChairMenuBar.js
@@ -19,7 +19,7 @@ const EthicsChairMenuBar = ({ tableRowsAll, tableRows, setPaperStatusTabData }) 
     title: ['note.content.title.value'],
     author: ['note.content.authors.value', 'note.content.authorids.value'],
     keywords: ['note.content.keywords.value'],
-    reviewer: ['reviewers'],
+    reviewer: ['ethicsReviewers'],
     numReviewersAssigned: ['numReviewersAssigned'],
     numReviewsDone: ['numReviewsDone'],
     replyCount: ['replyCount'],

--- a/components/webfield/EthicsChairConsole/EthicsChairPaperStatus.js
+++ b/components/webfield/EthicsChairConsole/EthicsChairPaperStatus.js
@@ -76,17 +76,19 @@ const EthicsChairPaperStatus = () => {
 
   const loadSubmissions = async () => {
     try {
-      const notesP = api.getAll(
-        '/notes',
-        {
-          invitation: submissionId,
-          details: 'replies,writable',
-          select: 'id,number,forum,content,details,invitations,readers',
-          sort: 'number:asc',
-          domain: venueId,
-        },
-        { accessToken }
-      ).then((notes) => notes.filter((note) => !note.details.writable))
+      const notesP = api
+        .getAll(
+          '/notes',
+          {
+            invitation: submissionId,
+            details: 'replies,writable',
+            select: 'id,number,forum,content,details,invitations,readers',
+            sort: 'number:asc',
+            domain: venueId,
+          },
+          { accessToken }
+        )
+        .then((notes) => notes.filter((note) => !note.details.writable))
 
       const perPaperGroupResultsP = api
         .get(
@@ -108,16 +110,25 @@ const EthicsChairPaperStatus = () => {
       let allGroupMembers = []
 
       perPaperGroupResults.forEach((p) => {
+        const number = getNumberFromGroup(p.id, submissionName)
         if (p.id.endsWith(`/${ethicsReviewersName}`)) {
           ethicsReviewerGroups.push({
             noteNumber: getNumberFromGroup(p.id, submissionName),
             ...p,
           })
-          allGroupMembers = allGroupMembers.concat(p.members)
+          p.members.forEach((member) => {
+            if (!(number in anonEthicsReviewerGroups)) anonEthicsReviewerGroups[number] = {}
+            if (
+              !(member in anonEthicsReviewerGroups[number]) &&
+              member.includes(anonEthicsReviewerName)
+            ) {
+              anonEthicsReviewerGroups[number][member] = member
+            }
+          })
         } else if (p.id.includes(anonEthicsReviewerName)) {
-          const number = getNumberFromGroup(p.id, submissionName)
           if (!(number in anonEthicsReviewerGroups)) anonEthicsReviewerGroups[number] = {}
-          if (p.members.length) anonEthicsReviewerGroups[number][p.members[0]] = p.id
+          if (p.members.length) anonEthicsReviewerGroups[number][p.id] = p.members[0]
+          allGroupMembers = allGroupMembers.concat(p.members)
         }
       })
 
@@ -127,12 +138,18 @@ const EthicsChairPaperStatus = () => {
         return {
           ...ethicsReviewerGroup,
           members: ethicsReviewerGroup.members.flatMap((member) => {
-            const reviewerAnonGroup = paperAnonEthicsReviewerGroups[member]
-            if (!reviewerAnonGroup) return []
+            let deanonymizedGroup = paperAnonEthicsReviewerGroups[member]
+            let anonymizedGroup = member
+            if (!deanonymizedGroup) {
+              deanonymizedGroup = member
+              anonymizedGroup = Object.keys(paperAnonEthicsReviewerGroups).find(
+                (key) => paperAnonEthicsReviewerGroups[key] === member
+              )
+            }
             return {
-              reviewerProfileId: member,
-              reviewerAnonGroup,
-              anonymousId: getIndentifierFromGroup(reviewerAnonGroup, anonEthicsReviewerName),
+              reviewerProfileId: deanonymizedGroup,
+              anonymizedGroup,
+              anonymousId: getIndentifierFromGroup(anonymizedGroup, anonEthicsReviewerName),
             }
           }),
         }
@@ -216,6 +233,7 @@ const EthicsChairPaperStatus = () => {
               preferredEmail: profile
                 ? profile.content.preferredEmail ?? profile.content.emails[0]
                 : reviewer.reviewerProfileId,
+              type: 'profile',
             }
           }),
           numReviewsDone: ethicsReviews.length,


### PR DESCRIPTION
currently ethics chair console expect the per paper ethics reviewers group to contain the tilde ids of ethics reviewers
while the new logic has changed to member of per paper ethics reviewers group to the anonymous id group of each assigned ethics reviewer

this pr should update the mapping logic accordingly
the changes should be compatible with the case where tilde ids are added as member of ethics reviewers group directly (for example NeurIPS 2023)

this pr should also fix query searching ethics reviewers by name or email (right now this is not working properly)