### PR TITLE
Fix/ Edge browser: don't show default value of ignore head browse invitation

### DIFF
--- a/components/browser/EdgeBrowser.js
+++ b/components/browser/EdgeBrowser.js
@@ -394,7 +394,7 @@ export default class EdgeBrowser extends React.Component {
       traverseInvitation: this.traverseInvitation,
       editInvitations: this.editInvitations,
       browseInvitations: this.browseInvitations,
-      ignoreHeadBrowseInvitations: this.startInvitation.query.storageKey
+      ignoreHeadBrowseInvitations: this.startInvitation?.query?.storageKey
         ? []
         : this.browseInvitations?.filter((p) => p?.query?.head === 'ignore'),
       hideInvitation: this.hideInvitation,

--- a/components/browser/EdgeBrowser.js
+++ b/components/browser/EdgeBrowser.js
@@ -394,9 +394,9 @@ export default class EdgeBrowser extends React.Component {
       traverseInvitation: this.traverseInvitation,
       editInvitations: this.editInvitations,
       browseInvitations: this.browseInvitations,
-      ignoreHeadBrowseInvitations: this.browseInvitations?.filter(
-        (p) => p?.query?.head === 'ignore'
-      ),
+      ignoreHeadBrowseInvitations: this.startInvitation.query.storageKey
+        ? []
+        : this.browseInvitations?.filter((p) => p?.query?.head === 'ignore'),
       hideInvitation: this.hideInvitation,
       availableSignaturesInvitationMap: this.availableSignaturesInvitationMap,
       version: this.version,


### PR DESCRIPTION
a logic to show default value of custom max papers is added in
#941

this pr should skip that logic when user is redirected to edge browser from histogram in assignment statistics page
because when the data is from local storage the custom max papers edges are not loaded so it shows default value for all profile entitites