### PR TITLE
Fix/ Edge browser - search text of dummy profiles

### DIFF
--- a/components/browser/EdgeBrowser.js
+++ b/components/browser/EdgeBrowser.js
@@ -220,7 +220,7 @@ export default class EdgeBrowser extends React.Component {
                 isDummyProfile: true,
                 isInvitedProfile: true,
               },
-              searchText: key,
+              searchText: `${key}\n${prettyId(key)}`,
               traverseEdgesCount: groupedEdges[key].count,
             }
           })


### PR DESCRIPTION
in edge browser when an assigned reviewer is removed from the reviewers pool without deleting the edge
the reviewer is added to the column as a dummy profile  with only the tilde id

currently its search text is also the tilde id

this caused the reviewer to appear in search result when part of the name is searched but not when the full name or tilde id is search.
for example the reviewer's tilde id is ~Abc_Edf1
the search will work when user search for 
- abc
- edf
- abc_edf
but not when search term is
- abc edf - because of the missing underscore
- ~Abc_Edf1 - because the regex has a word boundary \b and ~ will break it

this pr should add the pretty id of the tilde id to the search text so that when user search for "abc edf" the reviewer can be found.

this is only done for reviewers with an edge but not in the reviewers pool

for the dummy profile created because of the reviewer does not have a profile yet, the change won't make sense because the id/key will be an email