### PR TITLE
Fix/ PC Console - Show Correct Info when SAC is assigned to papers directly

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -71,6 +71,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
     emailReplyTo,
     reviewerEmailFuncs,
     acEmailFuncs,
+    sacEmailFuncs,
     submissionContentFields = [],
     sacDirectPaperAssignment,
     propertiesAllowed,

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -1144,6 +1144,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
               <SeniorAreaChairStatus
                 pcConsoleData={pcConsoleData}
                 loadSacAcInfo={loadSacAcInfo}
+                loadReviewMetaReviewData={calculateNotesReviewMetaReviewData}
               />
             </TabPanel>
           )}

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -72,6 +72,11 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
     reviewerEmailFuncs,
     acEmailFuncs,
     submissionContentFields = [],
+    sacDirectPaperAssignment,
+    propertiesAllowed,
+    sacStatuspropertiesAllowed,
+    messageAreaChairsInvitationId,
+    messageSeniorAreaChairsInvitationId,
   } = useContext(WebFieldContext)
   const { setBannerContent } = appContext
   const { user, accessToken, userLoading } = useUser()

--- a/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
@@ -9,11 +9,12 @@ import BaseMenuBar from '../BaseMenuBar'
 import QuerySearchInfoModal from '../QuerySearchInfoModal'
 import { pluralizeString, prettyField } from '../../../lib/utils'
 
-const MessageAreaChairsModal = ({
+export const MessageACSACModal = ({
   tableRowsDisplayed: tableRows,
   messageOption,
   messageParentGroup,
   messageSignature,
+  isMessageSeniorAreaChairs = false,
 }) => {
   const { accessToken } = useUser()
   const {
@@ -21,7 +22,9 @@ const MessageAreaChairsModal = ({
     emailReplyTo,
     submissionVenueId,
     messageAreaChairsInvitationId,
+    messageSeniorAreaChairsInvitationId,
     areaChairName = 'Area_Chairs',
+    seniorAreaChairName = 'Senior_Area_Chairs',
   } = useContext(WebFieldContext)
   const [currentStep, setCurrentStep] = useState(1)
   const [error, setError] = useState(null)
@@ -30,6 +33,9 @@ const MessageAreaChairsModal = ({
   const primaryButtonText = currentStep === 1 ? 'Next' : 'Confirm & Send Messages'
   const [recipientsInfo, setRecipientsInfo] = useState([])
   const totalMessagesCount = recipientsInfo.length
+  const messageInvitationId = isMessageSeniorAreaChairs
+    ? messageSeniorAreaChairsInvitationId
+    : messageAreaChairsInvitationId
 
   const handlePrimaryButtonClick = async () => {
     if (currentStep === 1) {
@@ -41,8 +47,8 @@ const MessageAreaChairsModal = ({
       await api.post(
         '/messages',
         {
-          invitation: messageAreaChairsInvitationId,
-          signature: messageAreaChairsInvitationId && messageSignature,
+          invitation: messageInvitationId,
+          signature: messageInvitationId && messageSignature,
           groups: recipientsInfo.map((p) => p.id),
           subject,
           message,
@@ -97,17 +103,18 @@ const MessageAreaChairsModal = ({
     const recipientRows = getRecipientRows()
     setRecipientsInfo(
       recipientRows.map((row) => {
-        const acProfile = row.areaChairProfile
-        return acProfile
+        const profile = isMessageSeniorAreaChairs ? row.sacProfile : row.areaChairProfile
+        const id = isMessageSeniorAreaChairs ? row.sacProfileId : row.areaChairProfileId
+        return profile
           ? {
-              id: row.areaChairProfileId,
-              preferredName: acProfile.preferredName,
-              preferredEmail: acProfile.preferredEmail,
+              id,
+              preferredName: profile.preferredName,
+              preferredEmail: profile.preferredEmail,
             }
           : {
-              id: row.areaChairProfileId,
-              preferredName: row.areaChairProfileId,
-              preferredEmail: row.areaChairProfileId,
+              id,
+              preferredName: id,
+              preferredEmail: id,
             }
       })
     )
@@ -130,8 +137,11 @@ const MessageAreaChairsModal = ({
         <>
           <p>
             Enter a message to be sent to all selected{' '}
-            {prettyField(areaChairName).toLowerCase()} below. You will have a chance to review
-            a list of all recipients after clicking &quot;Next&quot; below.
+            {prettyField(
+              isMessageSeniorAreaChairs ? seniorAreaChairName : areaChairName
+            ).toLowerCase()}{' '}
+            below. You will have a chance to review a list of all recipients after clicking
+            &quot;Next&quot; below.
           </p>
           <div className="form-group">
             <label htmlFor="subject">Email Subject</label>
@@ -365,7 +375,7 @@ const AreaChairStatusMenuBar = ({
       exportFileName={`${prettyField(areaChairName)} Status`}
       sortOptions={sortOptions}
       basicSearchFunction={basicSearchFunction}
-      messageModal={(props) => <MessageAreaChairsModal {...props} />}
+      messageModal={(props) => <MessageACSACModal {...props} />}
       querySearchInfoModal={(props) => <QuerySearchInfoModal {...props} />}
       extraClasses="ac-status-menu"
     />

--- a/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
@@ -57,7 +57,9 @@ export const MessageACSACModal = ({
         },
         { accessToken }
       )
-      $('#message-areachairs').modal('hide')
+      $(
+        `#${isMessageSeniorAreaChairs ? 'message-seniorareachairs' : 'message-areachairs'}`
+      ).modal('hide')
       promptMessage(`Successfully sent ${totalMessagesCount} emails`)
     } catch (apiError) {
       setError(apiError.message)
@@ -122,7 +124,7 @@ export const MessageACSACModal = ({
 
   return (
     <BasicModal
-      id="message-areachairs"
+      id={isMessageSeniorAreaChairs ? 'message-seniorareachairs' : 'message-areachairs'}
       title={messageOption?.label}
       primaryButtonText={primaryButtonText}
       onPrimaryButtonClick={handlePrimaryButtonClick}

--- a/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
@@ -291,6 +291,7 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaRev
           tableRowsAll={seniorAreaChairStatusTabData.tableRowsAll}
           tableRows={seniorAreaChairStatusTabData.tableRows}
           setSeniorAreaChairStatusTabData={setSeniorAreaChairStatusTabData}
+          sacDirectPaperAssignment={sacDirectPaperAssignment}
         />
         <p className="empty-message">No senior area chair matching search criteria.</p>
       </div>
@@ -301,6 +302,7 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaRev
         tableRowsAll={seniorAreaChairStatusTabData.tableRowsAll}
         tableRows={seniorAreaChairStatusTabData.tableRows}
         setSeniorAreaChairStatusTabData={setSeniorAreaChairStatusTabData}
+        sacDirectPaperAssignment={sacDirectPaperAssignment}
       />
       <Table
         className="console-table table-striped pc-console-ac-status"

--- a/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
@@ -1,9 +1,12 @@
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
+import { sortBy } from 'lodash'
 import { getProfileLink } from '../../../lib/webfield-utils'
 import LoadingSpinner from '../../LoadingSpinner'
 import PaginationLinks from '../../PaginationLinks'
 import Table from '../../Table'
 import SeniorAreaChairStatusMenuBar from './SeniorAreaChairStatusMenuBar'
+import WebFieldContext from '../../WebFieldContext'
+import { getNoteContentValues } from '../../../lib/forum-utils'
 
 const BasicProfileSummary = ({ profile, profileId }) => {
   const { id, preferredName, preferredEmail } = profile ?? {}
@@ -44,29 +47,182 @@ const SeniorAreaChairStatusRow = ({ rowData }) => (
   </tr>
 )
 
-const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo }) => {
+const SeniorAreaChairStatusRowForDirectPaperAssignment = ({
+  rowData,
+  referrerUrl,
+  metaReviewRecommendationName,
+}) => {
+  const { id, preferredName, preferredEmail } = rowData.sacProfile ?? {}
+  const numCompletedReviews = rowData.numCompletedReviews // eslint-disable-line prefer-destructuring
+  const numCompletedMetaReviews = rowData.numCompletedMetaReviews // eslint-disable-line prefer-destructuring
+  const numPapers = rowData.notes.length
+
+  return (
+    <tr>
+      <td>
+        <strong>{rowData.number}</strong>
+      </td>
+      <td>
+        <div>
+          {preferredName ? (
+            <>
+              <h4>
+                <a
+                  href={getProfileLink(id ?? rowData.sacProfileId)}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {preferredName}
+                </a>
+              </h4>
+              <p className="text-muted">({preferredEmail})</p>
+            </>
+          ) : (
+            <h4>{rowData.sacProfileId}</h4>
+          )}
+        </div>
+      </td>
+      <td>
+        <div className="reviewer-progress">
+          <h4>
+            {numCompletedReviews} of {numPapers} Papers Reviews Completed
+          </h4>
+          {rowData.notes.length !== 0 && <strong>Papers:</strong>}
+          <div className="review-progress">
+            {rowData.notes.map((p) => {
+              if (!p) return null
+              const { numReviewsDone, numReviewersAssigned, ratingAvg, ratingMin, ratingMax } =
+                p.reviewProgressData
+              const noteTitle = p.note?.content?.title?.value
+              return (
+                <div key={p.noteNumber}>
+                  <div className="note-info">
+                    <strong className="note-number">{p.noteNumber}</strong>
+                    <div className="review-info">
+                      <a
+                        href={`/forum?id=${p.note.forum}&referrer=${referrerUrl}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {noteTitle}
+                      </a>
+                      <div>
+                        <strong>
+                          {numReviewsDone} of {numReviewersAssigned} Reviews Submitted{' '}
+                        </strong>
+                        {ratingAvg &&
+                          `/ Average Rating:${ratingAvg} (Min: ${ratingMin}, Max: ${ratingMax})`}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </td>
+      <td>
+        <div className="areachair-progress">
+          <h4>
+            {numCompletedMetaReviews} of {numPapers} Papers Meta Review Completed
+          </h4>
+          {rowData.notes.length !== 0 && <strong>Papers:</strong>}
+          <div>
+            {rowData.notes.map((p) => {
+              if (!p) return null
+              const noteContent = getNoteContentValues(p.note?.content)
+              const noteVenue = noteContent?.venue
+              const metaReviews = p.metaReviewData?.metaReviews
+              const hasMetaReview = metaReviews?.length
+              return (
+                <div key={p.noteNumber} className="meta-review-info">
+                  <strong className="note-number">{p.noteNumber}</strong>
+                  {hasMetaReview ? (
+                    <>
+                      {metaReviews.map((metaReview) => {
+                        const metaReviewContent = getNoteContentValues(metaReview?.content)
+                        return (
+                          <div key={metaReview.id} className="meta-review">
+                            <span>{`${
+                              metaReviewContent.venue ? `${metaReviewContent.venue} - ` : ''
+                            }${metaReviewContent[metaReviewRecommendationName] ?? ''}`}</span>
+                            {metaReviewContent.format && (
+                              <span>Format: {metaReviewContent.format}</span>
+                            )}
+                            <a
+                              href={`/forum?id=${metaReview.forum}&noteId=${metaReview.id}&referrer=${referrerUrl}`}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Read Meta Review
+                            </a>
+                          </div>
+                        )
+                      })}
+                    </>
+                  ) : (
+                    <span>{`${noteVenue ? `${noteVenue} - ` : ''} No Meta Review`}</span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaReviewData }) => {
   const [seniorAreaChairStatusTabData, setSeniorAreaChairStatusTabData] = useState({})
   const [pageNumber, setPageNumber] = useState(1)
   const [totalCount, setTotalCount] = useState(pcConsoleData.areaChairs?.length ?? 0)
   const pageSize = 25
+  const {
+    venueId,
+    metaReviewRecommendationName = 'recommendation',
+    sacDirectPaperAssignment,
+  } = useContext(WebFieldContext)
+
+  const referrerUrl = encodeURIComponent(
+    `[Program Chair Console](/group?id=${venueId}/Program_Chairs#seniorareachair-status)`
+  )
 
   const loadSacStatusTabData = async () => {
     if (!pcConsoleData.sacAcInfo) {
       loadSacAcInfo()
+    } else if (sacDirectPaperAssignment && !pcConsoleData.noteNumberReviewMetaReviewMap) {
+      loadReviewMetaReviewData()
     } else {
       const tableRows = pcConsoleData.seniorAreaChairs.map((sacProfileId, index) => {
-        const acs =
-          pcConsoleData.sacAcInfo.acBySacMap.get(sacProfileId)?.map((acProfileId) => {
-            const acProfile = pcConsoleData.sacAcInfo.areaChairWithoutAssignmentIds.includes(
-              acProfileId
-            )
-              ? pcConsoleData.sacAcInfo.acSacProfileWithoutAssignmentMap.get(acProfileId)
-              : pcConsoleData.allProfilesMap.get(acProfileId)
-            return {
-              id: acProfileId,
-              profile: acProfile,
-            }
-          }) ?? []
+        let notes = []
+        let acs = []
+
+        if (sacDirectPaperAssignment) {
+          notes =
+            pcConsoleData.sacAcInfo.acBySacMap.get(sacProfileId)?.map((noteId) => {
+              const note = pcConsoleData.notes.find((p) => p.id === noteId)
+              if (!note) return null
+              const noteNumber = note?.number
+
+              const reviewMetaReviewInfo =
+                pcConsoleData.noteNumberReviewMetaReviewMap.get(noteNumber) ?? {}
+              return { note, noteNumber, ...reviewMetaReviewInfo }
+            }) ?? []
+        } else {
+          acs =
+            pcConsoleData.sacAcInfo.acBySacMap.get(sacProfileId)?.map((acProfileId) => {
+              const acProfile = pcConsoleData.sacAcInfo.areaChairWithoutAssignmentIds.includes(
+                acProfileId
+              )
+                ? pcConsoleData.sacAcInfo.acSacProfileWithoutAssignmentMap.get(acProfileId)
+                : pcConsoleData.allProfilesMap.get(acProfileId)
+              return {
+                id: acProfileId,
+                profile: acProfile,
+              }
+            }) ?? []
+        }
         const sacProfile =
           pcConsoleData.sacAcInfo.seniorAreaChairWithoutAssignmentIds.includes(sacProfileId)
             ? pcConsoleData.sacAcInfo.acSacProfileWithoutAssignmentMap.get(sacProfileId)
@@ -76,9 +232,18 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo }) => {
           sacProfileId,
           sacProfile,
           acs,
+          numCompletedReviews: notes.filter(
+            (p) => p?.reviewers?.length && p.reviewers?.length === p.officialReviews?.length
+          ).length,
+          numCompletedMetaReviews:
+            notes.filter(
+              (p) =>
+                p?.metaReviewData?.areaChairs?.length ===
+                p?.metaReviewData?.metaReviews?.length
+            ).length ?? 0,
+          notes: sortBy(notes, 'noteNumber'),
         }
       })
-
       setSeniorAreaChairStatusTabData({
         tableRowsAll: tableRows,
         tableRows: [...tableRows],
@@ -89,7 +254,11 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo }) => {
   useEffect(() => {
     if (!pcConsoleData?.paperGroups?.seniorAreaChairGroups) return
     loadSacStatusTabData()
-  }, [pcConsoleData?.paperGroups?.seniorAreaChairGroups, pcConsoleData.sacAcInfo])
+  }, [
+    pcConsoleData?.paperGroups?.seniorAreaChairGroups,
+    pcConsoleData.sacAcInfo,
+    pcConsoleData.noteNumberReviewMetaReviewMap,
+  ])
 
   useEffect(() => {
     setSeniorAreaChairStatusTabData((data) => ({
@@ -135,15 +304,33 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo }) => {
       />
       <Table
         className="console-table table-striped pc-console-ac-status"
-        headings={[
-          { id: 'number', content: '#', width: '55px' },
-          { id: 'seniorAreaChair', content: 'Senior Area Chair' },
-          { id: 'areachair', content: 'Area Chair' },
-        ]}
+        headings={
+          sacDirectPaperAssignment
+            ? [
+                { id: 'number', content: '#', width: '55px' },
+                { id: 'seniorAreaChair', content: 'Senior Area Chair', width: '10%' },
+                { id: 'reviewProgress', content: 'Review Progress' },
+                { id: 'metaReviewstatus', content: 'Meta Review Status' },
+              ]
+            : [
+                { id: 'number', content: '#', width: '55px' },
+                { id: 'seniorAreaChair', content: 'Senior Area Chair' },
+                { id: 'areachair', content: 'Area Chair' },
+              ]
+        }
       >
-        {seniorAreaChairStatusTabData.tableRowsDisplayed?.map((row) => (
-          <SeniorAreaChairStatusRow key={row.sacProfileId} rowData={row} />
-        ))}
+        {seniorAreaChairStatusTabData.tableRowsDisplayed?.map((row) =>
+          sacDirectPaperAssignment ? (
+            <SeniorAreaChairStatusRowForDirectPaperAssignment
+              key={row.sacProfileId}
+              rowData={row}
+              referrerUrl={referrerUrl}
+              metaReviewRecommendationName={metaReviewRecommendationName}
+            />
+          ) : (
+            <SeniorAreaChairStatusRow key={row.sacProfileId} rowData={row} />
+          )
+        )}
       </Table>
       <PaginationLinks
         currentPage={pageNumber}

--- a/components/webfield/ProgramChairConsole/SeniorAreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/SeniorAreaChairStatusMenuBar.js
@@ -15,6 +15,7 @@ const SeniorAreaChairStatusMenuBarForDirectPaperAssignment = ({
     shortPhrase,
     seniorAreaChairsId,
     enableQuerySearch,
+    sacEmailFuncs,
     areaChairStatusExportColumns: exportColumnsConfig,
     filterOperators: filterOperatorsConfig,
     sacStatuspropertiesAllowed: propertiesAllowedConfig,
@@ -29,7 +30,7 @@ const SeniorAreaChairStatusMenuBarForDirectPaperAssignment = ({
     name: ['sacProfile.preferredName'],
     email: ['areaChairProfile.preferredEmail'],
   }
-  const messageAreaChairOptions = [
+  const messageSeniorAreaChairOptions = [
     {
       label: `${prettyField(seniorAreaChairName)} with unsubmitted ${prettyField(
         officialReviewName
@@ -52,6 +53,7 @@ const SeniorAreaChairStatusMenuBarForDirectPaperAssignment = ({
       label: `${prettyField(seniorAreaChairName)} with 0 assignments`,
       value: 'missingAssignments',
     },
+    ...(sacEmailFuncs ?? []),
   ]
   const exportColumns = [
     { header: 'id', getValue: (p) => p.sacProfileId },
@@ -135,8 +137,8 @@ const SeniorAreaChairStatusMenuBarForDirectPaperAssignment = ({
       filterOperators={filterOperators}
       propertiesAllowed={propertiesAllowed}
       messageDropdownLabel={`Message ${prettyField(seniorAreaChairName)}`}
-      messageOptions={messageAreaChairOptions}
-      messageModalId="message-areachairs"
+      messageOptions={messageSeniorAreaChairOptions}
+      messageModalId="message-seniorareachairs"
       messageParentGroup={seniorAreaChairsId}
       messageSignature={venueId}
       exportColumns={exportColumns}

--- a/components/webfield/ProgramChairConsole/SeniorAreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/SeniorAreaChairStatusMenuBar.js
@@ -1,6 +1,156 @@
+import { useContext } from 'react'
 import BaseMenuBar from '../BaseMenuBar'
+import WebFieldContext from '../../WebFieldContext'
+import { pluralizeString, prettyField } from '../../../lib/utils'
+import QuerySearchInfoModal from '../QuerySearchInfoModal'
+import { MessageACSACModal } from './AreaChairStatusMenuBar'
 
-const SeniorAreaChairStatusMenuBar = ({
+const SeniorAreaChairStatusMenuBarForDirectPaperAssignment = ({
+  tableRowsAll,
+  tableRows,
+  setSeniorAreaChairStatusTabData,
+}) => {
+  const {
+    venueId,
+    shortPhrase,
+    seniorAreaChairsId,
+    enableQuerySearch,
+    areaChairStatusExportColumns: exportColumnsConfig,
+    filterOperators: filterOperatorsConfig,
+    sacStatuspropertiesAllowed: propertiesAllowedConfig,
+    seniorAreaChairName = 'Senior_Area_Chairs',
+    officialReviewName,
+    officialMetaReviewName = 'Meta_Review',
+    submissionName,
+  } = useContext(WebFieldContext)
+  const filterOperators = filterOperatorsConfig ?? ['!=', '>=', '<=', '>', '<', '==', '=']
+  const propertiesAllowed = propertiesAllowedConfig ?? {
+    number: ['number'],
+    name: ['sacProfile.preferredName'],
+    email: ['areaChairProfile.preferredEmail'],
+  }
+  const messageAreaChairOptions = [
+    {
+      label: `${prettyField(seniorAreaChairName)} with unsubmitted ${prettyField(
+        officialReviewName
+      )}`,
+      value: 'missingReviews',
+    },
+    {
+      label: `${prettyField(seniorAreaChairName)} with 0 submitted ${prettyField(
+        officialMetaReviewName
+      )}`,
+      value: 'noMetaReviews',
+    },
+    {
+      label: `${prettyField(seniorAreaChairName)} with unsubmitted ${prettyField(
+        officialMetaReviewName
+      )}`,
+      value: 'missingMetaReviews',
+    },
+    {
+      label: `${prettyField(seniorAreaChairName)} with 0 assignments`,
+      value: 'missingAssignments',
+    },
+  ]
+  const exportColumns = [
+    { header: 'id', getValue: (p) => p.sacProfileId },
+    {
+      header: 'name',
+      getValue: (p) => p.sacProfile?.preferredName ?? p.sacProfileId,
+    },
+    {
+      header: 'email',
+      getValue: (p) => p.sacProfile?.preferredEmail ?? p.sacProfileId,
+    },
+    { header: `assigned ${submissionName}`, getValue: (p) => p.notes?.length },
+    {
+      header: `${prettyField(officialReviewName)} completed`,
+      getValue: (p) => p.numCompletedReviews,
+    },
+    {
+      header: `${prettyField(officialMetaReviewName)} completed`,
+      getValue: (p) => p.numCompletedMetaReviews,
+    },
+    ...(exportColumnsConfig ?? []),
+  ]
+  const sortOptions = [
+    {
+      label: prettyField(seniorAreaChairName),
+      value: 'Senior Area Chair',
+      getValue: (p) => p.number,
+    },
+    {
+      label: `${prettyField(seniorAreaChairName)} Name`,
+      value: 'Senior Area Chair Name',
+      getValue: (p) => p.sacProfile?.preferredName ?? p.sacProfileId,
+    },
+    {
+      label: `Number of ${pluralizeString(submissionName)} Assigned`,
+      value: 'Number of Papers Assigned',
+      getValue: (p) => p.notes?.length,
+      initialDirection: 'desc',
+    },
+    {
+      label: `Number of ${pluralizeString(submissionName)} with Missing ${pluralizeString(
+        prettyField(officialReviewName)
+      )}`,
+      value: 'Number of Papers with Missing Reviews',
+      getValue: (p) => (p.notes?.length ?? 0) - p.numCompletedReviews ?? 0,
+      initialDirection: 'desc',
+    },
+    {
+      label: `Number of ${pluralizeString(submissionName)} with Completed ${pluralizeString(
+        prettyField(officialReviewName)
+      )}`,
+      value: 'Number of Papers with Completed Reviews',
+      getValue: (p) => p.numCompletedReviews,
+      initialDirection: 'desc',
+    },
+    {
+      label: `Number of Missing ${pluralizeString(prettyField(officialMetaReviewName))}`,
+      value: 'Number of Missing MetaReviews',
+      getValue: (p) => (p.notes?.length ?? 0) - p.numCompletedMetaReviews,
+      initialDirection: 'desc',
+    },
+    {
+      label: `Number of Completed ${pluralizeString(prettyField(officialMetaReviewName))}`,
+      value: 'Number of Completed MetaReviews',
+      getValue: (p) => p.numCompletedMetaReviews,
+      initialDirection: 'desc',
+    },
+  ]
+  const basicSearchFunction = (row, term) =>
+    (row.sacProfile?.preferredName.toLowerCase() ?? row.sacProfileId.toLowerCase()).includes(
+      term
+    )
+
+  return (
+    <BaseMenuBar
+      tableRowsAll={tableRowsAll}
+      tableRows={tableRows}
+      setData={setSeniorAreaChairStatusTabData}
+      shortPhrase={shortPhrase}
+      enableQuerySearch={enableQuerySearch}
+      filterOperators={filterOperators}
+      propertiesAllowed={propertiesAllowed}
+      messageDropdownLabel={`Message ${prettyField(seniorAreaChairName)}`}
+      messageOptions={messageAreaChairOptions}
+      messageModalId="message-areachairs"
+      messageParentGroup={seniorAreaChairsId}
+      messageSignature={venueId}
+      exportColumns={exportColumns}
+      exportFileName={`${prettyField(seniorAreaChairName)} Status`}
+      sortOptions={sortOptions}
+      basicSearchFunction={basicSearchFunction}
+      messageModal={(props) => <MessageACSACModal {...props} isMessageSeniorAreaChairs />}
+      querySearchInfoModal={(props) => <QuerySearchInfoModal {...props} />}
+      extraClasses="ac-status-menu"
+    />
+  )
+}
+
+const SeniorAreaChairStatusMenuBarForACAssignment = ({
   tableRowsAll,
   tableRows,
   setSeniorAreaChairStatusTabData,
@@ -35,6 +185,13 @@ const SeniorAreaChairStatusMenuBar = ({
       extraClasses="sac-status-menu"
     />
   )
+}
+const SeniorAreaChairStatusMenuBar = (props) => {
+  const { sacDirectPaperAssignment, ...otherProps } = props
+  if (sacDirectPaperAssignment) {
+    return <SeniorAreaChairStatusMenuBarForDirectPaperAssignment {...otherProps} />
+  }
+  return <SeniorAreaChairStatusMenuBarForACAssignment {...otherProps} />
 }
 
 export default SeniorAreaChairStatusMenuBar


### PR DESCRIPTION
pc console assumes that only ACs are assigned to SAC
so when papers are assigned to SAC directly (loaded by edge), it only shows some note id in SAC status tab.

this pr should add the following new configs to PC console

- **sacDirectPaperAssignment** - when set to true will show tab content and menu bar similar to ac status tab
- **sacStatuspropertiesAllowed** - overwrite the query search properties of sac status tab (has no effect if sacDirectPaperAssignment is false)
- **messageSeniorAreaChairsInvitationId** - the invitation id for sending messages to sac
- **sacEmailFuncs** - custom message options (array of object with fields label and filterFunc)




when the value is true, SAC console shows paper related data similar to what AC status tab is showing.