### PR TITLE
Fix/ Ethics Chair Console: filter submissions by ethics flag

### DIFF
--- a/components/webfield/EthicsChairConsole/EthicsChairPaperStatus.js
+++ b/components/webfield/EthicsChairConsole/EthicsChairPaperStatus.js
@@ -81,14 +81,13 @@ const EthicsChairPaperStatus = () => {
           '/notes',
           {
             invitation: submissionId,
-            details: 'replies,writable',
+            details: 'replies',
             select: 'id,number,forum,content,details,invitations,readers',
             sort: 'number:asc',
             domain: venueId,
           },
           { accessToken }
-        )
-        .then((notes) => notes.filter((note) => !note.details.writable))
+        ).then((notes) => notes.filter((note) => note.content?.flagged_for_ethics_review?.value))
 
       const perPaperGroupResultsP = api
         .get(


### PR DESCRIPTION
This PR fixes the issue where ethics chairs added as PCs can't see flagged submissions in the ethics chair console. We are now filtering by the field `flagged_for_ethics_review`.

This means that withdrawn/desk-rejected submissions, as well as flagged submissions authored by the ethics chair, will appear in the console. 