### PR TITLE
Fix/DBLP Import: send the publication title with their original case

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -136,10 +136,13 @@ export function formatProfileData(profileData, useLinkObjectFormat = false) {
   )
 
   // Format cdate
-  const createdDate = new Date(profileData.cdate ?? profileData.tcdate).toLocaleString('en-US', {
-    month: 'long',
-    year: 'numeric',
-  })
+  const createdDate = new Date(profileData.cdate ?? profileData.tcdate).toLocaleString(
+    'en-US',
+    {
+      month: 'long',
+      year: 'numeric',
+    }
+  )
 
   // Add metaContent data to profile fields
   if (!_.isEmpty(profileData.metaContent)) {
@@ -512,7 +515,7 @@ export async function postOrUpdatePaper(dblpPublication, profileId, names, acces
       },
       note: {
         content: {
-          title: { value: dblpPublication.formattedTitle },
+          title: { value: dblpPublication.title },
           venue: { value: dblpPublication.venue },
           authors: { value: dblpPublication.authorNames },
           authorids: { value: authorids },


### PR DESCRIPTION
currently the first edit of DBLP import has formatted title (used for comparison) as title and it was overwritten when the edit of xml transformation/abstract extraction is posted.

this pr should change it to post the original title from the first edit