### PR TITLE
Fix/ Tasks page: mark task as incomplete if the reply is deleted

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,6 @@ import get from 'lodash/get'
 import intersection from 'lodash/intersection'
 import union from 'lodash/union'
 import uniq from 'lodash/uniq'
-import { min } from 'lodash'
 
 /**
  * Get the human readable version of a group or profile id

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -777,7 +777,7 @@ export function formatTasksData(
     if (inv.noteInvitation) {
       if (
         inv.details.repliedNotes?.length ||
-        (inv.apiVersion === 2 && inv.details.repliedEdits?.length)
+        (inv.apiVersion === 2 && inv.details.repliedEdits?.length && !inv.details.repliedEdits.slice(-1)[0].note.ddate)
       ) {
         inv.completed = true
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -777,7 +777,7 @@ export function formatTasksData(
     if (inv.noteInvitation) {
       if (
         inv.details.repliedNotes?.length ||
-        (inv.apiVersion === 2 && inv.details.repliedEdits?.length && !inv.details.repliedEdits.slice(-1)[0].note.ddate)
+        (inv.apiVersion === 2 && inv.details.repliedEdits?.length && !inv.details.repliedEdits.slice(-1)[0].note?.ddate)
       ) {
         inv.completed = true
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,7 @@ import get from 'lodash/get'
 import intersection from 'lodash/intersection'
 import union from 'lodash/union'
 import uniq from 'lodash/uniq'
+import { min } from 'lodash'
 
 /**
  * Get the human readable version of a group or profile id
@@ -775,11 +776,21 @@ export function formatTasksData(
     }
 
     if (inv.noteInvitation) {
-      if (
-        inv.details.repliedNotes?.length ||
-        (inv.apiVersion === 2 && inv.details.repliedEdits?.length && !inv.details.repliedEdits.slice(-1)[0].note?.ddate)
-      ) {
+      if (inv.details.repliedNotes?.length > 0) {
         inv.completed = true
+      } else if (inv.apiVersion === 2 && inv.details.repliedEdits?.length > 0) {
+        const noteIds = new Set()
+        const sortedEdits = inv.details.repliedEdits.sort((a, b) => a.tcdate - b.tcdate)
+        sortedEdits.forEach((edit) => {
+          if (!edit.note) return
+          if (edit.note.ddate) {
+            noteIds.delete(edit.note.id)
+          } else {
+            noteIds.add(edit.note.id)
+          }
+        })
+        const minReplies = inv.minReplies || 1
+        inv.completed = noteIds.size >= minReplies
       }
       // can't locate a unique noteId when there are multiple repliedNotes
       if (inv.apiVersion === 1) {

--- a/tests/tasksPage.ts
+++ b/tests/tasksPage.ts
@@ -1,10 +1,11 @@
 import { Selector, Role } from 'testcafe'
 import { hasTaskUser, hasNoTaskUser } from './utils/api-helper'
 
+const confirmDeleteModal = Selector('#confirm-delete-modal')
 const hasTaskUserRole = Role(`http://localhost:${process.env.NEXT_PORT}`, async (t) => {
   await t
     .click(Selector('a').withText('Login'))
-    .typeText(Selector('#email-input'), hasTaskUser.email)
+    .typeText(Selector('#email-input'), 'test@mail.com')
     .typeText(Selector('#password-input'), hasTaskUser.password)
     .click(Selector('button').withText('Login to OpenReview'))
 })
@@ -12,92 +13,37 @@ const hasTaskUserRole = Role(`http://localhost:${process.env.NEXT_PORT}`, async 
 // eslint-disable-next-line no-unused-expressions
 fixture`Tasks Page`
 
-test('should open tasks page and complete pending task', async (t) => {
-  await t
-    .useRole(hasTaskUserRole)
-    .navigateTo(`http://localhost:${process.env.NEXT_PORT}`)
-    .click(Selector('a').withText('Tasks'))
-    // should see 1 task in testvenue 2020 conference
-    .expect(Selector('div.tasks-container').find('ul.list-unstyled').nth(0).childElementCount)
-    .eql(1)
-    .click(Selector('span.task-count-message')) // perform the task
-    .click(Selector('a').withText('Paper1 Official Review'))
-    .typeText(Selector('input').withAttribute('name', 'title'), 'test title') // fill in comment title
-    .typeText(Selector('textarea').withAttribute('name', 'review'), 'test comment') // fill in comment content
-    .click(Selector('input').withAttribute('name', 'rating')) // fill in comment content
-    .click(
-      Selector('div.dropdown_content div').withText(
-        '9: Top 15% of accepted papers, strong accept'
-      )
-    ) // fill in comment content
-    .click(
-      Selector('input')
-        .withAttribute('name', 'confidence')
-        .withAttribute(
-          'value',
-          '4: The reviewer is confident but not absolutely certain that the evaluation is correct'
-        )
-    ) // fill in comment content
-    .click(Selector('button').withText('Submit')) // submit
-
-    // should see 0 pending task and 1 completed
-    .click(Selector('a').withText('Tasks')) // go tasks page
-    .expect(Selector('span.task-count-message').innerText)
-    .eql('Show 0 pending tasks and 1 completed task')
-})
-
 test('task should change when note is deleted and restored', async (t) => {
   await t
     .useRole(hasTaskUserRole)
     .navigateTo(`http://localhost:${process.env.NEXT_PORT}/tasks`)
     .click(Selector('span.task-count-message'))
-    .click(Selector('a').withText('Paper1 Official Review')) // go to forum page
+    .click(Selector('a').withText('Submission1 Official Review')) // go to forum page
     .wait(2000)
-    .click(Selector('#note_children').find('button.trash_button'))
+    .click(Selector('#forum-replies').find('button').withAttribute('type', 'button').nth(5))
+    .expect(confirmDeleteModal.exists)
+    .ok()
+    .click(confirmDeleteModal.find('.modal-footer > button').withText('Delete'))
+    .expect(confirmDeleteModal.exists)
+    .notOk()
+    .expect(Selector('.note').hasClass('deleted'))
+    .ok()
     .click(Selector('a').withText('Tasks'))
     .wait(2000)
     .expect(Selector('span.task-count-message').innerText)
     .eql('Show 1 pending task')
     .click(Selector('span.task-count-message'))
-    .click(Selector('a').withText('Paper1 Official Review'))
-    .click(Selector('.note_editor').find('button').withText('Cancel')) // don't add new comment
-    .click(Selector('button').withText('Restore'))
+    .click(Selector('a').withText('Submission1 Official Review'))
+    .wait(2000)
+    .click(Selector('#forum-replies').find('button').withAttribute('type', 'button').nth(4))
+    .expect(confirmDeleteModal.exists)
+    .ok()
+    .click(confirmDeleteModal.find('.modal-footer > button').withText('Restore'))
+    .expect(confirmDeleteModal.exists)
+    .notOk()
+    .expect(Selector('.note').hasClass('deleted'))
+    .notOk()
     .click(Selector('a').withText('Tasks'))
     .expect(Selector('span.task-count-message').innerText)
     .eql('Show 0 pending tasks and 1 completed task')
-})
-
-test('user with no tasks should see an empty tasks page', async (t) => {
-  await t
-    .navigateTo(`http://localhost:${process.env.NEXT_PORT}`)
-    // no task user login
-    .click(Selector('a').withText('Login'))
-    .typeText(Selector('#email-input'), hasNoTaskUser.email)
-    .typeText(Selector('#password-input'), hasNoTaskUser.password)
-    .click(Selector('button').withText('Login to OpenReview'))
-    .click(Selector('a').withText('Tasks'))
-    // should see no task message
-    .expect(Selector('p.empty-message').exists)
-    .ok()
-    .expect(Selector('p.empty-message').textContent)
-    .eql('No current pending or completed tasks')
-})
-
-test('should not show referrer banner after navigation', async (t) => {
-  await t
-    .useRole(hasTaskUserRole)
-    .navigateTo(`http://localhost:${process.env.NEXT_PORT}/tasks`)
-    .click(Selector('span.task-count-message'))
-    .click(Selector('a').withText('Paper1 Official Review')) // go to the actual forum page
-    .expect(Selector('.banner').find('a').withText('Back to Tasks').exists)
-    .ok() // banner shows back to tasks
-    .click(Selector('a.home.push-link')) // go to index page
-    .expect(Selector('.banner').find('a').withText('Back to Tasks').exists)
-    .notOk() // banner should not show back to tasks anymore
-    .expect(
-      Selector('.banner')
-        .find('span.tagline')
-        .withText('Open Peer Review. Open Publishing. Open Access.').exists
-    )
-    .ok()
 })

--- a/tests/tasksPageV1.ts
+++ b/tests/tasksPageV1.ts
@@ -1,0 +1,103 @@
+import { Selector, Role } from 'testcafe'
+import { hasTaskUser, hasNoTaskUser } from './utils/api-helper'
+
+const hasTaskUserRole = Role(`http://localhost:${process.env.NEXT_PORT}`, async (t) => {
+  await t
+    .click(Selector('a').withText('Login'))
+    .typeText(Selector('#email-input'), hasTaskUser.email)
+    .typeText(Selector('#password-input'), hasTaskUser.password)
+    .click(Selector('button').withText('Login to OpenReview'))
+})
+
+// eslint-disable-next-line no-unused-expressions
+fixture`Tasks PageV1`
+
+test('should open tasks page and complete pending task', async (t) => {
+  await t
+    .useRole(hasTaskUserRole)
+    .navigateTo(`http://localhost:${process.env.NEXT_PORT}`)
+    .click(Selector('a').withText('Tasks'))
+    // should see 1 task in testvenue 2020 conference
+    .expect(Selector('div.tasks-container').find('ul.list-unstyled').nth(0).childElementCount)
+    .eql(1)
+    .click(Selector('span.task-count-message')) // perform the task
+    .click(Selector('a').withText('Paper1 Official Review'))
+    .typeText(Selector('input').withAttribute('name', 'title'), 'test title') // fill in comment title
+    .typeText(Selector('textarea').withAttribute('name', 'review'), 'test comment') // fill in comment content
+    .click(Selector('input').withAttribute('name', 'rating')) // fill in comment content
+    .click(
+      Selector('div.dropdown_content div').withText(
+        '9: Top 15% of accepted papers, strong accept'
+      )
+    ) // fill in comment content
+    .click(
+      Selector('input')
+        .withAttribute('name', 'confidence')
+        .withAttribute(
+          'value',
+          '4: The reviewer is confident but not absolutely certain that the evaluation is correct'
+        )
+    ) // fill in comment content
+    .click(Selector('button').withText('Submit')) // submit
+
+    // should see 0 pending task and 1 completed
+    .click(Selector('a').withText('Tasks')) // go tasks page
+    .expect(Selector('span.task-count-message').innerText)
+    .eql('Show 0 pending tasks and 1 completed task')
+})
+
+test('task should change when note is deleted and restored', async (t) => {
+  await t
+    .useRole(hasTaskUserRole)
+    .navigateTo(`http://localhost:${process.env.NEXT_PORT}/tasks`)
+    .click(Selector('span.task-count-message'))
+    .click(Selector('a').withText('Paper1 Official Review')) // go to forum page
+    .wait(2000)
+    .click(Selector('#note_children').find('button.trash_button'))
+    .click(Selector('a').withText('Tasks'))
+    .wait(2000)
+    .expect(Selector('span.task-count-message').innerText)
+    .eql('Show 1 pending task')
+    .click(Selector('span.task-count-message'))
+    .click(Selector('a').withText('Paper1 Official Review'))
+    .click(Selector('.note_editor').find('button').withText('Cancel')) // don't add new comment
+    .click(Selector('button').withText('Restore'))
+    .click(Selector('a').withText('Tasks'))
+    .expect(Selector('span.task-count-message').innerText)
+    .eql('Show 0 pending tasks and 1 completed task')
+})
+
+test('user with no tasks should see an empty tasks page', async (t) => {
+  await t
+    .navigateTo(`http://localhost:${process.env.NEXT_PORT}`)
+    // no task user login
+    .click(Selector('a').withText('Login'))
+    .typeText(Selector('#email-input'), hasNoTaskUser.email)
+    .typeText(Selector('#password-input'), hasNoTaskUser.password)
+    .click(Selector('button').withText('Login to OpenReview'))
+    .click(Selector('a').withText('Tasks'))
+    // should see no task message
+    .expect(Selector('p.empty-message').exists)
+    .ok()
+    .expect(Selector('p.empty-message').textContent)
+    .eql('No current pending or completed tasks')
+})
+
+test('should not show referrer banner after navigation', async (t) => {
+  await t
+    .useRole(hasTaskUserRole)
+    .navigateTo(`http://localhost:${process.env.NEXT_PORT}/tasks`)
+    .click(Selector('span.task-count-message'))
+    .click(Selector('a').withText('Paper1 Official Review')) // go to the actual forum page
+    .expect(Selector('.banner').find('a').withText('Back to Tasks').exists)
+    .ok() // banner shows back to tasks
+    .click(Selector('a.home.push-link')) // go to index page
+    .expect(Selector('.banner').find('a').withText('Back to Tasks').exists)
+    .notOk() // banner should not show back to tasks anymore
+    .expect(
+      Selector('.banner')
+        .find('span.tagline')
+        .withText('Open Peer Review. Open Publishing. Open Access.').exists
+    )
+    .ok()
+})

--- a/unitTests/ConsoleTaskList.test.js
+++ b/unitTests/ConsoleTaskList.test.js
@@ -658,7 +658,11 @@ describe('ConsoleTaskList', () => {
         duedate: now + oneDay,
         edit: {
           note: {
-            id: { param: { withInvitation: `${venueId}/${submissionName}5/Official_Review1/-/Rating` } },
+            id: {
+              param: {
+                withInvitation: `${venueId}/${submissionName}5/Official_Review1/-/Rating`,
+              },
+            },
             forum: 'paper5Id',
             replyto: 'review1Id',
           },
@@ -927,7 +931,9 @@ describe('ConsoleTaskList', () => {
       expect(metaReviewRevisionLink.nextElementSibling).toHaveClass('warning')
       expect(metaReviewRevisionLink).toHaveAttribute(
         'href',
-        expect.stringContaining('id=paper5Id&noteId=paper5Id&invitationId=ICML.cc/2023/Conference/Submission5/Meta_Review1/-/Revision')
+        expect.stringContaining(
+          'id=paper5Id&noteId=paper5Id&invitationId=ICML.cc/2023/Conference/Submission5/Meta_Review1/-/Revision'
+        )
       )
       // #endregion
 
@@ -1719,6 +1725,8 @@ describe('ConsoleTaskList', () => {
           repliedEdits: [
             {
               id: 'metaReviewSACEditId',
+              tcdate: 122334445555,
+              note: { id: '1' },
             },
           ],
         },
@@ -1750,16 +1758,18 @@ describe('ConsoleTaskList', () => {
           repliedEdits: [
             {
               id: 'metaReviewSACEditId',
+              tcdate: 122334445555,
               note: {
                 id: 'revision1',
-              }
+              },
             },
             {
               id: 'metaReviewSACEditId2',
+              tcdate: 122334445556,
               note: {
                 id: 'revision1',
-                ddate: 122334445555
-              }
+                ddate: 122334445555,
+              },
             },
           ],
         },

--- a/unitTests/ConsoleTaskList.test.js
+++ b/unitTests/ConsoleTaskList.test.js
@@ -1723,6 +1723,47 @@ describe('ConsoleTaskList', () => {
           ],
         },
       },
+      {
+        id: `${venueId}/${submissionName}6/-/Meta_Review_SAC_Revision`,
+        duedate: now - fourDays,
+        invitees: [`${venueId}/${submissionName}5/${seniorAreaChairName}`],
+        edit: {
+          note: {
+            id: {
+              param: {
+                withInvitation: `${venueId}/${submissionName}6/-/Meta_Review`,
+              },
+            },
+            forum: 'paper6Id',
+            replyto: 'paper6Id',
+          },
+        },
+        details: {
+          replytoNote: {
+            id: 'paper6Id',
+            forum: 'paper6Id',
+            content: {
+              title: { value: 'Paper 6 Title' },
+            },
+          },
+          repliedNotes: [], // signature is still ac so repliedNotes is empty
+          repliedEdits: [
+            {
+              id: 'metaReviewSACEditId',
+              note: {
+                id: 'revision1',
+              }
+            },
+            {
+              id: 'metaReviewSACEditId2',
+              note: {
+                id: 'revision1',
+                ddate: 122334445555
+              }
+            },
+          ],
+        },
+      },
     ]
     edgeInvitations = []
     tagInvitations = []
@@ -1740,7 +1781,8 @@ describe('ConsoleTaskList', () => {
     await waitFor(() => {
       const registrationLink = screen.getByText('Senior Area Chair Registration')
       const metaReviewAgreementLink = screen.getByText('Submission5 Meta Review Agreement')
-      const metaReviewRevisionLink = screen.getByText('Submission5 Meta Review SAC Revision')
+      const metaReview5RevisionLink = screen.getByText('Submission5 Meta Review SAC Revision')
+      const metaReview6RevisionLink = screen.getByText('Submission6 Meta Review SAC Revision')
 
       expect(registrationLink).toBeInTheDocument()
       expect(registrationLink.parentElement.parentElement).not.toHaveClass('completed')
@@ -1765,16 +1807,28 @@ describe('ConsoleTaskList', () => {
         expect.stringContaining('id=paper5Id&noteId=metaReviewId&invitationId=')
       )
 
-      expect(metaReviewRevisionLink).toBeInTheDocument()
-      expect(metaReviewRevisionLink.parentElement.parentElement).toHaveClass('completed')
-      expect(metaReviewRevisionLink.nextElementSibling).toHaveClass('expired')
-      expect(metaReviewRevisionLink).toHaveAttribute(
+      expect(metaReview5RevisionLink).toBeInTheDocument()
+      expect(metaReview5RevisionLink.parentElement.parentElement).toHaveClass('completed')
+      expect(metaReview5RevisionLink.nextElementSibling).toHaveClass('expired')
+      expect(metaReview5RevisionLink).toHaveAttribute(
         'href',
         expect.stringContaining('id=paper5Id&noteId=paper5Id')
       )
       expect(screen.getByText('Paper 5 Title')).toHaveAttribute(
         'href',
         expect.stringContaining('id=paper5Id')
+      )
+
+      expect(metaReview6RevisionLink).toBeInTheDocument()
+      expect(metaReview6RevisionLink.parentElement.parentElement).not.toHaveClass('completed')
+      expect(metaReview6RevisionLink.nextElementSibling).toHaveClass('expired')
+      expect(metaReview6RevisionLink).toHaveAttribute(
+        'href',
+        expect.stringContaining('id=paper6Id&noteId=paper6Id')
+      )
+      expect(screen.getByText('Paper 6 Title')).toHaveAttribute(
+        'href',
+        expect.stringContaining('id=paper6Id')
       )
     })
   })


### PR DESCRIPTION
It seems that check to mark as task as complete is the existence of the `repliedEdits` but some of these edits could be deleting the reply note. 

If a review is deleted, the task still appears a complete and it should be back to pending.

This PR checks the invitation has repliedEdits and the last edit doesn't content a note.ddate assuming the edits are sorted chronologically. @carlosmondra please confirm this is the case.

I created a new test case for API 2 tasks. 