### PR TITLE
Edge Browser: show label and weight if they are available

### DIFF
--- a/lib/webfield-utils.js
+++ b/lib/webfield-utils.js
@@ -660,14 +660,11 @@ export function getFieldConstValue(fieldDescription) {
  * @returns {string|number}
  */
 export function getEdgeValue(edge) {
-  if (
-    edge.name === 'Conflict' ||
-    edge.name === 'Bid' ||
-    edge.name === 'Invite Assignment' ||
-    edge.weight == null
-  )
+  if (edge.weight == null)
     return edge.label
-  return edge.weight
+  if (edge.label == null)
+    return edge.weight
+  return `${edge.label} (${edge.weight})`
 }
 
 /**


### PR DESCRIPTION
Sometime we use the weight to compute the assignments but showing a label is more meaningful.

<img width="422" alt="Screen Shot 2024-06-26 at 12 28 54 PM" src="https://github.com/openreview/openreview-web/assets/545506/896b2ac5-0a49-4810-bc81-8e408993b1d1">

@xkopenreview what do you think?
