### PR TITLE
Fix/ Forum page - note editor not open when query param has invitationId 

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -367,7 +367,7 @@ export default function Forum({
           listElem.scrollTop = listElem.scrollHeight
         }
       }
-    }, 200),
+    }, 500),
     [selectedNoteId, selectedInvitationId]
   )
 


### PR DESCRIPTION
when url has invitationId, the page should open note editor automatically.

this process is completed by finding the reply button which corresponds to the invitation and simulate clicking it.
it may fail when the function runs before the buttons complete rendering (so the button can't be found)


this pr may fix this issue by increasing delay for scrolling to selected note