### PR TITLE
Fix/ Note Editor - show items checkbox label correctly

### DIFF
--- a/components/EditorComponents/CheckboxWidget.js
+++ b/components/EditorComponents/CheckboxWidget.js
@@ -98,7 +98,13 @@ const CheckboxWidget = ({
       const defaultValues = field[fieldName].value?.param?.default ?? [] // array value
       const mandatoryValues =
         itemsValues.flatMap((p) => (p.optional === false ? p.value : [])) ?? []
-      setCheckboxOptions(itemsValues)
+      setCheckboxOptions(
+        itemsValues.map((p) => ({
+          value: p.value,
+          label: p.description,
+          optional: p.optional,
+        }))
+      )
       if (!note && (defaultValues?.length || mandatoryValues?.length)) {
         onChange({ fieldName, value: [...new Set([...defaultValues, ...mandatoryValues])] })
       }

--- a/unitTests/CheckboxWidget.test.js
+++ b/unitTests/CheckboxWidget.test.js
@@ -382,6 +382,10 @@ describe('CheckboxWidget in context of note editor', () => {
     }
 
     renderWithEditorComponentContext(<CheckboxWidget />, providerProps)
+    expect(screen.getByText('I certify')).toBeInTheDocument()
+    expect(screen.getByText('I do not certify')).toBeInTheDocument()
+    expect(screen.getByText('I am not sure')).toBeInTheDocument()
+
     expect(screen.getByDisplayValue('1')).toHaveAttribute('checked')
     expect(screen.getByDisplayValue('2')).not.toHaveAttribute('checked')
     expect(screen.getByDisplayValue('3')).toHaveAttribute('checked')


### PR DESCRIPTION
the checkbox options display value is changed from 
>description

to
>label

in #1715, but the change is missed for items used for non note readers field which is causing the label to show empty

this pr should fix this issue