### PR TITLE
Fix/ Error in profile auto merge test

### DIFF
--- a/tests/profilePage.ts
+++ b/tests/profilePage.ts
@@ -592,6 +592,7 @@ test('profile should be auto merged', async (t) => {
     .expect(Selector('a').withText('Merge Profiles').exists).notOk()
     .expect(Selector('#flash-message-container').find('div.alert-content').innerText)
     .contains(`A confirmation email has been sent to ${userF.email}`)
+    .click(saveProfileButton)
 
   const { superUserToken } = t.fixtureCtx
   const messages = await getMessages(


### PR DESCRIPTION
this pr should fix profile auto merge test due to api behavior change

previously a user (emailA) can request for merge with another profile (emailB) without saving emailB to profile
but now it requires the user to first save emailB to profile otherwise /mergelink call will fail with invalid token

so this pr changed to save the profile to add userF.email to userA's profile