### PR TITLE
Feature/SAC paper reviewer assignments

### DIFF
--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -30,8 +30,10 @@ const SeniorAreaChairConsole = ({ appContext }) => {
     assignmentLabel,
     submissionId,
     submissionName,
+    reviewersId,
     reviewerName,
     anonReviewerName,
+    areaChairsId,
     areaChairName = 'Area_Chairs',
     anonAreaChairName,
     secondaryAreaChairName,
@@ -113,6 +115,34 @@ const SeniorAreaChairConsole = ({ appContext }) => {
         : Promise.resolve([])
       // #endregion
 
+      // #region getInvitations
+      const reviewerInvitationsP = api.getAll(
+        '/invitations',
+        {
+          prefix: `${reviewersId}/-/.*`,
+          type: 'all',
+          domain: venueId,
+        },
+        { accessToken }
+      )
+      const acInvitationsP = areaChairsId
+        ? api.getAll(
+            '/invitations',
+            {
+              prefix: `${areaChairsId}/-/.*`,
+              type: 'all',
+              domain: venueId,
+            },
+            { accessToken }
+          )
+        : Promise.resolve([])
+
+      const invitationResultsP = Promise.all([
+        reviewerInvitationsP,
+        acInvitationsP
+      ])
+      // #endregion
+
       // #region getGroups (per paper groups)
       const perPaperGroupResultsP = api.get(
         '/groups',
@@ -141,8 +171,9 @@ const SeniorAreaChairConsole = ({ appContext }) => {
         : Promise.resolve([])
       // #endregion
 
-      const [notes, perPaperGroupResults, assignmentEdges] = await Promise.all([
+      const [notes, invitations, perPaperGroupResults, assignmentEdges] = await Promise.all([
         notesP,
+        invitationResultsP,
         perPaperGroupResultsP,
         assignmentsP,
       ])
@@ -348,6 +379,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
         assignedAreaChairIds,
         areaChairGroups,
         allProfilesMap,
+        invitations: invitations.flat(),
         notes: assignedNotes.map((note) => {
           const assignedReviewers =
             reviewerGroups?.find((p) => p.noteNumber === note.number)?.members ?? []

--- a/components/webfield/SeniorAreaChairConsole/PaperStatus.js
+++ b/components/webfield/SeniorAreaChairConsole/PaperStatus.js
@@ -30,13 +30,14 @@ const SelectAllCheckBox = ({ selectedNoteIds, setSelectedNoteIds, allNoteIds }) 
   )
 }
 
-const PaperRow = ({ rowData, selectedNoteIds, setSelectedNoteIds, decision, venue }) => {
+const PaperRow = ({ sacConsoleData, rowData, selectedNoteIds, setSelectedNoteIds, decision, venue }) => {
   const {
     venueId,
     officialReviewName,
     shortPhrase,
     seniorAreaChairName,
     submissionName,
+    assignmentUrls,
     metaReviewRecommendationName = 'recommendation',
     additionalMetaReviewFields = [],
   } = useContext(WebFieldContext)
@@ -46,6 +47,23 @@ const PaperRow = ({ rowData, selectedNoteIds, setSelectedNoteIds, decision, venu
       seniorAreaChairName
     )} Console](/group?id=${venueId}/${seniorAreaChairName}#${submissionName}-status)`
   )
+  const getManualAssignmentUrl = (role) => {
+    if (!assignmentUrls) return null
+    const assignmentUrl = assignmentUrls[role]?.manualAssignmentUrl // same for auto and manual
+    // auto
+    const isAssignmentConfigDeployed = sacConsoleData.invitations?.some(
+      (p) => p.id === `${venueId}/${role}/-/Assignment`
+    )
+    // manual
+    const isMatchingSetup = isAssignmentConfigDeployed
+
+    if (
+      (assignmentUrls[role]?.automaticAssignment === false && isMatchingSetup) ||
+      (assignmentUrls[role]?.automaticAssignment === true && isAssignmentConfigDeployed)
+    )
+      return assignmentUrl
+    return null
+  }
 
   return (
     <tr>
@@ -81,6 +99,7 @@ const PaperRow = ({ rowData, selectedNoteIds, setSelectedNoteIds, decision, venu
           referrerUrl={referrerUrl}
           shortPhrase={shortPhrase}
           submissionName={submissionName}
+          reviewerAssignmentUrl={getManualAssignmentUrl('Reviewers')}
         />
       </td>
       <td>
@@ -203,6 +222,7 @@ const PaperStatus = ({ sacConsoleData }) => {
         {paperStatusTabData.tableRowsDisplayed?.map((row) => (
           <PaperRow
             key={row.note.id}
+            sacConsoleData={sacConsoleData}
             rowData={row}
             selectedNoteIds={selectedNoteIds}
             setSelectedNoteIds={setSelectedNoteIds}


### PR DESCRIPTION
Adds ability for SACs to modify reviewer assignments, and uses the following fields in the webfield config:

- reviewersId
- areaChairsId
- assignmentUrls (same format as PC console)

Example from ARR config:
```
const assignmentUrls = {}
const reviewersId = domain.content.reviewers_id?.value
const areaChairsId = domain.content.area_chairs_id?.value
const automaticAssignment = domain.content.automatic_reviewer_assignment?.value
const manualReviewerAssignmentUrl = `/edges/browse?traverse=${domain.content.reviewers_assignment_id?.value}&edit=${domain.content.reviewers_assignment_id?.value};${domain.content.reviewers_invite_assignment_id?.value}&browse=${allBrowseInvitations}&version=2`
assignmentUrls[domain.content.reviewers_name?.value] = {
  manualAssignmentUrl: manualReviewerAssignmentUrl,
  automaticAssignment: automaticAssignment
}
```

Related issue: https://github.com/openreview/openreview-py/issues/2188