### PR TITLE
Feature/ Remove calls to add and remove members endpoints

### DIFF
--- a/components/group/GroupMembers.js
+++ b/components/group/GroupMembers.js
@@ -396,7 +396,7 @@ const GroupMembers = ({ group, accessToken, reloadGroup }) => {
     readers: [profileId],
     writers: [profileId],
     signatures: [profileId],
-    invitation: group.domain ? `${group.domain}/-/Edit` : group.invitations[0],
+    invitation: group.domain ? `${group.domain}/-/Edit` : group.invitations?.[0],
   })
 
   const deleteMember = async (memberId) => {
@@ -406,15 +406,7 @@ const GroupMembers = ({ group, accessToken, reloadGroup }) => {
     if (userIds.includes(memberId) && !window.confirm(confirmMessage)) return
 
     try {
-      if (group.invitations) {
-        await api.post('/groups/edits', buildEdit('remove', [memberId]), { accessToken })
-      } else {
-        await api.delete(
-          '/groups/members',
-          { id: group.id, members: [memberId] },
-          { accessToken, version: 1 }
-        )
-      }
+      await api.post('/groups/edits', buildEdit('remove', [memberId]), { accessToken })
       setGroupMembers({ type: 'DELETE', payload: [memberId] })
       reloadGroup()
     } catch (error) {
@@ -424,15 +416,7 @@ const GroupMembers = ({ group, accessToken, reloadGroup }) => {
 
   const restoreMember = async (memberId) => {
     try {
-      if (group.invitations) {
-        await api.post('/groups/edits', buildEdit('append', [memberId]), { accessToken })
-      } else {
-        await api.put(
-          '/groups/members',
-          { id: group.id, members: [memberId] },
-          { accessToken, version: 1 }
-        )
-      }
+      await api.post('/groups/edits', buildEdit('append', [memberId]), { accessToken })
       setGroupMembers({ type: 'RESTORE', payload: [memberId] })
       reloadGroup()
     } catch (error) {
@@ -498,19 +482,11 @@ const GroupMembers = ({ group, accessToken, reloadGroup }) => {
       : ''
 
     try {
-      if (group.invitations) {
-        await api.post(
-          '/groups/edits',
-          buildEdit('append', [...newMembers, ...existingDeleted]),
-          { accessToken }
-        )
-      } else {
-        await api.put(
-          '/groups/members',
-          { id: group.id, members: [...newMembers, ...existingDeleted] },
-          { accessToken, version: 1 }
-        )
-      }
+      await api.post(
+        '/groups/edits',
+        buildEdit('append', [...newMembers, ...existingDeleted]),
+        { accessToken }
+      )
       setSearchTerm('')
       setGroupMembers({
         type: 'ADD',
@@ -548,15 +524,7 @@ const GroupMembers = ({ group, accessToken, reloadGroup }) => {
     }
 
     try {
-      if (group.invitations) {
-        await api.post('/groups/edits', buildEdit('remove', membersToRemove), { accessToken })
-      } else {
-        await api.delete(
-          '/groups/members',
-          { id: group.id, members: membersToRemove },
-          { accessToken, version: 1 }
-        )
-      }
+      await api.post('/groups/edits', buildEdit('remove', membersToRemove), { accessToken })
       setGroupMembers({ type: 'DELETE', payload: membersToRemove })
       reloadGroup()
     } catch (error) {

--- a/components/group/GroupMembers.js
+++ b/components/group/GroupMembers.js
@@ -386,18 +386,29 @@ const GroupMembers = ({ group, accessToken, reloadGroup }) => {
     }${selectedMembers.length ? `, ${selectedMembers.length} selected` : ''})`
   }
 
-  const buildEdit = (action, members) => ({
-    group: {
-      id: group.id,
-      members: {
-        [action]: members,
+  const buildEdit = (action, members) => {
+    const userNameGroupInvitationId = `${process.env.SUPER_USER}/-/Username`
+    const emailGroupInvitationId = `${process.env.SUPER_USER}/-/Email`
+
+    let invitation = group.domain ? `${group.domain}/-/Edit` : group.invitations?.[0]
+    if (group.invitations?.includes(userNameGroupInvitationId))
+      invitation = userNameGroupInvitationId
+    if (group.invitations?.includes(emailGroupInvitationId))
+      invitation = emailGroupInvitationId
+
+    return {
+      group: {
+        id: group.id,
+        members: {
+          [action]: members,
+        },
       },
-    },
-    readers: [profileId],
-    writers: [profileId],
-    signatures: [profileId],
-    invitation: group.domain ? `${group.domain}/-/Edit` : group.invitations?.[0],
-  })
+      readers: [profileId],
+      writers: [profileId],
+      signatures: [profileId],
+      invitation,
+    }
+  }
 
   const deleteMember = async (memberId) => {
     const confirmMessage =

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -1921,14 +1921,24 @@ const UserModerationQueue = ({
   }
 
   const addSDNException = async (profileId) => {
+    const sdnExceptionGroupId = `${process.env.SUPER_USER}/Support/SDN_Profiles/Exceptions`
     try {
-      await api.put(
-        '/groups/members',
+      const sdnExceptionGroup = await api.getGroupById(sdnExceptionGroupId, accessToken)
+      await api.post(
+        '/groups/edits',
         {
-          id: `${process.env.SUPER_USER}/Support/SDN_Profiles/Exceptions`,
-          members: [profileId],
+          group: {
+            id: `${process.env.SUPER_USER}/Support/SDN_Profiles/Exceptions`,
+            members: {
+              append: [profileId],
+            },
+          },
+          readers: sdnExceptionGroup.signatures,
+          writers: sdnExceptionGroup.signatures,
+          signatures: sdnExceptionGroup.signatures,
+          invitation: sdnExceptionGroup.invitations?.[0],
         },
-        { accessToken, version: 1 }
+        { accessToken }
       )
       promptMessage(`${profileId} is added to SDN exception group`)
     } catch (error) {


### PR DESCRIPTION
this pr contains changes related to https://github.com/openreview/openreview-api/pull/495

when user edit member of old group with no invitations an error will be thrown by api for missing invitations

call in api helper is not removed so that tests still pass