### PR TITLE
Fix/Edge browser - fix entity with 0 quota

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -589,7 +589,7 @@ export default function Column(props) {
       const { filteredRows, queryIsInvalid } = filterCollections(
         colItems.map((p) => {
           const customLoad = getQuota(p)
-          const quotaNotReached = !customLoad || p.traverseEdgesCount < customLoad
+          const quotaNotReached = customLoad === undefined || p.traverseEdgesCount < customLoad
 
           return {
             ...p,

--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -589,7 +589,7 @@ export default function Column(props) {
       const { filteredRows, queryIsInvalid } = filterCollections(
         colItems.map((p) => {
           const customLoad = getQuota(p)
-          const quotaNotReached = customLoad === undefined || p.traverseEdgesCount < customLoad
+          const quotaNotReached = p.traverseEdgesCount < customLoad
 
           return {
             ...p,
@@ -629,7 +629,7 @@ export default function Column(props) {
 
     return colItems.filter((p) => {
       const customLoad = getQuota(p)
-      if (customLoad === undefined) return true
+      if (customLoad === undefined) return false
       return p.traverseEdgesCount < customLoad
     })
   }


### PR DESCRIPTION
currently when the custom quota is 0, the quotaNotReached value will be wrong
and it will cause the entity to appear in column even if the filter quota reached checkbox is checked

this pr should fix this issue