### PR TITLE
Feature/ Bidding console - allow config to specify subject area field

### DIFF
--- a/components/webfield/BidConsole.js
+++ b/components/webfield/BidConsole.js
@@ -249,7 +249,9 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
           { accessToken }
         )
         setNotes(
-          notesResult.filter((p) => p.content[subjectAreasName]?.value === subjectAreaSelected)
+          notesResult.filter(
+            (p) => p.content?.[subjectAreasName]?.value === subjectAreaSelected
+          )
         )
       } else {
         const result = await api.get(

--- a/components/webfield/BidConsole.js
+++ b/components/webfield/BidConsole.js
@@ -12,7 +12,7 @@ import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
 import Icon from '../Icon'
 import Dropdown from '../Dropdown'
-import { pluralizeString, prettyInvitationId } from '../../lib/utils'
+import { pluralizeString, prettyField, prettyInvitationId } from '../../lib/utils'
 import LoadingSpinner from '../LoadingSpinner'
 import PaginationLinks from '../PaginationLinks'
 import ErrorDisplay from '../ErrorDisplay'
@@ -39,8 +39,11 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
     scoreIds,
     submissionVenueId,
     subjectAreas,
+    subjectAreasName,
   } = useContext(WebFieldContext)
-  const defaultSubjectArea = 'All Subject Areas'
+  const defaultSubjectArea = subjectAreasName
+    ? `All ${prettyField(subjectAreasName)}`
+    : 'All Subject Areas'
   const [notes, setNotes] = useState([])
   const { user, accessToken } = useUser()
   const [pageNumber, setPageNumber] = useState(null)
@@ -53,8 +56,15 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
 
   const sortOptions = scoreIds?.map((p) => ({ label: prettyInvitationId(p), value: p }))
   const subjectAreaOptions = subjectAreas?.length
-    ? [{ label: 'All Subject Areas', value: 'All Subject Areas' }].concat(
-        subjectAreas.map((p) => ({ label: p, value: p }))
+    ? [
+        {
+          label: `All ${subjectAreasName ? prettyField(subjectAreasName) : 'Subject Areas'}`,
+          value: `All ${subjectAreasName ? prettyField(subjectAreasName) : 'Subject Areas'}`,
+        },
+      ].concat(
+        subjectAreasName
+          ? subjectAreas.map((p) => ({ label: p.description, value: p.value }))
+          : subjectAreas.map((p) => ({ label: p, value: p }))
       )
     : []
   const pageSize = 50
@@ -229,20 +239,34 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
     }
     setIsLoading(true)
     try {
-      const result = await api.get(
-        '/notes/search',
-        {
-          term: subjectAreaSelected,
-          type: 'terms',
-          content: 'subject_areas',
-          source: 'forum',
-          limit: 200,
-          offset: 0,
-          venueid: submissionVenueId,
-        },
-        { accessToken }
-      )
-      setNotes(result.notes.filter((p) => !conflictIds.includes(p.id)).slice(0, 100))
+      if (subjectAreasName) {
+        const notesResult = await api.getAll(
+          '/notes',
+          {
+            'content.venueid': submissionVenueId,
+            domain: invitation.domain,
+          },
+          { accessToken }
+        )
+        setNotes(
+          notesResult.filter((p) => p.content[subjectAreasName]?.value === subjectAreaSelected)
+        )
+      } else {
+        const result = await api.get(
+          '/notes/search',
+          {
+            term: subjectAreaSelected,
+            type: 'terms',
+            content: 'subject_areas',
+            source: 'forum',
+            limit: 200,
+            offset: 0,
+            venueid: submissionVenueId,
+          },
+          { accessToken }
+        )
+        setNotes(result.notes.filter((p) => !conflictIds.includes(p.id)).slice(0, 100))
+      }
     } catch (error) {
       promptError(error.message)
     }
@@ -283,13 +307,10 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
       setPageNumber(1)
       return
     }
-    if (
-      searchState.source === 'selectedSubjectArea' &&
-      searchState.selectedSubjectArea !== defaultSubjectArea
-    ) {
+    if (searchState.source === 'selectedSubjectArea') {
       handleSubjectAreaDropdownChange(searchState.selectedSubjectArea)
-      setShowPagination(false)
-      setShowBidScore(false)
+      setShowPagination(searchState.selectedSubjectArea === defaultSubjectArea)
+      setShowBidScore(searchState.selectedSubjectArea === defaultSubjectArea)
       return
     }
     if (searchState.source === 'immediateSearchTerm') {
@@ -348,7 +369,9 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
         )}
         {subjectAreas?.length > 0 && (
           <div className="form-group">
-            <label htmlFor="subjectarea-dropdown">Subject Area:</label>
+            <label htmlFor="subjectarea-dropdown">
+              {subjectAreasName ? prettyField(subjectAreasName) : 'Subject Area'}:
+            </label>
             <Dropdown
               className="dropdown-select subjectarea"
               options={subjectAreaOptions}
@@ -632,6 +655,7 @@ const BidConsole = ({ appContext }) => {
     submissionVenueId,
     conflictInvitationId,
     subjectAreas,
+    subjectAreasName,
     submissionName = 'Submission',
   } = useContext(WebFieldContext)
 

--- a/unitTests/BidConsole.test.js
+++ b/unitTests/BidConsole.test.js
@@ -5,6 +5,7 @@ import { renderWithWebFieldContext } from './util'
 import '@testing-library/jest-dom'
 import api from '../lib/api-client'
 
+jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
 jest.mock('../hooks/useUser', () => () => ({
   user: {
     profile: {

--- a/unitTests/BidConsole.test.js
+++ b/unitTests/BidConsole.test.js
@@ -1,0 +1,207 @@
+import userEvent from '@testing-library/user-event'
+import { screen, waitFor } from '@testing-library/react'
+import BidConsole from '../components/webfield/BidConsole'
+import { renderWithWebFieldContext } from './util'
+import '@testing-library/jest-dom'
+import api from '../lib/api-client'
+
+jest.mock('../hooks/useUser', () => () => ({
+  user: {
+    profile: {
+      id: 'some id',
+    },
+  },
+  accessToken: 'some token',
+}))
+jest.mock('../hooks/useQuery', () => () => ({}))
+let bidInvitation
+
+global.promptError = jest.fn()
+global.typesetMathJax = jest.fn()
+global.marked = jest.fn()
+global.DOMPurify = {
+  sanitize: jest.fn(),
+}
+
+beforeEach(() => {
+  bidInvitation = {
+    id: 'AAAI.org/2025/Conference/Program_Committee/-/Bid',
+    edge: {
+      label: {
+        param: {
+          enum: ['Very High', 'High', 'Neutral', 'Low', 'Very Low'],
+          input: 'radio',
+        },
+      },
+    },
+  }
+})
+
+describe('BidConsole', () => {
+  test('show error page if config is not complete', () => {
+    bidInvitation.edge.label.param.enum = undefined
+    const providerProps = {
+      value: {
+        header: {
+          title: 'Program Committee Bidding Console',
+          instructions: '** some instructions **',
+        },
+        venueId: 'AAAI.org/2025/Conference',
+        submissionVenueId: 'AAAI.org/2025/Conference/Submission',
+        entity: bidInvitation,
+        scoreIds: [],
+        conflictInvitationId: 'AAAI.org/2025/Conference/Program_Committee/-/Conflict',
+      },
+    }
+
+    renderWithWebFieldContext(
+      <BidConsole appContext={{ setBannerContent: jest.fn() }} />,
+      providerProps
+    )
+    expect(
+      screen.getByText('Bidding Console is missing required properties: bidOptions')
+    ).toBeInTheDocument()
+  })
+
+  test('support subjectAreasName', async () => {
+    const providerProps = {
+      value: {
+        header: {
+          title: 'Program Committee Bidding Console',
+          instructions: '** some instructions **',
+        },
+        venueId: 'AAAI.org/2025/Conference',
+        submissionVenueId: 'AAAI.org/2025/Conference/Submission',
+        entity: bidInvitation,
+        scoreIds: [],
+        conflictInvitationId: 'AAAI.org/2025/Conference/Program_Committee/-/Conflict',
+        subjectAreasName: 'primary_keyword',
+        subjectAreas: [
+          // subjectAreas is an array of objects when subjectAreasName is specified
+          { value: 'subject_area_1', description: 'Subject Area One' },
+          { value: 'subject_area_2', description: 'Subject Area Two' },
+        ],
+      },
+    }
+
+    api.getAll = jest.fn((path) => {
+      switch (path) {
+        case '/edges': // bid and conflict edges
+          return Promise.resolve([])
+        case '/notes': // all notes for subject areas dropdown filtering
+          return Promise.resolve([
+            {
+              id: 'noteId1',
+              content: {
+                title: {
+                  value: 'Note one',
+                },
+                primary_keyword: {
+                  value: 'subject_area_1',
+                },
+              },
+              invitations: ['AAAI.org/2025/Conference/-/Submission'],
+              readers: [
+                'AAAI.org/2025/Conference',
+                'AAAI.org/2025/Conference/Program_Committee',
+              ],
+            },
+            {
+              id: 'noteId2',
+              content: {
+                title: {
+                  value: 'Note two',
+                },
+                primary_keyword: {
+                  value: 'subject_area_2',
+                },
+              },
+              invitations: ['AAAI.org/2025/Conference/-/Submission'],
+              readers: [
+                'AAAI.org/2025/Conference',
+                'AAAI.org/2025/Conference/Program_Committee',
+              ],
+            },
+          ])
+        default:
+          return null
+      }
+    })
+
+    api.get = jest.fn((path) => {
+      switch (path) {
+        case '/notes':
+          return Promise.resolve({
+            notes: [
+              {
+                id: 'noteId1',
+                content: {
+                  title: {
+                    value: 'Note one',
+                  },
+                  primary_keyword: {
+                    value: 'subject_area_1',
+                  },
+                },
+                invitations: ['AAAI.org/2025/Conference/-/Submission'],
+                readers: [
+                  'AAAI.org/2025/Conference',
+                  'AAAI.org/2025/Conference/Program_Committee',
+                ],
+              },
+              {
+                id: 'noteId2',
+                content: {
+                  title: {
+                    value: 'Note two',
+                  },
+                  primary_keyword: {
+                    value: 'subject_area_2',
+                  },
+                },
+                invitations: ['AAAI.org/2025/Conference/-/Submission'],
+                readers: [
+                  'AAAI.org/2025/Conference',
+                  'AAAI.org/2025/Conference/Program_Committee',
+                ],
+              },
+            ],
+            count: 2,
+          })
+        default:
+          return null
+      }
+    })
+
+    renderWithWebFieldContext(
+      <BidConsole appContext={{ setBannerContent: jest.fn() }} />,
+      providerProps
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Primary Keyword', { exact: false })[0].textContent).toEqual(
+        // label is using custom name
+        'Primary Keyword:'
+      )
+    })
+
+    await userEvent.click(screen.getByRole('combobox'))
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Subject Area One' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Subject Area Two' })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('option', { name: 'Subject Area One' })) // select subject area one should filter out note 2
+    await waitFor(() => {
+      expect(screen.getByText('Note one')).toBeInTheDocument()
+      expect(screen.queryByText('Note two')).not.toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('combobox')) // select subject area two should filter out note 1
+    await userEvent.click(screen.getByRole('option', { name: 'Subject Area Two' }))
+    await waitFor(() => {
+      expect(screen.queryByText('Note one')).not.toBeInTheDocument()
+      expect(screen.getByText('Note two')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
currently the subject area dropdown search for a fixed field "subject_areas" using /notes/search route

bidding console can now specify a config 
> subjectAreasName

which is the note content field name which is used to compare with user selected subject area
when **subjectAreasName** is specified, the other config 
> subjectAreas

should be an array of objects with 2 fields: value and description
value is used to match note content field value and description is displayed in the subject areas field dropdown

the notes filtering method is also changed because not all note content fields are indexed so the filtering logic is moved inside the bidding console after getting all notes
