### PR TITLE
Fix/ Group directory: sort child groups correctly

### DIFF
--- a/components/webfield/GroupDirectory.js
+++ b/components/webfield/GroupDirectory.js
@@ -40,8 +40,8 @@ export default function GroupDirectory({ appContext }) {
                 // Sort by year in descending order, or if year is not present sort alphabetically
                 const yearA = a.match(/.*(\d{4})/)?.[1] ?? 0
                 const yearB = b.match(/.*(\d{4})/)?.[1] ?? 0
-                if (!yearA && !yearB) {
-                  return prettyId(a.groupId).localeCompare(prettyId(b.groupId))
+                if ((!yearA && !yearB) || (yearA === yearB)) {
+                  return prettyId(a).localeCompare(prettyId(b))
                 }
                 return yearA > yearB ? -1 : 1
               })


### PR DESCRIPTION
Fix alphabetical sort. Add case for groups with matching years.

Fixes #1895 