### PR TITLE
Fix/ Forum reply - display note with no visible content

### DIFF
--- a/components/forum/ForumReply.js
+++ b/components/forum/ForumReply.js
@@ -490,6 +490,14 @@ function NoteContentCollapsible({
       </div>
     )
   }
+  if (!Object.keys(content ?? {}).length)
+    return (
+      <div className="note-content-container">
+        <div className="note-content">
+          <em>[empty]</em>
+        </div>
+      </div>
+    )
 
   return (
     <div className={`note-content-container ${contentExpanded ? '' : 'collapsed'}`}>

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -452,11 +452,11 @@ const AreaChairConsole = ({ appContext }) => {
           })
           ?.map((q) => {
             const anonymousId = getIndentifierFromGroup(q.signatures[0], anonReviewerName)
-            const reviewValue = q.content.review?.value
+            const reviewValue = q.content?.review?.value
             return {
               ...q,
               anonymousId,
-              confidence: parseNumberField(q.content[reviewConfidenceName]?.value),
+              confidence: parseNumberField(q.content?.[reviewConfidenceName]?.value),
               ...Object.fromEntries(
                 (Array.isArray(reviewRatingName) ? reviewRatingName : [reviewRatingName]).map(
                   (ratingName) => {
@@ -465,9 +465,9 @@ const AreaChairConsole = ({ appContext }) => {
                     const ratingValue =
                       typeof ratingName === 'object'
                         ? Object.values(ratingName)[0]
-                            .map((r) => q.content[r]?.value)
+                            .map((r) => q.content?.[r]?.value)
                             .find((s) => s !== undefined)
-                        : q.content[ratingName]?.value
+                        : q.content?.[ratingName]?.value
                     return [[ratingDisplayName], parseNumberField(ratingValue)]
                   }
                 )
@@ -548,9 +548,10 @@ const AreaChairConsole = ({ appContext }) => {
           },
           metaReviewData: {
             [metaReviewRecommendationName]:
-              metaReview?.content[metaReviewRecommendationName]?.value ?? 'N/A',
+              metaReview?.content?.[metaReviewRecommendationName]?.value ?? 'N/A',
             ...additionalMetaReviewFields.reduce((prev, curr) => {
-              const additionalMetaReviewFieldValue = metaReview?.content[curr]?.value ?? 'N/A'
+              const additionalMetaReviewFieldValue =
+                metaReview?.content?.[curr]?.value ?? 'N/A'
               return { ...prev, [curr]: additionalMetaReviewFieldValue }
             }, {}),
             metaReviewInvitationId: `${venueId}/${submissionName}${note.number}/-/${officialMetaReviewName}`,

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -404,11 +404,11 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                 return p.invitations.includes(officialReviewInvitationId)
               })
               ?.map((review) => {
-                const reviewValue = review.content.review?.value
+                const reviewValue = review.content?.review?.value
                 return {
                   ...review,
                   anonymousId: getIndentifierFromGroup(review.signatures[0], anonReviewerName),
-                  confidence: parseNumberField(review.content[reviewConfidenceName]?.value),
+                  confidence: parseNumberField(review.content?.[reviewConfidenceName]?.value),
                   ...Object.fromEntries(
                     (Array.isArray(reviewRatingName)
                       ? reviewRatingName
@@ -421,9 +421,9 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                       const ratingValue =
                         typeof ratingName === 'object'
                           ? Object.values(ratingName)[0]
-                              .map((r) => review.content[r]?.value)
+                              .map((r) => review.content?.[r]?.value)
                               .find((s) => s !== undefined)
-                          : review.content[ratingName]?.value
+                          : review.content?.[ratingName]?.value
                       return [[displayRatingName], parseNumberField(ratingValue)]
                     })
                   ),
@@ -457,7 +457,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             )
           )
 
-          const confidences = officialReviews.map((p) => p.confidence)
+          const confidences = officialReviews.map((p) => p?.confidence)
           const validConfidences = confidences.filter((p) => p !== null)
           const confidenceAvg = validConfidences.length
             ? (
@@ -496,10 +496,10 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                 metaReviewAgreement?.content?.[metaReviewAgreementConfig?.displayField]?.value
               return {
                 [metaReviewRecommendationName]:
-                  metaReview?.content[metaReviewRecommendationName]?.value,
+                  metaReview?.content?.[metaReviewRecommendationName]?.value,
                 ...metaReview,
                 ...additionalMetaReviewFields?.reduce((prev, curr) => {
-                  const additionalMetaReviewFieldValue = metaReview?.content[curr]?.value
+                  const additionalMetaReviewFieldValue = metaReview?.content?.[curr]?.value
                   return {
                     ...prev,
                     [curr]: {
@@ -539,9 +539,10 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             if (prelimDecisionNote) {
               preliminaryDecision = {
                 id: prelimDecisionNote.id,
-                recommendation: prelimDecisionNote.content.recommendation?.value,
-                confidence: prelimDecisionNote.content.confidence?.value,
-                discussionNeeded: prelimDecisionNote.content.discussion_with_SAC_needed?.value,
+                recommendation: prelimDecisionNote.content?.recommendation?.value,
+                confidence: prelimDecisionNote.content?.confidence?.value,
+                discussionNeeded:
+                  prelimDecisionNote.content?.discussion_with_SAC_needed?.value,
               }
             }
           }

--- a/lib/banner-links.js
+++ b/lib/banner-links.js
@@ -66,7 +66,7 @@ export function forumLink(note) {
     ? `/forum?id=${forumId}${id && id !== forum ? `&noteId=${id}` : ''}`
     : '/'
   const title = isV2Note
-    ? content.title?.value ?? details.forumContent?.title?.value
+    ? content?.title?.value ?? details.forumContent?.title?.value
     : content.title || buildNoteTitle(invitation, signatures)
   const truncatedTitle = title
     ? truncate(title, { length: 50, separator: /,? +/ })

--- a/lib/forum-utils.js
+++ b/lib/forum-utils.js
@@ -93,8 +93,8 @@ export function getNoteInvitations(invitations, note) {
       const appliesToNote =
         invNoteId === note.id ||
         note.invitations.includes(invNoteId?.param?.withInvitation) ||
-        (note.content.venueid?.value &&
-          note.content.venueid?.value === invNoteId?.param?.withVenueid)
+        (note.content?.venueid?.value &&
+          note.content.venueid.value === invNoteId?.param?.withVenueid)
       const invitationExpired = p.expdate && p.expdate < Date.now()
       return appliesToNote && (!invitationExpired || p.details?.writable)
     })

--- a/pages/revisions/index.js
+++ b/pages/revisions/index.js
@@ -269,9 +269,7 @@ const RevisionsList = ({
                 <div className="meta_actions">
                   {reference.ddate ? (
                     <RestoreButton
-                      onClick={() =>
-                        deleteOrRestoreNote(reference, invitation)
-                      }
+                      onClick={() => deleteOrRestoreNote(reference, invitation)}
                       disableButton={!isNoteWritable}
                       disableReason={
                         !isNoteWritable
@@ -297,9 +295,7 @@ const RevisionsList = ({
                         />
                         {invitation.edit.ddate && (
                           <TrashButton
-                            onClick={() =>
-                              deleteOrRestoreNote(reference, invitation)
-                            }
+                            onClick={() => deleteOrRestoreNote(reference, invitation)}
                             disableButton={!isNoteWritable}
                             disableReason={
                               !isNoteWritable
@@ -461,6 +457,7 @@ const Revisions = ({ appContext }) => {
           sort: 'tcdate',
           details: 'writable,presentation,invitation',
           trash: true,
+          tauthor: true,
         },
         { accessToken }
       )

--- a/unitTests/AreaChairConsole.test.js
+++ b/unitTests/AreaChairConsole.test.js
@@ -920,6 +920,199 @@ describe('AreaChairConsole', () => {
     })
   })
 
+  test('show assigned papers (with review which has invisible content)', async () => {
+    const acAnonId = Math.random().toString(36).substring(2, 6)
+    const paper1Reviewer1AnonId = Math.random().toString(36).substring(2, 6)
+    const paper1Reviewer2AnonId = Math.random().toString(36).substring(2, 6)
+    api.getAll = jest.fn((path, param) => {
+      switch (path) {
+        case '/groups': // all groups
+          return Promise.resolve([
+            {
+              id: 'AAAI.org/2025/Conference/Submission1/Senior_Program_Committee',
+            },
+            {
+              id: `AAAI.org/2025/Conference/Submission1/Senior_Program_Committee_${acAnonId}`,
+            },
+          ])
+        case '/notes':
+          return Promise.resolve([
+            {
+              id: 'note1Id',
+              forum: 'note1Id',
+              number: 1,
+              details: {
+                replies: [
+                  // reviewer 1 review
+                  {
+                    content: {
+                      review: { value: 'some review from reviewer1' },
+                      rating: { value: 5 },
+                      confidence: { value: 5 },
+                    },
+                    invitations: ['AAAI.org/2025/Conference/Submission1/-/First_Round_Review'],
+                    signatures: [
+                      `AAAI.org/2025/Conference/Submission1/Program_Committee_${paper1Reviewer1AnonId}`,
+                    ],
+                  },
+                  // reviewer 2 review
+                  {
+                    content: undefined, // content field readers do not contain AC
+                    invitations: ['AAAI.org/2025/Conference/Submission1/-/First_Round_Review'],
+                    signatures: [
+                      `AAAI.org/2025/Conference/Submission1/Program_Committee_${paper1Reviewer2AnonId}`,
+                    ],
+                  },
+                ],
+              },
+            },
+          ])
+        default:
+          return null
+      }
+    })
+    api.get = jest.fn((path) => {
+      switch (path) {
+        case '/groups': // reviewer groups
+          return Promise.resolve({
+            groups: [
+              // paper 1 all reviewers group
+              {
+                id: 'AAAI.org/2025/Conference/Submission1/Program_Committee',
+                members: [
+                  `AAAI.org/2025/Conference/Submission1/Program_Committee_${paper1Reviewer1AnonId}`,
+                  `AAAI.org/2025/Conference/Submission1/Program_Committee_${paper1Reviewer2AnonId}`,
+                ],
+              },
+              // paper 1 reviewer1 group
+              {
+                id: `AAAI.org/2025/Conference/Submission1/Program_Committee_${paper1Reviewer1AnonId}`,
+                members: ['~PaperOne_Reviewer1'],
+              },
+              // paper 1 reviewer2 group
+              {
+                id: `AAAI.org/2025/Conference/Submission1/Program_Committee_${paper1Reviewer2AnonId}`,
+                members: ['~PaperOne_Reviewer2'],
+              },
+              // paper 1 all ac group
+              {
+                id: 'AAAI.org/2025/Conference/Submission1/Senior_Program_Committee',
+                members: [
+                  `AAAI.org/2025/Conference/Submission1/Senior_Program_Committee_${acAnonId}`,
+                ],
+              },
+              // paper 1 ac group
+              {
+                id: `AAAI.org/2025/Conference/Submission1/Senior_Program_Committee_${acAnonId}`,
+                members: ['~PaperOne_AC1'],
+              },
+            ],
+          })
+        case '/edges': // sac assignments
+          return Promise.resolve({ edges: [] })
+        default:
+          return null
+      }
+    })
+    api.post = jest.fn(() =>
+      Promise.resolve({
+        profiles: [
+          {
+            content: {
+              names: [{ username: '~PaperOne_Reviewer1', fullname: 'PaperOne Reviewer1' }],
+              emails: [],
+            },
+          },
+          {
+            content: {
+              names: [{ username: '~PaperOne_Reviewer2', fullname: 'PaperOne Reviewer2' }],
+              emails: [],
+            },
+          },
+        ],
+      })
+    ) // profile search
+
+    const providerProps = {
+      value: {
+        header: { title: 'Senior Program Committee', instructions: 'some instructions' },
+        entity: { id: 'AAAI.org/2025/Conference/Senior_Program_Committee' },
+        venueId: 'AAAI.org/2025/Conference',
+        reviewerAssignment: {
+          showEdgeBrowserUrl: true,
+          proposedAssignmentTitle: 'Proposed Assignment',
+          edgeBrowserProposedUrl: 'proposed edge browser url',
+          edgeBrowserDeployedUrl: 'deployed edge browser url',
+        },
+        submissionInvitationId: 'AAAI.org/2025/Conference/-/Submission',
+        seniorAreaChairsId: 'AAAI.org/2025/Conference/Area_Chairs',
+        areaChairName: 'Senior_Program_Committee',
+        submissionName: 'Submission',
+        officialReviewName: 'First_Round_Review',
+        reviewRatingName: 'rating',
+        reviewConfidenceName: 'confidence',
+        officialMetaReviewName: 'Meta_Review',
+        reviewerName: 'Program_Committee',
+        anonReviewerName: 'Program_Committee_',
+        metaReviewRecommendationName: undefined,
+        additionalMetaReviewFields: ['final_recommendation'],
+        shortPhrase: 'AAAI 2025',
+        filterOperators: undefined,
+        propertiesAllowed: undefined,
+        enableQuerySearch: true,
+        emailReplyTo: 'pc@aaai.org',
+        extraExportColumns: undefined,
+      },
+    }
+
+    renderWithWebFieldContext(
+      <AreaChairConsole appContext={{ setBannerContent: jest.fn() }} />,
+      providerProps
+    )
+
+    await waitFor(() => {
+      expect(global.marked).toHaveBeenCalledWith(
+        expect.stringContaining('proposed edge browser url')
+      )
+      expect(screen.getByText('note summary')).toBeInTheDocument()
+      expect(screen.getByText('note review status')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Download PDFs' })).toBeInTheDocument()
+      expect(noteSummaryProps).toHaveBeenCalledWith(
+        expect.objectContaining({ note: expect.objectContaining({ id: 'note1Id' }) })
+      )
+      expect(noteReviewStatusProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          referrerUrl: expect.stringContaining(
+            encodeURIComponent('[Senior Program Committee Console]')
+          ),
+        })
+      )
+      expect(noteReviewStatusProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          referrerUrl: expect.stringContaining(encodeURIComponent('#assigned-submissions')),
+        })
+      )
+
+      expect(noteReviewStatusProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rowData: expect.objectContaining({
+            reviewProgressData: expect.objectContaining({
+              confidenceAvg: '5.00',
+              ratings: {
+                rating: {
+                  ratingAvg: '5.00',
+                  ratingMax: 5,
+                  ratingMin: 5,
+                },
+              },
+            }),
+          }),
+        })
+      )
+    })
+  })
+
   test('switch to secondary ac tab and tasks tab', async () => {
     // the AC is AC of paper1 and secondary AC of paper 5
     const acAnonId = Math.random().toString(36).substring(2, 6)


### PR DESCRIPTION
this pr should allow note reply to be displayed as [empty] when there's no visible content to the user
the note has no visible content to the user because the note invitation has readers for all content fields and the user is not included.

with changes in https://github.com/openreview/openreview-api/pull/503
the user can post the note but the posted note is not visible to the user

the user can still see contents in revisions page and activities page

the user won't be able to delete the invisible note because content is not available
the user can edit the note but there's no existing value so it's like posting a new note