### PR TITLE
Fix/ DBLP import - allow up to 500 papers to be imported each time

### DIFF
--- a/components/DblpImportModal.js
+++ b/components/DblpImportModal.js
@@ -64,6 +64,7 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
   const modalEl = useRef(null)
   const dblpNames = useRef(null)
   const { accessToken } = useContext(UserContext)
+  const maxNumberofPublicationsToImport = 500
 
   const getExistingFromDblpPubs = (allDblpPubs) => {
     const existingPubsInAllDblpPubs = allDblpPubs.filter(
@@ -329,6 +330,7 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
                 }
                 selectedPublications={selectedPublications}
                 setSelectedPublications={setSelectedPublications}
+                maxNumberofPublicationsToImport={maxNumberofPublicationsToImport}
               />
             )}
 
@@ -344,7 +346,9 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
               {selectedPublications.length !== 0 && (
                 <strong>
                   {inflect(selectedPublications.length, 'publication', 'publications', true)}{' '}
-                  selected
+                  selected{' '}
+                  {selectedPublications.length === maxNumberofPublicationsToImport &&
+                    '(max allowed)'}
                 </strong>
               )}
             </div>

--- a/components/DblpPublicationTable.js
+++ b/components/DblpPublicationTable.js
@@ -15,6 +15,7 @@ export default function DblpPublicationTable({
   selectedPublications,
   setSelectedPublications,
   orPublicationsImportedByOtherProfile,
+  maxNumberofPublicationsToImport,
 }) {
   const { accessToken } = useContext(UserContext)
   const [profileIdsRequested, setProfileIdsRequested] = useState([])
@@ -52,7 +53,12 @@ export default function DblpPublicationTable({
       ?.map((p) => p.key)
       .filter((q) => pubsCouldImport.includes(q))
     if (e.target.checked) {
-      setSelectedPublications([...selectedPublications, ...publicationKeysOfYear])
+      setSelectedPublications(
+        [...selectedPublications, ...publicationKeysOfYear].slice(
+          0,
+          maxNumberofPublicationsToImport
+        )
+      )
     } else {
       setSelectedPublications(
         selectedPublications.filter((p) => !publicationKeysOfYear.includes(p))
@@ -63,7 +69,9 @@ export default function DblpPublicationTable({
 
   const selectPublication = (publicationKey) => (checked) => {
     if (checked) {
-      setSelectedPublications([...selectedPublications, publicationKey])
+      setSelectedPublications(
+        [...selectedPublications, publicationKey].slice(0, maxNumberofPublicationsToImport)
+      )
     } else {
       setSelectedPublications(selectedPublications.filter((p) => p !== publicationKey))
     }
@@ -112,7 +120,9 @@ export default function DblpPublicationTable({
 
   return (
     <>
-      <Table headings={headings} />
+      <Table
+        headings={pubsCouldImport.length <= maxNumberofPublicationsToImport ? headings : []}
+      />
       <div>
         <Accordion
           sections={Object.keys(dblpPublicationsGroupedByYear)


### PR DESCRIPTION
when a lot of papers (>1000) are selected for import
the browser will report error for insufficient resource
api will report error for max reply reached
cloud function to abstract extraction may throw service unavailable error (reason is unknown)

so this pr should allow user to select up to 500 papers for import to avoid error so that user don't keep retry importing which  may cause the process function queue to be blocked