### PR TITLE
Fix/ Forum - Formula in forum reply may not get rendered

### DIFF
--- a/components/NoteContent.js
+++ b/components/NoteContent.js
@@ -1,4 +1,4 @@
-/* globals DOMPurify,marked: false */
+/* globals DOMPurify,marked,typesetMathJax: false */
 
 import { useState, useEffect } from 'react'
 import union from 'lodash/union'
@@ -184,6 +184,10 @@ export const NoteContentV2 = ({
   ]
     .concat(omit)
     .filter((field) => !include.includes(field))
+
+  useEffect(() => {
+    if (content) typesetMathJax()
+  }, [content])
 
   return (
     <div className="note-content">

--- a/unitTests/NoteContent.test.js
+++ b/unitTests/NoteContent.test.js
@@ -7,6 +7,7 @@ beforeEach(() => {
     sanitize: jest.fn(),
   }
   global.marked = jest.fn()
+  global.typesetMathJax = jest.fn()
 })
 
 describe('NoteContentV2', () => {
@@ -100,8 +101,7 @@ describe('NoteContentV2', () => {
       ],
     }
 
-    const { container } = render(<NoteContentV2 {...props} />)
-    screen.debug()
+    render(<NoteContentV2 {...props} />)
     expect(global.marked).toHaveBeenCalledTimes(1)
     expect(global.marked).toHaveBeenCalledWith('<image/src/onerror=prompt(document.domain)>')
 
@@ -111,5 +111,6 @@ describe('NoteContentV2', () => {
       '<image/src/onerror=prompt(document.domain)>'
     )
     expect(global.DOMPurify.sanitize).toHaveBeenNthCalledWith(2, 'markdown output')
+    expect(global.typesetMathJax).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
changes introduced in chat caused the mathajx typeset to be executed before the replies are actually rendered.
this can cause the formula in forum replies not to be rendered depends on how long it takes for mathjax to execute.

this pr should call mathjax in note content so that it's guaranteed to be rendered.