### PR TITLE
Fix/ Forum page: show filtered replies when the filter URL param is present

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -668,7 +668,12 @@ export default function Forum({
 
     if (window.location.hash) {
       handleRouteChange(window.location.hash)
-    } else if (replyForumViews?.length > 0 && !selectedNoteId && !selectedInvitationId) {
+    } else if (
+      replyForumViews?.length > 0 &&
+      !selectedNoteId &&
+      !selectedInvitationId &&
+      !(query.filter || query.search || query.sort || query.nesting)
+    ) {
       setTimeout(() => {
         const tab = replyForumViews[0]
         const newActiveTab = document.querySelector(`.filter-tabs li[data-id="${tab.id}"] a`)


### PR DESCRIPTION
Don't default to first tab when filter query param is present.

To test: copy a filter URL using the button in the filters form. Load that URL and make sure filters are applied correctly.