### PR TITLE
Fix/ PC Console not responding

### DIFF
--- a/components/Collapse.js
+++ b/components/Collapse.js
@@ -24,9 +24,15 @@ const Collapse = ({ showLabel, hideLabel, onExpand, className, indent, children 
       >
         {collapsed ? showLabel : hideLabel}
       </a>
-      <div ref={collapseRef} className={`collapse${indent ? ' collapse-indent' : ''}`} id={id}>
-        {children}
-      </div>
+      {!collapsed && (
+        <div
+          ref={collapseRef}
+          className={`collapse${indent ? ' collapse-indent' : ''}`}
+          id={id}
+        >
+          {children}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
some changes are added in #2002 to fix the issue of formula not rendered

when there are a lot of formulas to be rendered, it can cause to page to hang.
for the pc console, it could be the abstracts of papers in paper status tab

this pr should change the collapse to show content only when it's expanded so that formulas which are not shown won't cause the unnecessary rendering