### PR TITLE
Fix/ Edge browser - show email/copy email below title/institution

### DIFF
--- a/components/browser/ProfileEntity.js
+++ b/components/browser/ProfileEntity.js
@@ -443,19 +443,21 @@ export default function ProfileEntity(props) {
           >
             {content.name.fullname}
           </a>
-          {!query.preferredEmailInvitationId && <span>({content.email})</span>}
         </h3>
-        {query.preferredEmailInvitationId && !content.isDummyProfile && (
-          <p
-            onClick={(e) => {
-              e.stopPropagation()
-              getEmail()
-            }}
-          >
-            Copy Email
-          </p>
-        )}
         <p>{content.title}</p>
+        <h3>
+          {!query.preferredEmailInvitationId && <span>({content.email})</span>}
+          {query.preferredEmailInvitationId && !content.isDummyProfile && (
+            <span
+              onClick={(e) => {
+                e.stopPropagation()
+                getEmail()
+              }}
+            >
+              Copy Email
+            </span>
+          )}
+        </h3>
       </div>
 
       {/* existing editEdges */}


### PR DESCRIPTION
this pr should show email or copy email link (when preferredEmailInvitaitonId exists) below title in profile entity