### PR TITLE
Fix/Message Reviewers modal - fix grouping from email to id

### DIFF
--- a/components/webfield/MessageReviewersModal.js
+++ b/components/webfield/MessageReviewersModal.js
@@ -36,7 +36,7 @@ const MessageReviewersModal = ({
     0
   )
   const primaryButtonText = currentStep === 1 ? 'Next' : 'Confirm & Send Messages'
-  const uniqueRecipientsInfo = uniqBy(recipientsInfo, (p) => p.preferredEmail)
+  const uniqueRecipientsInfo = uniqBy(recipientsInfo, (p) => p.preferredId)
 
   const handlePrimaryButtonClick = async () => {
     if (currentStep === 1) {
@@ -132,10 +132,10 @@ const MessageReviewersModal = ({
       } else {
         noteNumberReviewerIdsMap.set(noteNumber, [recipient.anonymizedGroup])
       }
-      if (recipient.preferredEmail in recipientsWithCount) {
-        recipientsWithCount[recipient.preferredEmail].count += 1
+      if (recipient.preferredId in recipientsWithCount) {
+        recipientsWithCount[recipient.preferredId].count += 1
       } else {
-        recipientsWithCount[recipient.preferredEmail] = { ...recipient, count: 1 }
+        recipientsWithCount[recipient.preferredId] = { ...recipient, count: 1 }
       }
     })
     setAllRecipients(noteNumberReviewerIdsMap)
@@ -200,7 +200,7 @@ const MessageReviewersModal = ({
               data={uniqueRecipientsInfo}
               itemHeight={18}
               height={Math.min(uniqueRecipientsInfo.length * 18, 580)}
-              itemKey="preferredEmail"
+              itemKey="preferredId"
             >
               {(recipientInfo) => (
                 <li>

--- a/unitTests/MessageReviewersModal.test.js
+++ b/unitTests/MessageReviewersModal.test.js
@@ -1,0 +1,313 @@
+import { screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import MessageReviewersModal from '../components/webfield/MessageReviewersModal'
+import { renderWithWebFieldContext } from './util'
+import api from '../lib/api-client'
+
+let basicModalProps
+
+jest.mock('../hooks/useUser', () => () => ({ user: {}, accessToken: 'some token' }))
+jest.mock('../components/BasicModal', () => (props) => {
+  basicModalProps = props
+  return <span>Basic Modal</span>
+})
+
+beforeEach(() => {
+  basicModalProps = jest.fn()
+})
+
+describe('MessageReviewersModal', () => {
+  test('display basic modal', () => {
+    const providerProps = { value: { officialReviewName: 'Official_Review' } }
+    const componentProps = {
+      messageModalId: 'message-reviewers',
+      messageOption: { value: 'allReviewers', label: 'All Reviewers of Selected Submission' },
+      selectedIds: [],
+    }
+
+    renderWithWebFieldContext(<MessageReviewersModal {...componentProps} />, providerProps)
+
+    expect(screen.getByText('Basic Modal')).toBeInTheDocument()
+    expect(basicModalProps.id).toEqual('message-reviewers')
+    expect(basicModalProps.title).toEqual('All Reviewers of Selected Submission')
+  })
+
+  test('show default message template in step1', async () => {
+    const providerProps = {
+      value: { officialReviewName: 'Official_Review', shortPhrase: 'Test Venue' },
+    }
+    const componentProps = {
+      tableRowsDisplayed: [
+        {
+          note: { id: 'noteId1', number: 1, forum: 'noteId1' },
+          reviewers: [
+            {
+              reviewerProfileId: '~Reviewer_One1',
+              preferredId: '~Reviewer_One1',
+              anonymizedGroup: 'TestVenue/Submission1/Reviewer_ABCD',
+              hasReview: true,
+              noteNumber: 1,
+            },
+          ],
+          messageSignature: 'messageSignature1',
+        },
+      ],
+      messageModalId: 'message-reviewers',
+      messageOption: { value: 'allReviewers', label: 'All Reviewers of Selected Submission' },
+      selectedIds: ['noteId1'],
+    }
+
+    renderWithWebFieldContext(<MessageReviewersModal {...componentProps} />, providerProps)
+
+    expect(screen.getByText('Basic Modal')).toBeInTheDocument()
+    expect(basicModalProps.id).toEqual('message-reviewers')
+    expect(basicModalProps.title).toEqual('All Reviewers of Selected Submission')
+
+    await waitFor(() => {
+      expect(basicModalProps.children[1].props.children[0].props.children).toEqual(
+        expect.stringContaining(
+          'You may customize the message that will be sent to the reviewers'
+        )
+      )
+      expect(basicModalProps.children[1].props.children[0].props.children).toEqual(
+        expect.stringContaining('where the reviewers can fill out his or her official review')
+      )
+      expect(
+        basicModalProps.children[1].props.children[1].props.children[1].props.value
+      ).toEqual('Test Venue Reminder')
+      expect(
+        basicModalProps.children[1].props.children[1].props.children[3].props.value
+      ).toEqual(
+        expect.stringContaining('Click on the link below to go to the official review page:')
+      )
+      expect(
+        basicModalProps.children[1].props.children[1].props.children[3].props.value
+      ).toEqual(expect.stringContaining(`Thank you,\nTest Venue`))
+
+      expect(
+        basicModalProps.children[1].props.children[1].props.children[3].props.value
+      ).not.toEqual(
+        expect.stringContaining(
+          'This is a reminder to please submit your official review for Test Venue'
+        )
+      )
+    })
+  })
+
+  test('show default message template in step1 (missingReviews option)', async () => {
+    const providerProps = {
+      value: { officialReviewName: 'Official_Review', shortPhrase: 'Test Venue' },
+    }
+    const componentProps = {
+      tableRowsDisplayed: [
+        {
+          note: { id: 'noteId1', number: 1, forum: 'noteId1' },
+          reviewers: [
+            {
+              reviewerProfileId: '~Reviewer_One1',
+              preferredId: '~Reviewer_One1',
+              anonymizedGroup: 'TestVenue/Submission1/Reviewer_ABCD',
+              hasReview: true,
+              noteNumber: 1,
+            },
+          ],
+          messageSignature: 'messageSignature1',
+        },
+      ],
+      messageModalId: 'message-reviewers',
+      messageOption: {
+        value: 'missingReviews',
+        label: 'Reviewers of Selected Submissions with unsubmitted Official Reviews',
+      },
+      selectedIds: ['noteId1'],
+    }
+
+    renderWithWebFieldContext(<MessageReviewersModal {...componentProps} />, providerProps)
+
+    expect(screen.getByText('Basic Modal')).toBeInTheDocument()
+    expect(basicModalProps.id).toEqual('message-reviewers')
+    expect(basicModalProps.title).toEqual(
+      'Reviewers of Selected Submissions with unsubmitted Official Reviews'
+    )
+
+    await waitFor(() => {
+      expect(
+        basicModalProps.children[1].props.children[1].props.children[3].props.value
+      ).toEqual(
+        expect.stringContaining(
+          'This is a reminder to please submit your official review for Test Venue'
+        )
+      )
+    })
+  })
+
+  test('show total number of messages and recipients', async () => {
+    const providerProps = {
+      value: { officialReviewName: 'Official_Review', shortPhrase: 'Test Venue' },
+    }
+    const componentProps = {
+      tableRowsDisplayed: [
+        {
+          note: { id: 'noteId1', number: 1, forum: 'noteId1' },
+          reviewers: [
+            {
+              reviewerProfileId: '~Reviewer_One1',
+              preferredId: '~Reviewer_One1',
+              preferredEmail: '****@test.com',
+              anonymizedGroup: 'TestVenue/Submission1/Reviewer_ABCD',
+              hasReview: true,
+              noteNumber: 1,
+            },
+          ],
+          messageSignature: 'messageSignature1',
+        },
+      ],
+      messageModalId: 'message-reviewers',
+      messageOption: { value: 'allReviewers', label: 'All Reviewers of Selected Submission' },
+      selectedIds: ['noteId1'],
+    }
+
+    renderWithWebFieldContext(<MessageReviewersModal {...componentProps} />, providerProps)
+
+    await waitFor(async () => {
+      // go to step2
+      await basicModalProps.onPrimaryButtonClick()
+    })
+
+    await waitFor(() => {
+      expect(
+        basicModalProps.children[1].props.children[0].props.children[1].props.children
+      ).toEqual(1) // total number of messages
+      expect(
+        basicModalProps.children[1].props.children[1].props.children.props.data[0]
+      ).toEqual({
+        reviewerProfileId: '~Reviewer_One1',
+        preferredId: '~Reviewer_One1',
+        preferredEmail: '****@test.com',
+        anonymizedGroup: 'TestVenue/Submission1/Reviewer_ABCD',
+        hasReview: true,
+        count: 1,
+        noteNumber: 1,
+      })
+    })
+  })
+
+  test('show total number of messages and recipients grouped by profile id', async () => {
+    api.post = jest.fn()
+    const providerProps = {
+      value: { officialReviewName: 'Official_Review', shortPhrase: 'Test Venue' },
+    }
+    const componentProps = {
+      tableRowsDisplayed: [
+        {
+          note: { id: 'noteId1', number: 1, forum: 'noteId1' },
+          reviewers: [
+            {
+              reviewerProfileId: '~Reviewer_One1',
+              preferredId: '~Reviewer_One1',
+              preferredEmail: '****@test.com',
+              anonymizedGroup: 'TestVenue/Submission1/Reviewer_ABCD',
+              hasReview: true,
+              noteNumber: 1,
+            },
+            {
+              reviewerProfileId: '~Reviewer_Two1',
+              preferredId: '~Reviewer_Two1',
+              preferredEmail: '****@test.com',
+              anonymizedGroup: 'TestVenue/Submission1/Reviewer_QWER',
+              hasReview: false,
+              noteNumber: 1,
+            },
+            {
+              reviewerProfileId: '~Reviewer_Three1',
+              preferredId: '~Reviewer_Three1',
+              preferredEmail: '****@test.com',
+              anonymizedGroup: 'TestVenue/Submission1/Reviewer_XXYY',
+              hasReview: true,
+              noteNumber: 1,
+            },
+          ],
+          messageSignature: 'TestVenue/Program_Chairs',
+        },
+        {
+          note: { id: 'noteId2', number: 2, forum: 'noteId2' },
+          reviewers: [
+            {
+              reviewerProfileId: '~Reviewer_One1',
+              preferredId: '~Reviewer_One1',
+              preferredEmail: '****@test.com',
+              anonymizedGroup: 'TestVenue/Submission2/Reviewer_DCBA',
+              hasReview: true,
+              noteNumber: 2,
+            },
+            {
+              reviewerProfileId: '~Reviewer_Two2', // an alternate id of reviewer two
+              preferredId: '~Reviewer_Two2',
+              preferredEmail: '****@test.com',
+              anonymizedGroup: 'TestVenue/Submission2/Reviewer_RRSS',
+              hasReview: true,
+              noteNumber: 2,
+            },
+          ],
+          messageSignature: 'TestVenue/Program_Chairs',
+        },
+      ],
+      messageModalId: 'message-reviewers',
+      messageOption: { value: 'allReviewers', label: 'All Reviewers of Selected Submission' },
+      selectedIds: ['noteId1', 'noteId2'],
+    }
+
+    renderWithWebFieldContext(<MessageReviewersModal {...componentProps} />, providerProps)
+
+    await waitFor(async () => {
+      // go to step2
+      await basicModalProps.onPrimaryButtonClick()
+    })
+
+    await waitFor(() => {
+      expect(
+        basicModalProps.children[1].props.children[0].props.children[1].props.children
+      ).toEqual(5) // total number of messages
+      expect(
+        basicModalProps.children[1].props.children[1].props.children.props.data.length
+      ).toEqual(4)
+      expect(
+        basicModalProps.children[1].props.children[1].props.children.props.data[0]
+      ).toEqual(expect.objectContaining({ count: 2, preferredId: '~Reviewer_One1' }))
+    })
+
+    await waitFor(async () => {
+      // send messages
+      await basicModalProps.onPrimaryButtonClick()
+    })
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledTimes(2)
+      expect(api.post).toHaveBeenNthCalledWith(
+        // message for submission 1
+        1,
+        expect.anything(),
+        expect.objectContaining({
+          groups: [
+            'TestVenue/Submission1/Reviewer_ABCD',
+            'TestVenue/Submission1/Reviewer_QWER',
+            'TestVenue/Submission1/Reviewer_XXYY',
+          ],
+        }),
+        expect.anything()
+      )
+      expect(api.post).toHaveBeenNthCalledWith(
+        // message for submission 2
+        2,
+        expect.anything(),
+        expect.objectContaining({
+          groups: [
+            'TestVenue/Submission2/Reviewer_DCBA',
+            'TestVenue/Submission2/Reviewer_RRSS',
+          ],
+        }),
+        expect.anything()
+      )
+    })
+  })
+})


### PR DESCRIPTION
currently the message reviewers modal is grouping the messages by preferredEmail to show a count of messages that will be sent to the user

when the emails are masked, the display will be wrong because emails from the same domain are grouped together (email sending is still correct )

this pr should change the grouping from email to id
this pr should also add some tests