### PR TITLE
Feature/ User moderation - allow moderator to search and accept a profile

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -893,6 +893,7 @@ export function formatDateTime(timestamp, option = {}) {
     minute: '2-digit',
     second: '2-digit',
     timeZoneName: undefined,
+    hour12: true,
   }
   // eslint-disable-next-line no-param-reassign
   option = { ...defaultOption, ...option }
@@ -904,6 +905,7 @@ export function formatDateTime(timestamp, option = {}) {
     hour: option.hour,
     minute: option.minute,
     second: option.second,
+    hour12: option.hour12,
     ...(option.timeZoneName && { timeZoneName: option.timeZoneName }),
   }
   return new Date(timestamp).toLocaleDateString(option.locale ?? 'en-US', dateSettings)
@@ -1276,7 +1278,9 @@ export function prettyTasksInvitationId(invitationId) {
   const invMatches = invitationId.match(/\/(Paper\d+|Submission\d+)\//)
   if (invMatches) {
     paperStr = invMatches[1]
-    const anonReviewerMatches = invitationId.match(/\/(AnonReviewer\d+|Reviewer_\w+|Official_Review\d+|Meta_Review\d+)\//)
+    const anonReviewerMatches = invitationId.match(
+      /\/(AnonReviewer\d+|Reviewer_\w+|Official_Review\d+|Meta_Review\d+)\//
+    )
     if (anonReviewerMatches) {
       paperStr = `${paperStr} ${anonReviewerMatches[1].replace('_', ' ')}`
     }

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -1756,11 +1756,13 @@ const UserModerationQueue = ({
     'Inactive',
     'Merged',
   ].map((p) => ({ label: p, value: p }))
+  const twoWeeksAgo = dayjs().subtract(2, 'week').valueOf()
 
   const getProfiles = async () => {
     const queryOptions = onlyModeration ? { needsModeration: true } : {}
     const cleanSearchTerm = filters.term?.trim()
     const shouldSearchProfile = profileStateOption === 'All' && cleanSearchTerm
+    const sortKey = onlyModeration ? 'tmdate' : 'tcdate'
     let searchQuery = { fullname: cleanSearchTerm?.toLowerCase() }
     if (cleanSearchTerm?.startsWith('~')) searchQuery = { id: cleanSearchTerm }
     if (cleanSearchTerm?.includes('@')) searchQuery = { email: cleanSearchTerm.toLowerCase() }
@@ -1771,7 +1773,7 @@ const UserModerationQueue = ({
         {
           ...queryOptions,
 
-          ...(!shouldSearchProfile && { sort: `tcdate:${descOrder ? 'desc' : 'asc'}` }),
+          ...(!shouldSearchProfile && { sort: `${sortKey}:${descOrder ? 'desc' : 'asc'}` }),
           limit: pageSize,
           offset: (pageNumber - 1) * pageSize,
           withBlocked: onlyModeration ? undefined : true,
@@ -1981,7 +1983,7 @@ const UserModerationQueue = ({
       </h4>
       {showSortButton && profiles && profiles.length !== 0 && (
         <button className="btn btn-xs sort-button" onClick={() => setDescOrder((p) => !p)}>{`${
-          descOrder ? 'Sort: Newest First' : 'Sort: Oldest First'
+          descOrder ? 'Sort: Most Recently Modified' : 'Sort: Least Recently Modified'
         }`}</button>
       )}
 
@@ -2028,7 +2030,35 @@ const UserModerationQueue = ({
                   </a>
                 </span>
                 <span className="col-email text-muted">{profile.content.preferredEmail}</span>
-                <span className="col-created">{formatDateTime(profile.tcdate)}</span>
+                <span className="col-created">
+                  <span
+                    className={`${profile.tmdate < twoWeeksAgo ? 'passed-moderation' : ''}`}
+                  >
+                    {formatDateTime(profile.tmdate, {
+                      day: '2-digit',
+                      month: 'short',
+                      year: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      second: undefined,
+                      timeZoneName: undefined,
+                      hour12: false,
+                    })}
+                  </span>
+                  /
+                  <span>
+                    {formatDateTime(profile.tcdate, {
+                      day: '2-digit',
+                      month: 'short',
+                      year: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      second: undefined,
+                      timeZoneName: undefined,
+                      hour12: false,
+                    })}
+                  </span>
+                </span>
                 <span className="col-status">
                   <span className={`label label-${profile.password ? 'success' : 'danger'}`}>
                     password

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -2031,23 +2031,29 @@ const UserModerationQueue = ({
                 </span>
                 <span className="col-email text-muted">{profile.content.preferredEmail}</span>
                 <span className="col-created">
+                  {profile.tcdate !== profile.tmdate && (
+                    <>
+                      <span>
+                        {formatDateTime(profile.tcdate, {
+                          day: '2-digit',
+                          month: 'short',
+                          year: '2-digit',
+                          hour: '2-digit',
+                          minute: '2-digit',
+                          second: undefined,
+                          timeZoneName: undefined,
+                          hour12: false,
+                        })}
+                      </span>
+                      {' / '}
+                    </>
+                  )}
                   <span
-                    className={`${profile.tmdate < twoWeeksAgo ? 'passed-moderation' : ''}`}
+                    className={`${
+                      onlyModeration && profile.tmdate < twoWeeksAgo ? 'passed-moderation' : ''
+                    }`}
                   >
                     {formatDateTime(profile.tmdate, {
-                      day: '2-digit',
-                      month: 'short',
-                      year: '2-digit',
-                      hour: '2-digit',
-                      minute: '2-digit',
-                      second: undefined,
-                      timeZoneName: undefined,
-                      hour12: false,
-                    })}
-                  </span>
-                  /
-                  <span>
-                    {formatDateTime(profile.tcdate, {
                       day: '2-digit',
                       month: 'short',
                       year: '2-digit',

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -2074,6 +2074,15 @@ const UserModerationQueue = ({
                     </>
                   ) : (
                     <>
+                      {profile.state === 'Needs Moderation' && (
+                        <button
+                          type="button"
+                          className="btn btn-xs"
+                          onClick={() => acceptUser(profile.id)}
+                        >
+                          <Icon name="ok-circle" /> Accept
+                        </button>
+                      )}{' '}
                       {!(
                         profile.state === 'Blocked' ||
                         profile.state === 'Limited' ||
@@ -2108,7 +2117,7 @@ const UserModerationQueue = ({
                           {`${profile.state === 'Blocked' ? 'Unblock' : 'Block'}`}
                         </button>
                       )}{' '}
-                      {state !== 'Merged' && (
+                      {state !== 'Merged' && profile.state !== 'Needs Moderation' && (
                         <button
                           type="button"
                           className="btn btn-xs"

--- a/styles/components.scss
+++ b/styles/components.scss
@@ -1098,7 +1098,7 @@ table.table-minimal {
 
 // User Moderation
 .moderation-status {
-  width: 1100px;
+  width: 1150px;
   margin: 1.75rem auto 0 -1rem;
   display: flex;
   align-items: center;
@@ -1137,7 +1137,7 @@ table.table-minimal {
   }
 
   .profiles-list {
-    width: 1100px;
+    width: 1150px;
     margin: 1.75rem 0;
     min-height: 100px;
 
@@ -1171,7 +1171,11 @@ table.table-minimal {
         width: 250px;
       }
       &.col-created {
-        width: 200px;
+        width: 240px;
+
+        .passed-moderation {
+          color: constants.$orRed;
+        }
       }
       &.col-status {
         width: 200px;


### PR DESCRIPTION
currently accept profile action button is only available in the moderate only queue and not available in the all profiles queue
so when there are many profiles pending moderation it's tedious for the moderator to find a profile and activate it.

this pr should allow moderator to search a pending moderation profile from all profiles and accept it.
delete button is hidden for needs moderation profiles to make space for accept button


this pr should also sort the profiles pending moderation by modification date so that those old profiles which are claimed can be seen

this pr should also color the modification date of the profiles which has passed 2 weeks