### PR TITLE
Feature/ Workflow invitations

### DIFF
--- a/components/group/GroupEditor.js
+++ b/components/group/GroupEditor.js
@@ -6,6 +6,7 @@ import GroupRelatedInvitations from './GroupRelatedInvitations'
 import GroupUICode from './GroupUICode'
 import GroupContent from './GroupContent'
 import GroupContentScripts from './GroupContentScripts'
+import WorkFlowInvitations from './WorkflowInvitations'
 
 const GroupEditor = ({ group, isSuperUser, profileId, accessToken, reloadGroup }) => {
   if (!group) return null
@@ -40,6 +41,7 @@ const GroupEditor = ({ group, isSuperUser, profileId, accessToken, reloadGroup }
       <GroupSignedNotes group={group} accessToken={accessToken} />
       <GroupChildGroups groupId={group.id} accessToken={accessToken} />
       <GroupRelatedInvitations group={group} accessToken={accessToken} />
+      <WorkFlowInvitations group={group} accessToken={accessToken} />
       <GroupUICode
         group={group}
         profileId={profileId}

--- a/components/group/WorkflowInvitations.js
+++ b/components/group/WorkflowInvitations.js
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react'
+import Link from 'next/link'
+import EditorSection from '../EditorSection'
+import PaginatedList from '../PaginatedList'
+import api from '../../lib/api-client'
+import { prettyId } from '../../lib/utils'
+
+const WorflowInvitationRow = ({ item }) => (
+  <Link href={`/invitation/edit?id=${item.id}`}>{prettyId(item.id)}</Link>
+)
+
+const WorkFlowInvitations = ({ group, accessToken }) => {
+  const groupId = group.id
+  const isV1Group = !group.domain
+  const submissionName = group.content?.submission_name?.value
+
+  const [totalCount, setTotalCount] = useState(null)
+
+  const loadWorkflowInvitations = async (limit, offset) => {
+    const queryParam =
+     {
+      prefix: `${groupId}/-/${submissionName}/.*`,
+      expired: true,
+      type: 'all',
+      limit,
+      offset,
+    }
+
+    const result = await api.get('/invitations', queryParam, {
+      accessToken,
+      ...(isV1Group && { version: 1 }),
+    })
+
+    if (result.count !== totalCount) {
+      setTotalCount(result.count ?? 0)
+    }
+    return {
+      items: result.invitations,
+      count: result.count,
+    }
+  }
+
+  const loadItems = useCallback(loadWorkflowInvitations, [groupId, accessToken])
+
+  return (
+    <EditorSection
+      title={`Workflow Invitations (2)`}
+      className="workflow"
+    >
+      <Link href={`/invitation/edit?id=${groupId}/-/${submissionName}`}>{prettyId(`${groupId}/-/${submissionName}`)}</Link>
+      <ul>
+        <li>{prettyId(`Deadlines`)} <Link href={`/invitation/edit?id=${groupId}/-/${submissionName}/Deadlines`}><u>{`Edit`}</u></Link></li>
+        <li>{prettyId(`Submission_Form`)} <Link href={`/invitation/edit?id=${groupId}/-/${submissionName}/Submission_Form`}><u>{`Edit`}</u></Link></li>
+        <li>{prettyId(`Notifications`)} <Link href={`/invitation/edit?id=${groupId}/-/${submissionName}/Notifications`}><u>{`Edit`}</u></Link></li>
+      </ul>
+      <Link href={`/invitation/edit?id=${groupId}/-/Post_${submissionName}`}>{prettyId(`${groupId}/-/Post_${submissionName}`)}</Link>
+
+      {/* <dir>
+      <PaginatedList
+        ListItem={WorflowInvitationRow}
+        loadItems={loadItems}
+        emptyMessage="No workflow invitations"
+      />
+      </dir> */}
+    </EditorSection>
+  )
+}
+
+export default WorkFlowInvitations


### PR DESCRIPTION
I have started hardcoding some of the workflow invitations we have so we can have an idea what this will look like. 
I tried using `PaginatedList` but I am not sure how to make it work with the indented "sub-invitations". This is what it looks like now:

<img width="801" alt="Screen Shot 2024-05-13 at 12 29 58 PM" src="https://github.com/openreview/openreview-web/assets/32438984/05278797-ee78-4097-aec2-3a0e7c186d85">

The `Edit` link should actually open a form that shows the fields that can be edited. 

To check, you can run the `test_venue_configuration.py` test here: https://github.com/openreview/openreview-py/pull/2118