### PR TITLE
Fix/ Avoid API is unavailable in the home page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -39,28 +39,34 @@ export default function Home() {
 
     const loadVenues = async () => {
       try {
-        const [userVenues, activeVenues, openVenues, allVenues] = await Promise.all([
+        const [userVenues, activeVenues, openVenues, allVenues] = await Promise.allSettled([
           user
             ? api
-                .get('/groups', { member: user.id, web: true })
+                .get('/groups', { member: user.id, web: true, select: 'id' })
                 .then((apiRes) => apiRes.groups || [])
             : Promise.resolve([]),
           api.get('/groups', { id: 'active_venues' }).then(formatGroupResults),
           api
-            .getCombined('/invitations', { invitee: '~', pastdue: false, type: 'notes' }, { invitee: '~', pastdue: false, type: 'note' })
+            .getCombined(
+              '/invitations',
+              { invitee: '~', pastdue: false, type: 'notes' },
+              { invitee: '~', pastdue: false, type: 'note' }
+            )
             .then(formatInvitationResults),
           api.get('/groups', { id: 'host' }).then(formatGroupResults).then(sortAlpha),
         ])
-        const activeAndOpenVenues = activeVenues.concat(openVenues)
-        const filteredUserVenues = userVenues
-          .filter((group) => activeAndOpenVenues.find((v) => group.id.startsWith(v.groupId)))
+        const activeAndOpenVenues = (activeVenues.value ?? []).concat(openVenues.value ?? [])
+        const filteredUserVenues = (userVenues.value ?? [])
+          .filter((group) =>
+            (activeAndOpenVenues ?? []).find((v) => group.id.startsWith(v.groupId))
+          )
           .map((group) => ({ groupId: group.id, dueDate: null }))
 
         setVenues({
           user: filteredUserVenues,
-          active: activeVenues,
-          open: openVenues,
-          all: allVenues,
+          active: activeVenues.value,
+          open: openVenues.value,
+          all: allVenues.value,
         })
       } catch (apiError) {
         setError(apiError)


### PR DESCRIPTION
this pr should :
1. continue showing other venue lists in homepage when some groups call fail/timeout
2. load only id of user consoles because only id is used