### PR TITLE
Fix/ SAC/PC Console - issues caused by overlapping role names

### DIFF
--- a/components/webfield/ConsoleTaskList.js
+++ b/components/webfield/ConsoleTaskList.js
@@ -68,7 +68,7 @@ const ConsoleTaskList = ({
       allInvitations = allInvitations.filter((p) =>
         filterAssignedInvitation
           ? filterAssignedInvitations(p, roleName, submissionName, submissionNumbers)
-          : p.invitees.some((q) => q.includes(roleName))
+          : p.invitees.some((q) => q.includes(`/${roleName}`))
       )
 
       setInvitations(formatTasksData([allInvitations, [], []], true))

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -71,7 +71,7 @@ const ProgramChairConsole = ({ appContext }) => {
     emailReplyTo,
     reviewerEmailFuncs,
     acEmailFuncs,
-    submissionContentFields=[],
+    submissionContentFields = [],
   } = useContext(WebFieldContext)
   const { setBannerContent } = appContext
   const { user, accessToken, userLoading } = useUser()
@@ -345,7 +345,7 @@ const ProgramChairConsole = ({ appContext }) => {
               anonReviewerGroups[number][member] = member
             }
           })
-        } else if (p.id.includes(anonReviewerName)) {
+        } else if (p.id.includes(`/${anonReviewerName}`)) {
           if (!(number in anonReviewerGroups)) anonReviewerGroups[number] = {}
           if (p.members.length) anonReviewerGroups[number][p.id] = p.members[0]
           allGroupMembers = allGroupMembers.concat(p.members)
@@ -856,7 +856,7 @@ const ProgramChairConsole = ({ appContext }) => {
 
         decision,
         venue: note?.content?.venue?.value,
-        messageSignature: programChairsId
+        messageSignature: programChairsId,
       })
     })
     setPcConsoleData((data) => ({ ...data, noteNumberReviewMetaReviewMap }))
@@ -1059,8 +1059,8 @@ const ProgramChairConsole = ({ appContext }) => {
               Desk Rejected/Withdrawn Papers
             </Tab>
           )}
-          {(submissionContentFields.length > 0) && (
-            submissionContentFields.map(fieldAttrs => (
+          {submissionContentFields.length > 0 &&
+            submissionContentFields.map((fieldAttrs) => (
               <Tab
                 id={fieldAttrs.field}
                 key={fieldAttrs.field}
@@ -1069,8 +1069,7 @@ const ProgramChairConsole = ({ appContext }) => {
               >
                 {prettyField(fieldAttrs.field)}
               </Tab>
-            ))
-          )}
+            ))}
         </TabList>
 
         <TabPanels>
@@ -1114,19 +1113,18 @@ const ProgramChairConsole = ({ appContext }) => {
               <RejectedWithdrawnPapers pcConsoleData={pcConsoleData} />
             )}
           </TabPanel>
-          {(submissionContentFields.length > 0) && (
-            submissionContentFields.map(fieldAttrs => (
+          {submissionContentFields.length > 0 &&
+            submissionContentFields.map((fieldAttrs) => (
               <TabPanel id={fieldAttrs.field} key={fieldAttrs.field}>
-                {activeTabId === `#${fieldAttrs.field}` &&
+                {activeTabId === `#${fieldAttrs.field}` && (
                   <PaperStatus
                     pcConsoleData={pcConsoleData}
                     loadReviewMetaReviewData={calculateNotesReviewMetaReviewData}
                     noteContentField={fieldAttrs}
                   />
-                }
+                )}
               </TabPanel>
-            ))
-          )}
+            ))}
         </TabPanels>
       </Tabs>
     </>

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -167,7 +167,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
               anonReviewerGroups[number][member] = member
             }
           })
-        } else if (p.id.includes(anonReviewerName)) {
+        } else if (p.id.includes(`/${anonReviewerName}`)) {
           if (!(number in anonReviewerGroups)) anonReviewerGroups[number] = {}
           if (p.members.length) anonReviewerGroups[number][p.id] = p.members[0]
           allGroupMembers = allGroupMembers.concat(p.members)
@@ -669,7 +669,11 @@ const SeniorAreaChairConsole = ({ appContext }) => {
           </TabPanel>
           {activeTabId === '#areachair-status' && (
             <TabPanel id="areachair-status">
-              <AreaChairStatus sacConsoleData={sacConsoleData} loadSacConsoleData={loadData} user={user} />
+              <AreaChairStatus
+                sacConsoleData={sacConsoleData}
+                loadSacConsoleData={loadData}
+                user={user}
+              />
             </TabPanel>
           )}
           {activeTabId === '#seniorareachair-tasks' && (

--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -230,7 +230,7 @@ export function filterAssignedInvitations(inv, roleName, submissionName, submiss
     !(number && submissionNumbers) || submissionNumbers.find((p) => p == number)
   const roleNames = [roleName, ...(roleName.endsWith('s') ? [roleName.slice(0, -1)] : [])]
   return (
-    roleNames.some((p) => inv.id.includes(p)) ||
+    roleNames.some((p) => inv.id.includes(`/${p}`)) ||
     (inv.invitees?.some((p) => roleNames.find((q) => p.includes(q))) && invMatchesNumber)
   )
 }

--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -231,7 +231,7 @@ export function filterAssignedInvitations(inv, roleName, submissionName, submiss
   const roleNames = [roleName, ...(roleName.endsWith('s') ? [roleName.slice(0, -1)] : [])]
   return (
     roleNames.some((p) => inv.id.includes(`/${p}`)) ||
-    (inv.invitees?.some((p) => roleNames.find((q) => p.includes(q))) && invMatchesNumber)
+    (inv.invitees?.some((p) => roleNames.find((q) => p.includes(`/${q}`))) && invMatchesNumber)
   )
 }
 

--- a/unitTests/ConsoleTaskList.test.js
+++ b/unitTests/ConsoleTaskList.test.js
@@ -1842,4 +1842,279 @@ describe('ConsoleTaskList', () => {
       )
     })
   })
+
+  test('show tasks of area chairs (in AC Console) when user is also senior area chair', async () => {
+    const now = Date.now()
+    noteInvitations = [
+      {
+        id: `${venueId}/${areaChairName}/-/Registration`,
+        duedate: now + oneDay,
+        invitees: [`${venueId}/${areaChairName}`],
+        edit: {
+          note: {
+            forum: 'registrationForumId',
+            replyto: 'registrationForumId',
+          },
+        },
+        details: {
+          replytoNote: {
+            forum: 'registrationForumId',
+            content: {
+              title: {
+                value: 'ICML 2023 Conference - Area Chair registration',
+              },
+            },
+          },
+          repliedNotes: [],
+        },
+      },
+      {
+        id: `${venueId}/${areaChairName}/-/Registration_Two`,
+        duedate: now - oneDay,
+        invitees: [`${venueId}/${areaChairName}`],
+        edit: {
+          note: {
+            forum: 'registrationForumId2',
+            replyto: 'registrationForumId2',
+          },
+        },
+        details: {
+          replytoNote: {
+            forum: 'registrationForumId2',
+            content: {
+              title: {
+                value: 'ICML 2023 Conference - Area Chair registration Two',
+              },
+            },
+          },
+          repliedNotes: [
+            {
+              id: 'registrationReplyId',
+              forum: 'registrationForumId2',
+            },
+          ],
+        },
+      },
+      {
+        id: `${venueId}/${submissionName}5/-/Meta_Review`,
+        duedate: now + fourDays,
+        invitees: [`${venueId}/${areaChairName}`],
+        edit: {
+          note: {
+            forum: 'paper5Id',
+            replyto: 'paper5Id',
+          },
+        },
+        details: {
+          replytoNote: {
+            forum: 'paper5Id',
+            content: {
+              title: {
+                value: 'Paper 5 Title',
+              },
+            },
+          },
+          repliedNotes: [],
+        },
+      },
+      {
+        id: `${venueId}/${submissionName}123/-/Meta_Review`,
+        duedate: now - fourDays,
+        invitees: [`${venueId}/${areaChairName}`],
+        edit: {
+          note: {
+            forum: 'paper123Id',
+            replyto: 'paper123Id',
+          },
+        },
+        details: {
+          replytoNote: {
+            forum: 'paper123Id',
+            content: {
+              title: {
+                value: 'Paper 123 Title',
+              },
+            },
+          },
+          repliedNotes: [
+            {
+              id: 'paper123ReplyId',
+              forum: 'paper123Id',
+              replyto: 'paper123Id',
+            },
+          ],
+        },
+      },
+      // invitations for SAC
+      {
+        id: `${venueId}/${seniorAreaChairName}/-/Registration`,
+        duedate: now + oneDay,
+        invitees: [`${venueId}/${seniorAreaChairName}`],
+        edit: {
+          note: {
+            forum: 'registrationForumId',
+            replyto: 'registrationForumId',
+          },
+        },
+        details: {
+          replytoNote: {
+            forum: 'registrationForumId',
+            content: {
+              title: {
+                value: 'ICML 2023 Conference - Senior Area Chair registration',
+              },
+            },
+          },
+          repliedNotes: [],
+        },
+      },
+      {
+        id: `${venueId}/${submissionName}5/Area_Chair_AnonId/-/Meta_Review_Agreement`,
+        duedate: now + fourDays,
+        invitees: [`${venueId}/${submissionName}5/${seniorAreaChairName}`],
+        edit: {
+          note: {
+            forum: 'paper5Id',
+            replyto: 'metaReviewId',
+          },
+          details: {
+            replytoNote: {
+              id: 'metaReviewId',
+              forum: 'paper5Id',
+              replyto: 'paper5Id',
+              content: {
+                title: undefined, // meta review may not have title
+                metareview: { value: 'meta review content' },
+                recommendation: { value: 'meta review recommendation' },
+              },
+            },
+            repliedNotes: [
+              {
+                id: 'metaReviewAgreementId',
+                forum: 'paper5Id',
+                replyto: 'metaReviewId',
+              },
+            ],
+          },
+        },
+      },
+      {
+        id: `${venueId}/${submissionName}5/-/Meta_Review_SAC_Revision`,
+        duedate: now - fourDays,
+        invitees: [`${venueId}/${submissionName}5/${seniorAreaChairName}`],
+        edit: {
+          note: {
+            id: {
+              param: {
+                withInvitation: `${venueId}/${submissionName}5/-/Meta_Review`,
+              },
+            },
+            forum: 'paper5Id',
+            replyto: 'paper5Id',
+          },
+        },
+        details: {
+          replytoNote: {
+            id: 'paper5Id',
+            forum: 'paper5Id',
+            content: {
+              title: { value: 'Paper 5 Title' },
+            },
+          },
+          repliedNotes: [], // signature is still ac so repliedNotes is empty
+          repliedEdits: [
+            {
+              id: 'metaReviewSACEditId',
+              tcdate: 122334445555,
+              note: { id: '1' },
+            },
+          ],
+        },
+      },
+      {
+        id: `${venueId}/${submissionName}6/-/Meta_Review_SAC_Revision`,
+        duedate: now - fourDays,
+        invitees: [`${venueId}/${submissionName}5/${seniorAreaChairName}`],
+        edit: {
+          note: {
+            id: {
+              param: {
+                withInvitation: `${venueId}/${submissionName}6/-/Meta_Review`,
+              },
+            },
+            forum: 'paper6Id',
+            replyto: 'paper6Id',
+          },
+        },
+        details: {
+          replytoNote: {
+            id: 'paper6Id',
+            forum: 'paper6Id',
+            content: {
+              title: { value: 'Paper 6 Title' },
+            },
+          },
+          repliedNotes: [], // signature is still ac so repliedNotes is empty
+          repliedEdits: [
+            {
+              id: 'metaReviewSACEditId',
+              tcdate: 122334445555,
+              note: {
+                id: 'revision1',
+              },
+            },
+            {
+              id: 'metaReviewSACEditId2',
+              tcdate: 122334445556,
+              note: {
+                id: 'revision1',
+                ddate: 122334445555,
+              },
+            },
+          ],
+        },
+      },
+    ]
+    edgeInvitations = []
+    tagInvitations = []
+
+    render(
+      <ConsoleTaskList
+        venueId={venueId}
+        roleName={areaChairName}
+        referrer={areaChairConsoleReferrer}
+        filterAssignedInvitation={true} // value in AC console is true
+        submissionName={undefined}
+        submissionNumbers={undefined}
+      />
+    )
+
+    await waitFor(() => {
+      const acRegistrationLink = screen.getByText('Area Chair Registration')
+      const ac2RegistrationTwoLink = screen.getByText('Area Chair Registration Two')
+      const Paper5metaReviewLink = screen.getByText('Submission5 Meta Review')
+      const Paper123metaReviewLink = screen.getByText('Submission123 Meta Review')
+
+      const sacRegistrationLink = screen.queryByText('Senior Area Chair Registration')
+      const metaReviewAgreementLink = screen.getByText('Submission5 Meta Review Agreement')
+      const metaReview5RevisionLink = screen.queryByText(
+        'Submission5 Meta Review SAC Revision'
+      )
+      const metaReview6RevisionLink = screen.queryByText(
+        'Submission6 Meta Review SAC Revision'
+      )
+
+      expect(acRegistrationLink).toBeInTheDocument()
+      expect(ac2RegistrationTwoLink).toBeInTheDocument()
+      expect(Paper5metaReviewLink).toBeInTheDocument()
+      expect(Paper123metaReviewLink).toBeInTheDocument()
+
+      // should not have sac tasks
+      expect(sacRegistrationLink).not.toBeInTheDocument()
+      // user as SAC is asked to submit meta review agreement for the meta review that the user made as AC
+      expect(metaReviewAgreementLink).toBeInTheDocument()
+      expect(metaReview5RevisionLink).not.toBeInTheDocument()
+      expect(metaReview6RevisionLink).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
this pr should fix the following 2 issues caused by overlapping role names:
1. in PC and SAC console - if reviewer name and ac name overlap, for example reviewer name is Program_Committee and ac name is Senior_Program_Committee, SAC console and PC console won't get the correct ac assigned to papers if the members of AC group is anonymous AC group instead of tiled ids

it's caused by the anon ac groups being treated as anon reviewer group and the anon ac group is used as ac instead of the tilde id inside the anon ac group (becomes the logic of non anon id)

2. in AC console tasks - if a user is both AC and SAC and role names of AC and SAC overlap, the SAC tasks won't be filtered out in AC console tasks