### PR TITLE
Fix/ Author Console - change profiles call to load for each paper

### DIFF
--- a/components/webfield/AuthorConsole.js
+++ b/components/webfield/AuthorConsole.js
@@ -328,15 +328,12 @@ const AuthorConsole = ({ appContext }) => {
 
   const loadProfiles = async (notes, version) => {
     const authorIds = new Set()
-    const authorEmails = new Set()
     notes.forEach((note) => {
       const ids = version === 2 ? note.content.authorids.value : note.content.authorids
       if (!Array.isArray(ids)) return
 
       ids.forEach((id) => {
-        if (id.includes('@')) {
-          authorEmails.add(id)
-        } else {
+        if (!id.includes('@')) {
           authorIds.add(id)
         }
       })
@@ -349,20 +346,22 @@ const AuthorConsole = ({ appContext }) => {
             .get('/profiles', { ids: Array.from(authorIds).join(',') }, { accessToken })
             .then(getProfiles)
         : Promise.resolve([])
-    const emailProfilesP =
-      authorEmails.size > 0
-        ? api
-            .get(
-              '/profiles',
-              { confirmedEmails: Array.from(authorEmails).join(',') },
-              { accessToken }
-            )
-            .then(getProfiles)
-        : Promise.resolve([])
+
+    const emailProfilesP = Promise.all(
+      notes.flatMap((note) => {
+        const emailIds = (
+          version === 2 ? note.content.authorids.value : note.content.authorids
+        )?.filter((id) => id.includes('@'))
+        if (!emailIds?.length) return []
+        return api
+          .get('/profiles', { confirmedEmails: emailIds.join(',') }, { accessToken })
+          .then(getProfiles)
+      })
+    )
     const [idProfiles, emailProfiles] = await Promise.all([idProfilesP, emailProfilesP])
 
     const profilesByUsernames = {}
-    idProfiles.concat(emailProfiles).forEach((profile) => {
+    idProfiles.concat(...emailProfiles).forEach((profile) => {
       profile.content.names.forEach((name) => {
         if (name.username) {
           profilesByUsernames[name.username] = profile


### PR DESCRIPTION
this pr should update the profile loading logic using emails in author console
to avoid the case that multiple emails of one user are used in different papers and some papers will show the user is not active