### PR TITLE
Fix/PC console - error when paperX/reviewers/submitted group is added to paperY/reviewers group

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -538,6 +538,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
                     (key) => paperAnonReviewerGroups[key] === member
                   )
                 }
+                if (!anonymizedGroup) return []
                 return {
                   reviewerProfileId: deanonymizedGroup,
                   anonymizedGroup,


### PR DESCRIPTION
an error will be thrown in

anonymousId: getIndentifierFromGroup(anonymizedGroup, anonReviewerName)

when anonymizedGroup is undefined
this happens when the paperX/reviewers/submitted is added as a member of paperY/reviewers group

fix is similar to #1617 