### PR TITLE
Fix/Edge browser - Bid/Recommendation edge browser url

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -81,7 +81,7 @@ export default function Column(props) {
     editAndBrowserInvitations.some((p) => p.id.includes('Custom_Max_Papers'))
 
   // Helpers
-  const formatEdge = (edge) => ({
+  const formatEdge = (edge, invitation) => ({
     id: edge.id,
     invitation: edge.invitation,
     name: transformName(edge.invitation.split('/').pop().replace(/_/g, ' ')),
@@ -93,7 +93,7 @@ export default function Column(props) {
     writers: edge.writers || [],
     readers: edge.readers || [],
     signatures: edge.signatures || [],
-    nonreaders: edge.nonreaders || [],
+    ...(invitation?.nonreaders && { nonreaders: edge.nonreaders || [] }),
     creationDate: edge.tcdate,
     modificationDate: edge.tmdate,
     writable: edge.details?.writable ?? false,
@@ -784,8 +784,8 @@ export default function Column(props) {
         )
         // eslint-disable-next-line no-param-reassign
         traverseEdges = _.orderBy(
-          traverseEdges.map((e) => ({ ...e, weight: traverseLabelMap[e.label] || 0 })),
-          ['weight'],
+          traverseEdges,
+          [(edge) => traverseLabelMap[edge.label] || 0],
           ['desc']
         )
       }
@@ -829,7 +829,7 @@ export default function Column(props) {
           ...itemToAdd,
           browseEdges: [],
           editEdges: [],
-          traverseEdge: formatEdge(tEdge),
+          traverseEdge: formatEdge(tEdge, traverseInvitation),
           metadata: {
             ...columnMetadata,
             isAssigned: true,

--- a/components/webfield/ProgramChairConsole/AreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatus.js
@@ -55,7 +55,7 @@ const CommitteeSummary = ({ rowData, bidEnabled, recommendationEnabled, invitati
         <p>
           {bidEnabled && (
             <>
-              {`Completed Bids: ${completedBids}`}
+              {`Completed Bids: ${completedBids}`}{' '}
               {completedBids > 0 && (
                 <a
                   href={edgeBrowserBidsUrl}
@@ -70,7 +70,7 @@ const CommitteeSummary = ({ rowData, bidEnabled, recommendationEnabled, invitati
           )}
           {recommendationEnabled && (
             <>
-              {`Reviewers Recommended: ${completedRecs}`}
+              {`Reviewers Recommended: ${completedRecs}`}{' '}
               {completedBids > 0 && (
                 <a
                   href={edgeBrowserRecsUrl}

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -44,7 +44,7 @@ const ReviewerSummary = ({ rowData, bidEnabled, invitations }) => {
       <div>
         {bidEnabled && (
           <>
-            <span>{`Completed Bids: ${completedBids}`}</span>
+            <span>{`Completed Bids: ${completedBids}`}</span>{' '}
             {completedBids > 0 && (
               <div>
                 <a

--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -617,7 +617,7 @@ export function buildEdgeBrowserUrl(
   // other scores invitations + labels are not available in the PC console
   return `/edges/browse${
     startQuery ? `?start=${invitationId},${startQuery}&` : '?'
-  }traverse=${invitationId}&browse=${invitationId}${
+  }traverse=${invitationId}&edit=${invitationId}&browse=${invitationId}${
     scoresInvitationId ? `;${scoresInvitationId}` : ''
   }${conflictInvitationId ? `;${conflictInvitationId}` : ''}${
     apiVersion === 2 ? '&version=2' : ''


### PR DESCRIPTION
this pr should:
1. add bid invitation as edit param in edge browser url for editing bids
2. remove weight from traverseEdges which was added to sort edges
3. not to add nonreaders when traverse (bid) invitation does not have it so that api validation does not fail