### PR TITLE
Fix/ Message Reviewers - batch every 1000 selected notes

### DIFF
--- a/components/BasicModal.js
+++ b/components/BasicModal.js
@@ -1,6 +1,7 @@
 /* globals $: false */
 
 import { useEffect, useRef } from 'react'
+import SpinnerButton from './SpinnerButton'
 
 export default function BasicModal({
   id,
@@ -12,6 +13,7 @@ export default function BasicModal({
   onPrimaryButtonClick,
   onClose,
   onOpen,
+  isLoading,
   options = {},
 }) {
   const modalRef = useRef(null)
@@ -53,16 +55,26 @@ export default function BasicModal({
               <button type="button" className="btn btn-default" data-dismiss="modal">
                 {cancelButtonText}
               </button>
-              {primaryButtonText && (
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  onClick={onPrimaryButtonClick}
-                  disabled={primaryButtonDisabled}
-                >
-                  {primaryButtonText}
-                </button>
-              )}
+              {primaryButtonText &&
+                (options.useSpinnerButton ? (
+                  <SpinnerButton
+                    type="primary"
+                    onClick={onPrimaryButtonClick}
+                    disabled={primaryButtonDisabled}
+                    loading={isLoading}
+                  >
+                    {primaryButtonText}
+                  </SpinnerButton>
+                ) : (
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={onPrimaryButtonClick}
+                    disabled={primaryButtonDisabled}
+                  >
+                    {primaryButtonText}
+                  </button>
+                ))}
             </div>
           )}
         </div>

--- a/unitTests/MessageReviewersModal.test.js
+++ b/unitTests/MessageReviewersModal.test.js
@@ -77,9 +77,7 @@ describe('MessageReviewersModal', () => {
       ).toEqual('Test Venue Reminder')
       expect(
         basicModalProps.children[1].props.children[1].props.children[3].props.value
-      ).toEqual(
-        expect.stringContaining('Your message...')
-      )
+      ).toEqual(expect.stringContaining('Your message...'))
     })
   })
 
@@ -122,11 +120,7 @@ describe('MessageReviewersModal', () => {
     await waitFor(() => {
       expect(
         basicModalProps.children[1].props.children[1].props.children[3].props.value
-      ).toEqual(
-        expect.stringContaining(
-          'Your message...'
-        )
-      )
+      ).toEqual(expect.stringContaining('Your message...'))
     })
   })
 
@@ -297,6 +291,48 @@ describe('MessageReviewersModal', () => {
         }),
         expect.anything()
       )
+    })
+  })
+
+  test('group note ids by batch size 1000', async () => {
+    api.post = jest.fn()
+    const providerProps = {
+      value: { officialReviewName: 'Official_Review', shortPhrase: 'Test Venue' },
+    }
+    const numberOfNotes = 10000
+    const componentProps = {
+      tableRowsDisplayed: Array.from({ length: numberOfNotes }, (_, i) => ({
+        note: { id: `noteId${i}`, number: i, forum: `noteId${i}` },
+        reviewers: [
+          {
+            reviewerProfileId: '~Reviewer_One1',
+            preferredId: '~Reviewer_One1',
+            preferredEmail: '****@test.com',
+            anonymizedGroup: `TestVenue/Submission${i}/Reviewer_ABCD`,
+            hasReview: true,
+            noteNumber: i,
+          },
+        ],
+      })),
+      messageModalId: 'message-reviewers',
+      messageOption: { value: 'allReviewers', label: 'All Reviewers of Selected Submission' },
+      selectedIds: Array.from({ length: numberOfNotes }, (_, i) => `noteId${i}`),
+    }
+
+    renderWithWebFieldContext(<MessageReviewersModal {...componentProps} />, providerProps)
+
+    await waitFor(async () => {
+      // go to step2
+      await basicModalProps.onPrimaryButtonClick()
+    })
+
+    await waitFor(async () => {
+      // send messages
+      await basicModalProps.onPrimaryButtonClick()
+    })
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledTimes(10000)
     })
   })
 })


### PR DESCRIPTION
currently the reviewer reminder api calls can exhaust browser resources when pc select many papers.
this pr should group every 1000 selected papers and chain the calls so that it doesn't fail

this pr should also change the send button to spinner button as it can take a while to send those messages