### PR TITLE
Group editor: add fromName and fromEmail properties when sending messages

### DIFF
--- a/components/group/GroupMembers.js
+++ b/components/group/GroupMembers.js
@@ -70,6 +70,8 @@ const MessageMemberModal = ({
           parentGroup: groupId,
           ...(cleanReplytoEmail && { replyTo: cleanReplytoEmail }),
           useJob: true,
+          fromName: groupDomainContent?.subtitle?.value,
+          fromEmail: `${groupDomainContent?.subtitle?.value.replace(' ', '').toLowerCase()}-notifications@openreview.net`,
         },
         { accessToken }
       )


### PR DESCRIPTION
When we use the meta invitation, we need to set the properties `fromName` and `fromEmail` to indicate the venue that is sending the notifications.