### PR TITLE
Fix/ Forum page - note editor not shown when forum has no reply yet

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -763,7 +763,10 @@ export default function Forum({
 
   // Update reply visibility
   useEffect(() => {
-    if (!replyNoteMap || !displayOptionsMap || !orderedReplies?.length) return
+    if (!replyNoteMap || !displayOptionsMap || !orderedReplies?.length) {
+      delayedScroll(layout, scrolled)
+      return
+    }
 
     const newDisplayOptions = {}
 


### PR DESCRIPTION
this pr should fix the issue that submit review (or something else) link does not open the note editor in forum page when there's no reply.
when there's no orderedReplies, deayedScroll( which calls to open NoteEditor ) is skipped so note editor will not open.

related to #1498 