### PR TITLE
Fix/ Edge browser - Not to add ignore head browser edges for dummy profiles

### DIFF
--- a/components/browser/ProfileEntity.js
+++ b/components/browser/ProfileEntity.js
@@ -57,17 +57,20 @@ export default function ProfileEntity(props) {
       p.invitation.includes('Custom_Max_Papers')
     )?.weight ?? defaultWeight
 
-  ignoreHeadBrowseInvitations.forEach((p) => {
-    if (!p.defaultLabel && !p.defaultWeight && p.defaultWeight !== 0) return
-    if (!browseEdges?.find((q) => q.invitation === p.id)) {
-      browseEdges = browseEdges.concat({
-        id: nanoid(),
-        name: p.name,
-        label: p.defaultLabel,
-        weight: p.defaultWeight,
-      })
-    }
-  })
+  if (!content.isDummyProfile) {
+    ignoreHeadBrowseInvitations.forEach((p) => {
+      if (!p.defaultLabel && !p.defaultWeight && p.defaultWeight !== 0) return
+      if (!browseEdges?.find((q) => q.invitation === p.id)) {
+        browseEdges = browseEdges.concat({
+          id: nanoid(),
+          name: p.name,
+          label: p.defaultLabel,
+          weight: p.defaultWeight,
+        })
+      }
+    })
+  }
+
   const isInviteAcceptedProfile =
     editEdges?.find((p) => p.invitation.includes('Invite_Assignment'))?.label === 'Accepted'
 


### PR DESCRIPTION
currently when the browse invitation has head:ignore and has default weight/label, the default weight/label will be displayed as browse edge.

this applies even if the reviewer has been removed from the reviewers group (but still have assignment)
and it's difficult for AE to tell whether these entities should be assigned papers.

this pr should update the logic not to add head:ignore browse edges if profile is not in reviewers group