### PR TITLE
Fix/PC Console - Load Registration Notes

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -300,22 +300,6 @@ const ProgramChairConsole = ({ appContext }) => {
       const bidCountResults = results[6]
       const perPaperGroupResults = results[7]
 
-      // Get registration notes from all registration forms
-      const registrationNotes = await Promise.all(
-        registrationForms.map((regForm) =>
-          api.getAll(
-            '/notes',
-            {
-              forum: regForm.id,
-              select: 'id,signatures,invitations,content',
-              domain: venueId,
-            },
-            { accessToken }
-          )
-        )
-      )
-      const registrationNoteMap = groupBy(registrationNotes.flat(), 'signatures[0]')
-
       // #region categorize result of per paper groups
       const reviewerGroups = []
       const anonReviewerGroups = {}
@@ -433,16 +417,6 @@ const ProgramChairConsole = ({ appContext }) => {
       allProfiles.forEach((profile) => {
         const usernames = profile.content.names.flatMap((p) => p.username ?? [])
         const profileEmails = profile.content.emails.filter((p) => p)
-
-        let userRegNotes = []
-        usernames.forEach((username) => {
-          if (registrationNoteMap[username]) {
-            userRegNotes = userRegNotes.concat(registrationNoteMap[username])
-          }
-        })
-        // eslint-disable-next-line no-param-reassign
-        profile.registrationNotes = userRegNotes
-
         usernames.concat(profileEmails).forEach((key) => {
           allProfilesMap.set(key, profile)
         })
@@ -859,6 +833,21 @@ const ProgramChairConsole = ({ appContext }) => {
         messageSignature: programChairsId,
       })
     })
+
+    // add profileRegistrationNote
+    pcConsoleData.allProfilesMap.forEach((profile, id) => {
+      const usernames = profile.content.names.flatMap((p) => p.username ?? [])
+
+      let userRegNotes = []
+      usernames.forEach((username) => {
+        if (pcConsoleData.registrationNoteMap && pcConsoleData.registrationNoteMap[username]) {
+          userRegNotes = userRegNotes.concat(pcConsoleData.registrationNoteMap[username])
+        }
+      })
+      // eslint-disable-next-line no-param-reassign
+      profile.registrationNotes = userRegNotes
+    })
+
     setPcConsoleData((data) => ({ ...data, noteNumberReviewMetaReviewMap }))
   }
 
@@ -933,6 +922,17 @@ const ProgramChairConsole = ({ appContext }) => {
     acSacProfilesWithoutAssignment.forEach((profile) => {
       const usernames = profile.content.names.flatMap((p) => p.username ?? [])
       const profileEmails = profile.content.emails.filter((p) => p)
+
+      let userRegNotes = []
+      usernames.forEach((username) => {
+        if (pcConsoleData.registrationNoteMap && pcConsoleData.registrationNoteMap[username]) {
+          userRegNotes = userRegNotes.concat(pcConsoleData.registrationNoteMap[username])
+        }
+      })
+
+      // eslint-disable-next-line no-param-reassign
+      profile.registrationNotes = userRegNotes
+
       usernames.concat(profileEmails).forEach((key) => {
         acSacProfileWithoutAssignmentMap.set(key, profile)
       })
@@ -948,6 +948,33 @@ const ProgramChairConsole = ({ appContext }) => {
         seniorAreaChairWithoutAssignmentIds,
       },
     }))
+  }
+
+  const loadRegistrationNoteMap = async () => {
+    if (!pcConsoleData.registrationForms) {
+      setPcConsoleData((data) => ({ ...data, registrationNoteMap: {} }))
+    }
+    if (pcConsoleData.registrationNoteMap) return
+
+    try {
+      const registrationNotes = await Promise.all(
+        pcConsoleData.registrationForms.map((regForm) =>
+          api.getAll(
+            '/notes',
+            {
+              forum: regForm.id,
+              select: 'id,signatures,invitations,content',
+              domain: venueId,
+            },
+            { accessToken }
+          )
+        )
+      )
+      const registrationNoteMap = groupBy(registrationNotes.flat(), 'signatures[0]')
+      setPcConsoleData((data) => ({ ...data, registrationNoteMap }))
+    } catch (error) {
+      promptError(`Erro loading registration notes: ${error.message}`)
+    }
   }
 
   useEffect(() => {
@@ -1087,6 +1114,7 @@ const ProgramChairConsole = ({ appContext }) => {
             <ReviewerStatusTab
               pcConsoleData={pcConsoleData}
               loadReviewMetaReviewData={calculateNotesReviewMetaReviewData}
+              loadRegistrationNoteMap={loadRegistrationNoteMap}
               showContent={activeTabId === '#reviewer-status'}
             />
           </TabPanel>
@@ -1096,6 +1124,7 @@ const ProgramChairConsole = ({ appContext }) => {
                 pcConsoleData={pcConsoleData}
                 loadSacAcInfo={loadSacAcInfo}
                 loadReviewMetaReviewData={calculateNotesReviewMetaReviewData}
+                loadRegistrationNoteMap={loadRegistrationNoteMap}
               />
             </TabPanel>
           )}

--- a/components/webfield/ProgramChairConsole/AreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatus.js
@@ -253,7 +253,12 @@ const AreaChairStatusRow = ({
   </tr>
 )
 
-const AreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaReviewData }) => {
+const AreaChairStatus = ({
+  pcConsoleData,
+  loadSacAcInfo,
+  loadReviewMetaReviewData,
+  loadRegistrationNoteMap,
+}) => {
   const [areaChairStatusTabData, setAreaChairStatusTabData] = useState({})
   const {
     shortPhrase,
@@ -279,7 +284,9 @@ const AreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaReviewDat
   )
 
   const loadACStatusTabData = async () => {
-    if (!pcConsoleData.sacAcInfo) {
+    if (!pcConsoleData.registrationNoteMap) {
+      loadRegistrationNoteMap()
+    } else if (!pcConsoleData.sacAcInfo) {
       loadSacAcInfo()
     } else if (!pcConsoleData.noteNumberReviewMetaReviewMap) {
       loadReviewMetaReviewData()
@@ -378,6 +385,7 @@ const AreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaReviewDat
     pcConsoleData.paperGroups?.areaChairGroups,
     pcConsoleData.sacAcInfo,
     pcConsoleData.noteNumberReviewMetaReviewMap,
+    pcConsoleData.registrationNoteMap,
   ])
 
   useEffect(() => {

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -13,7 +13,8 @@ import ReviewerStatusMenuBar from './ReviewerStatusMenuBar'
 import { NoteContentV2 } from '../../NoteContent'
 
 const ReviewerSummary = ({ rowData, bidEnabled, invitations }) => {
-  const { id, preferredName, preferredEmail } = rowData.reviewerProfile ?? {}
+  const { id, preferredName, preferredEmail, registrationNotes } =
+    rowData.reviewerProfile ?? {}
   const { completedBids, reviewerProfileId } = rowData
   const { reviewersId, bidName } = useContext(WebFieldContext)
   const edgeBrowserBidsUrl = buildEdgeBrowserUrl(
@@ -60,6 +61,20 @@ const ReviewerSummary = ({ rowData, bidEnabled, invitations }) => {
           </>
         )}
       </div>
+      {registrationNotes?.length > 0 && (
+        <>
+          <br />
+          <strong className="paper-label">Registration Notes:</strong>
+          {registrationNotes.map((note) => (
+            <NoteContentV2
+              key={note.id}
+              id={note.id}
+              content={note.content}
+              noteReaders={note.readers}
+            />
+          ))}
+        </>
+      )}
     </div>
   )
 }
@@ -148,9 +163,8 @@ const ReviewerProgress = ({ rowData, referrerUrl, reviewRatingName }) => {
 
 // modified from notesReviewerStatus.hbs
 const ReviewerStatus = ({ rowData }) => {
-  const { numOfPapersWhichCompletedReviews, notesInfo, reviewerProfile } = rowData
+  const { numOfPapersWhichCompletedReviews, notesInfo } = rowData
   const numPapers = notesInfo.length
-  const { registrationNotes } = reviewerProfile ?? {}
 
   return (
     <div className="status-column">
@@ -180,21 +194,6 @@ const ReviewerStatus = ({ rowData }) => {
           )
         })}
       </div>
-
-      {registrationNotes?.length > 0 && (
-        <>
-          <br />
-          <strong className="paper-label">Registration Notes:</strong>
-          {registrationNotes.map((note) => (
-            <NoteContentV2
-              key={note.id}
-              id={note.id}
-              content={note.content}
-              noteReaders={note.readers}
-            />
-          ))}
-        </>
-      )}
     </div>
   )
 }

--- a/components/webfield/ProgramChairConsole/ReviewerStatus.js
+++ b/components/webfield/ProgramChairConsole/ReviewerStatus.js
@@ -226,7 +226,12 @@ const ReviewerStatusRow = ({
   </tr>
 )
 
-const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showContent }) => {
+const ReviewerStatusTab = ({
+  pcConsoleData,
+  loadReviewMetaReviewData,
+  loadRegistrationNoteMap,
+  showContent,
+}) => {
   const [reviewerStatusTabData, setReviewerStatusTabData] = useState({})
   const {
     venueId,
@@ -293,6 +298,19 @@ const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showConten
         reviewerProfilesWithoutAssignment.forEach((profile) => {
           const usernames = profile.content.names.flatMap((p) => p.username ?? [])
           const profileEmails = profile.content.emails.filter((p) => p)
+
+          let userRegNotes = []
+          usernames.forEach((username) => {
+            if (
+              pcConsoleData.registrationNoteMap &&
+              pcConsoleData.registrationNoteMap[username]
+            ) {
+              userRegNotes = userRegNotes.concat(pcConsoleData.registrationNoteMap[username])
+            }
+          })
+          // eslint-disable-next-line no-param-reassign
+          profile.registrationNotes = userRegNotes
+
           usernames.concat(profileEmails).forEach((key) => {
             reviewerProfileWithoutAssignmentMap.set(key, profile)
           })
@@ -375,8 +393,17 @@ const ReviewerStatusTab = ({ pcConsoleData, loadReviewMetaReviewData, showConten
 
   useEffect(() => {
     if (!pcConsoleData.reviewers || !showContent) return
-    loadReviewerData()
-  }, [pcConsoleData.reviewers, pcConsoleData.noteNumberReviewMetaReviewMap, showContent])
+    if (!pcConsoleData.registrationNoteMap) {
+      loadRegistrationNoteMap()
+    } else {
+      loadReviewerData()
+    }
+  }, [
+    pcConsoleData.reviewers,
+    pcConsoleData.noteNumberReviewMetaReviewMap,
+    pcConsoleData.registrationNoteMap,
+    showContent,
+  ])
 
   useEffect(() => {
     setReviewerStatusTabData((data) => ({


### PR DESCRIPTION
This pr should change the pc console to load registration notes once when user open reviewer status tab/ac status tab

this pr should also show registration notes for reviewers and acs with no assignment