### PR TITLE
Fix/ Test - remove temp fix added for profile auto merge

### DIFF
--- a/tests/profilePage.ts
+++ b/tests/profilePage.ts
@@ -592,7 +592,6 @@ test('profile should be auto merged', async (t) => {
     .expect(Selector('a').withText('Merge Profiles').exists).notOk()
     .expect(Selector('#flash-message-container').find('div.alert-content').innerText)
     .contains(`A confirmation email has been sent to ${userF.email}`)
-    .click(saveProfileButton)
 
   const { superUserToken } = t.fixtureCtx
   const messages = await getMessages(


### PR DESCRIPTION
this pr should revert the fix added in #1953
as the issue is fixed in api (to allow user to merge with email which is not in profile at time of merge)