### PR TITLE
Fix/Reviewer Console - undefined error when there's no AC

### DIFF
--- a/components/webfield/BasicHeader.js
+++ b/components/webfield/BasicHeader.js
@@ -1,7 +1,8 @@
 // webfield.ui.header
+import { inflect, pluralizeString } from '../../lib/utils'
 import Markdown from '../EditorComponents/Markdown'
 
-const BasicHeader = ({ title, instructions, customLoad, options }) => {
+const BasicHeader = ({ title, instructions, customLoad, submissionName, options }) => {
   if (options?.fullWidth) {
     return (
       <div id="header">
@@ -25,7 +26,16 @@ const BasicHeader = ({ title, instructions, customLoad, options }) => {
           <Markdown text={instructions} />
           {customLoad && customLoad !== 0 ? (
             <p className="dark">
-              You have agreed to review up to <strong>{`${customLoad} papers`}</strong>.
+              You have agreed to review up to{' '}
+              <strong>
+                {inflect(
+                  customLoad,
+                  submissionName.toLowerCase(),
+                  pluralizeString(submissionName.toLowerCase()),
+                  true
+                )}
+              </strong>
+              .
             </p>
           ) : null}
         </div>

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -573,6 +573,7 @@ const ReviewerConsole = ({ appContext }) => {
         title={header?.title}
         instructions={header.instructions}
         customLoad={reviewerConsoleData.customLoad}
+        submissionName={submissionName}
       />
       <Tabs>
         <TabList>

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -382,7 +382,6 @@ const ReviewerConsole = ({ appContext }) => {
     // #endregion
 
     // #region get area chair groups
-
     const getAreaChairGroupsP = areaChairName
       ? api
           .get(

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -382,9 +382,7 @@ const ReviewerConsole = ({ appContext }) => {
     // #endregion
 
     // #region get area chair groups
-    const singularAreaChairName = areaChairName.endsWith('s')
-      ? areaChairName.slice(0, -1)
-      : areaChairName
+
     const getAreaChairGroupsP = areaChairName
       ? api
           .get(
@@ -398,6 +396,9 @@ const ReviewerConsole = ({ appContext }) => {
             { accessToken }
           )
           .then((result) => {
+            const singularAreaChairName = areaChairName.endsWith('s')
+              ? areaChairName.slice(0, -1)
+              : areaChairName
             const areaChairMap = {}
             result.groups.forEach((areaChairgroup) => {
               if (areaChairgroup.id.endsWith(`/${areaChairName}`)) {


### PR DESCRIPTION
this pr is to append #1909 by moving the singularAreachairName logic after areaChairName check so that it does not break for venues with no AC

it should also parameterize submission name in reviewer console header when there's custom load (only used by reviewer console)