### PR TITLE
Fix/ Assignment stats: If the assignment is to another group, change "Papers" to group name

### DIFF
--- a/components/assignments/HistogramStat.js
+++ b/components/assignments/HistogramStat.js
@@ -94,7 +94,6 @@ ${customLoadInvitation ? `;${customLoadInvitation},head:ignore` : ''}\
       .attr('y', 15)
       .attr('text-anchor', 'middle')
       .text(stats.name)
-      .style('font-size', '1rem')
     svg = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
     const binCount = stats.binCount ?? 20
     const xAxisBarLabelFontStyle =

--- a/lib/assignment-stats-utils.js
+++ b/lib/assignment-stats-utils.js
@@ -162,7 +162,8 @@ export const getMeanPaperCountPerGroup = (assignmentMap) => {
 export const getDistributionPapersByUserCount = (
   assignmentMap,
   unassignedPapersList,
-  headName
+  headName,
+  tailName
 ) => {
   const paperMap = groupBy(assignmentMap, (p) => p.paperId) ?? {}
   let groupCountPerPaperList = Object.entries(paperMap).map(([paperId, matches]) => ({
@@ -178,12 +179,12 @@ export const getDistributionPapersByUserCount = (
   return {
     tag: 'discrete',
     data: groupCountPerPaperDataList,
-    name: `Distribution of ${headName} by Number of Users`,
+    name: `Distribution of ${headName} by Number of ${tailName}`,
     min: 0,
     max: groupCountPerPaperDataList
       .filter(Number.isFinite)
       .reduce((a, b) => Math.max(a, b), 0),
-    xLabel: 'Number of Users',
+    xLabel: `Number of ${tailName}`,
     yLabel: `Number of ${headName}`,
     type: 'paper',
     interactiveData: groupCountPerPaperList,
@@ -194,7 +195,8 @@ export const getDistributionPapersByUserCount = (
 export const getDistributionUsersByPaperCount = (
   assignmentMap,
   unassignedUsersList,
-  headName
+  headName,
+  tailName
 ) => {
   const groupMap = groupBy(assignmentMap, (p) => p.groupId) ?? {}
   let paperCountPerGroupList = Object.entries(groupMap).map(([p, matches]) => ({
@@ -211,13 +213,13 @@ export const getDistributionUsersByPaperCount = (
   return {
     tag: 'discrete',
     data: paperCountPerGroupDataList,
-    name: `Distribution of Users by Number of ${headName}`,
+    name: `Distribution of ${tailName} by Number of ${headName}`,
     min: 0,
     max: paperCountPerGroupDataList
       .filter(Number.isFinite)
       .reduce((a, b) => Math.max(a, b), 0),
     xLabel: `Number of ${headName}`,
-    yLabel: 'Number of Users',
+    yLabel: `Number of ${tailName}`,
     type: 'reviewer',
     interactiveData: paperCountPerGroupList,
   }
@@ -291,7 +293,11 @@ export const getDistributionPapersByMeanScore = (
 }
 
 // Distribution of Number of Users by Mean Scores
-export const getDistributionUsersByMeanScore = (assignmentMap, unassignedUsersList) => {
+export const getDistributionUsersByMeanScore = (
+  assignmentMap,
+  unassignedUsersList,
+  tailName
+) => {
   const groupMap = groupBy(assignmentMap, (p) => p.groupId) ?? {}
   const usersWithoutAssignmentsList = unassignedUsersList.map((p) => ({
     num: 0,
@@ -311,14 +317,14 @@ export const getDistributionUsersByMeanScore = (assignmentMap, unassignedUsersLi
   return {
     tag: 'continuous',
     data: meanScorePerGroupDataList,
-    name: 'Distribution of Number of Users by Mean Scores',
+    name: `Distribution of Number of ${tailName} by Mean Scores`,
     min: 0,
     max:
       1.1 *
       meanScorePerGroupDataList.filter(Number.isFinite).reduce((a, b) => Math.max(a, b), 0),
     binCount: 20,
     xLabel: 'Mean Score',
-    yLabel: 'Number of Users',
+    yLabel: `Number of ${tailName}`,
     type: 'reviewer',
     interactiveData: meanScorePerGroupList,
   }
@@ -370,7 +376,12 @@ export const getDistributionRecomGroupCountPerWeight = (assignmentMap) => {
 
 // Bid Distributions
 // Distribution of Number of Papers per User with Bid of bidVal (high, low, neutral ...)
-export const getNumDataPerGroupDataByBidScore = (assignmentMap, headName) => {
+export const getNumDataPerGroupDataByBidScore = (
+  assignmentMap,
+  headName,
+  tailName,
+  singularTailName
+) => {
   const bidValues = [...new Set(assignmentMap.flatMap((p) => p.otherScores.bid ?? []))].sort()
   const groupMap = groupBy(assignmentMap, (p) => p.groupId) ?? {}
 
@@ -386,14 +397,14 @@ export const getNumDataPerGroupDataByBidScore = (assignmentMap, headName) => {
         {
           tag: 'discrete',
           data: numDataPerGroupList.map((p) => p.num),
-          name: `Distribution of Number of ${headName} per User with Bid of ${bidVal}`,
+          name: `Distribution of Number of ${headName} per ${singularTailName} with Bid of ${bidVal}`,
           min: 0,
           max: numDataPerGroupList
             .map((p) => p.num)
             .filter(Number.isFinite)
             .reduce((a, b) => Math.max(a, b), 0),
           xLabel: `Number of ${headName} with Bid = ${bidVal}`,
-          yLabel: 'Number of Users',
+          yLabel: `Number of ${tailName}`,
           type: 'reviewer',
           interactiveData: numDataPerGroupList,
         },

--- a/lib/assignment-stats-utils.js
+++ b/lib/assignment-stats-utils.js
@@ -159,7 +159,11 @@ export const getMeanPaperCountPerGroup = (assignmentMap) => {
 }
 
 // Distribution of Papers by Number of Users
-export const getDistributionPapersByUserCount = (assignmentMap, unassignedPapersList) => {
+export const getDistributionPapersByUserCount = (
+  assignmentMap,
+  unassignedPapersList,
+  headName
+) => {
   const paperMap = groupBy(assignmentMap, (p) => p.paperId) ?? {}
   let groupCountPerPaperList = Object.entries(paperMap).map(([paperId, matches]) => ({
     num: matches.length,
@@ -174,20 +178,24 @@ export const getDistributionPapersByUserCount = (assignmentMap, unassignedPapers
   return {
     tag: 'discrete',
     data: groupCountPerPaperDataList,
-    name: 'Distribution of Papers by Number of Users',
+    name: `Distribution of ${headName} by Number of Users`,
     min: 0,
     max: groupCountPerPaperDataList
       .filter(Number.isFinite)
       .reduce((a, b) => Math.max(a, b), 0),
     xLabel: 'Number of Users',
-    yLabel: 'Number of Papers',
+    yLabel: `Number of ${headName}`,
     type: 'paper',
     interactiveData: groupCountPerPaperList,
   }
 }
 
 // Distribution of Users by Number of Papers
-export const getDistributionUsersByPaperCount = (assignmentMap, unassignedUsersList) => {
+export const getDistributionUsersByPaperCount = (
+  assignmentMap,
+  unassignedUsersList,
+  headName
+) => {
   const groupMap = groupBy(assignmentMap, (p) => p.groupId) ?? {}
   let paperCountPerGroupList = Object.entries(groupMap).map(([p, matches]) => ({
     num: matches.length,
@@ -203,12 +211,12 @@ export const getDistributionUsersByPaperCount = (assignmentMap, unassignedUsersL
   return {
     tag: 'discrete',
     data: paperCountPerGroupDataList,
-    name: 'Distribution of Users by Number of Papers',
+    name: `Distribution of Users by Number of ${headName}`,
     min: 0,
     max: paperCountPerGroupDataList
       .filter(Number.isFinite)
       .reduce((a, b) => Math.max(a, b), 0),
-    xLabel: 'Number of Papers',
+    xLabel: `Number of ${headName}`,
     yLabel: 'Number of Users',
     type: 'reviewer',
     interactiveData: paperCountPerGroupList,
@@ -245,7 +253,11 @@ export const getDistributionAssignmentByScore = (assignmentMap) => {
 }
 
 // Distribution of Number of Papers by Mean Scores
-export const getDistributionPapersByMeanScore = (assignmentMap, unassignedPapersList) => {
+export const getDistributionPapersByMeanScore = (
+  assignmentMap,
+  unassignedPapersList,
+  headName
+) => {
   const paperMap = groupBy(assignmentMap, (p) => p.paperId) ?? {}
   const papersWithoutAssignmentsList = unassignedPapersList.map((paperId) => ({
     num: 0,
@@ -265,14 +277,14 @@ export const getDistributionPapersByMeanScore = (assignmentMap, unassignedPapers
   return {
     tag: 'continuous',
     data: meanScorePerPaperDataList,
-    name: 'Distribution of Number of Papers by Mean Scores',
+    name: `Distribution of Number of ${headName} by Mean Scores`,
     min: 0,
     max:
       1.1 *
       meanScorePerPaperDataList.filter(Number.isFinite).reduce((a, b) => Math.max(a, b), 0),
     binCount: 20,
     xLabel: 'Mean Score',
-    yLabel: 'Number of Papers',
+    yLabel: `Number of ${headName}`,
     type: 'paper',
     interactiveData: meanScorePerPaperList,
   }
@@ -313,7 +325,11 @@ export const getDistributionUsersByMeanScore = (assignmentMap, unassignedUsersLi
 }
 
 // Distribution of Number of Recommended Users per Paper
-export const getDistributionRecomGroupCountPerPaper = (assignmentMap) => {
+export const getDistributionRecomGroupCountPerPaper = (
+  assignmentMap,
+  headName,
+  singularHeadName
+) => {
   const paperMap = groupBy(assignmentMap, (p) => p.paperId) ?? {}
   const recomNumDataPerPaperList = Object.entries(paperMap).map(([paperId, matches]) => ({
     num: matches.filter((p) => p.otherScores.recommendation > 0).length,
@@ -324,14 +340,14 @@ export const getDistributionRecomGroupCountPerPaper = (assignmentMap) => {
     tag: 'discrete',
     data: recomNumDataPerPaperList.map((p) => p.num),
     interactiveData: recomNumDataPerPaperList,
-    name: 'Distribution of Number of Recommended Users per Paper',
+    name: `Distribution of Number of Recommended Users per ${singularHeadName}`,
     min: 0,
     max: recomNumDataPerPaperList
       .map((p) => p.num)
       .filter(Number.isFinite)
       .reduce((a, b) => Math.max(a, b), 0),
     xLabel: 'Number of Users',
-    yLabel: 'Number of Papers',
+    yLabel: `Number of ${headName}`,
     type: 'paper',
   }
 }
@@ -354,7 +370,7 @@ export const getDistributionRecomGroupCountPerWeight = (assignmentMap) => {
 
 // Bid Distributions
 // Distribution of Number of Papers per User with Bid of bidVal (high, low, neutral ...)
-export const getNumDataPerGroupDataByBidScore = (assignmentMap) => {
+export const getNumDataPerGroupDataByBidScore = (assignmentMap, headName) => {
   const bidValues = [...new Set(assignmentMap.flatMap((p) => p.otherScores.bid ?? []))].sort()
   const groupMap = groupBy(assignmentMap, (p) => p.groupId) ?? {}
 
@@ -370,13 +386,13 @@ export const getNumDataPerGroupDataByBidScore = (assignmentMap) => {
         {
           tag: 'discrete',
           data: numDataPerGroupList.map((p) => p.num),
-          name: `Distribution of Number of Papers per User with Bid of ${bidVal}`,
+          name: `Distribution of Number of ${headName} per User with Bid of ${bidVal}`,
           min: 0,
           max: numDataPerGroupList
             .map((p) => p.num)
             .filter(Number.isFinite)
             .reduce((a, b) => Math.max(a, b), 0),
-          xLabel: `Number of Papers with Bid = ${bidVal}`,
+          xLabel: `Number of ${headName} with Bid = ${bidVal}`,
           yLabel: 'Number of Users',
           type: 'reviewer',
           interactiveData: numDataPerGroupList,

--- a/pages/assignments/stats.js
+++ b/pages/assignments/stats.js
@@ -41,12 +41,16 @@ const AssignmentStats = ({ appContext }) => {
   const [values, setValues] = useState({})
   const [groupId, setGroupId] = useState(null)
   const [error, setError] = useState(null)
-  const [headName, setHeadName] = useState('papers')
+  const [labelNames, setLabelNames] = useState({})
   const query = useQuery()
   const { setBannerContent } = appContext
 
+  const headName = labelNames.headName ?? 'papers'
+  const tailName = labelNames.tailName ?? 'users'
   const upperHeadName = upperFirst(headName)
+  const upperTailName = upperFirst(tailName)
   const upperSingularHeadName = getSingularRoleName(upperHeadName)
+  const upperSingularTailName = getSingularRoleName(upperTailName)
 
   let edgeBrowserUrlParams = {}
   if (assignmentConfigNote) {
@@ -83,7 +87,16 @@ const AssignmentStats = ({ appContext }) => {
           const headNameInAssignmentInvitation = prettyId(
             assignmentInvitation?.edge?.head?.param?.inGroup?.split('/').pop()
           )
-          if (headNameInAssignmentInvitation) setHeadName(headNameInAssignmentInvitation)
+          const tailNameInAssignmentInvitation = prettyId(
+            assignmentInvitation?.edge?.tail?.param?.options?.group?.split('/').pop()
+          )
+
+          if (headNameInAssignmentInvitation && tailNameInAssignmentInvitation) {
+            setLabelNames({
+              headName: headNameInAssignmentInvitation,
+              tailName: tailNameInAssignmentInvitation,
+            })
+          }
           setAssignmentConfigNote({ ...note, content: getNoteContentValues(note.content) })
           setGroupId(getGroupIdfromInvitation(note.invitations[0]))
         } else {
@@ -274,12 +287,14 @@ const AssignmentStats = ({ appContext }) => {
       distributionPapersByUserCount: getDistributionPapersByUserCount(
         matchLists[0],
         matchLists[1],
-        upperHeadName
+        upperHeadName,
+        upperTailName
       ),
       distributionUsersByPaperCount: getDistributionUsersByPaperCount(
         matchLists[0],
         matchLists[2],
-        upperHeadName
+        upperHeadName,
+        upperTailName
       ),
       distributionAssignmentByScore: getDistributionAssignmentByScore(matchLists[0]),
       distributionPapersByMeanScore: getDistributionPapersByMeanScore(
@@ -289,7 +304,8 @@ const AssignmentStats = ({ appContext }) => {
       ),
       distributionUsersByMeanScore: getDistributionUsersByMeanScore(
         matchLists[0],
-        matchLists[2]
+        matchLists[2],
+        upperTailName
       ),
       ...(showRecommendationDistribution && {
         distributionRecomGroupCountPerPaper: getDistributionRecomGroupCountPerPaper(
@@ -301,7 +317,12 @@ const AssignmentStats = ({ appContext }) => {
           matchLists[0]
         ),
       }),
-      ...getNumDataPerGroupDataByBidScore(matchLists[0], upperHeadName),
+      ...getNumDataPerGroupDataByBidScore(
+        matchLists[0],
+        upperHeadName,
+        upperTailName,
+        upperSingularTailName
+      ),
     })
   }, [matchLists])
 
@@ -377,16 +398,16 @@ const AssignmentStats = ({ appContext }) => {
         />
         <ScalarStat
           value={values.userCount}
-          name="Number of users / Number of users with assignments"
+          name={`Number of ${tailName} / Number of ${tailName} with assignments`}
         />
         <ScalarStat value={values.meanFinalScore} name="Mean Final Score" />
         <ScalarStat
           value={values.meanGroupCountPerPaper}
-          name={`Mean Number of Users per ${upperSingularHeadName}`}
+          name={`Mean Number of ${upperTailName} per ${upperSingularHeadName}`}
         />
         <ScalarStat
           value={values.meanPaperCountPerGroup}
-          name={`Mean Number of ${upperHeadName} per User`}
+          name={`Mean Number of ${upperHeadName} per ${upperSingularTailName}`}
         />
         {assignmentConfigNote?.content.randomized_fraction_of_opt && (
           <ScalarStat

--- a/styles/pages/assignment-stats.scss
+++ b/styles/pages/assignment-stats.scss
@@ -160,7 +160,7 @@ main.assignment-stats {
     }
     .stat-name {
       text-align: center;
-      font-size: clamp(0.25rem, 0.8rem, 1rem);
+      font-size: clamp(0.25rem, 0.75rem, 0.8rem);
     }
   }
 

--- a/styles/pages/assignment-stats.scss
+++ b/styles/pages/assignment-stats.scss
@@ -64,7 +64,6 @@ main.assignment-stats {
     background-color: constants.$sandyBrown;
     border: 1px solid constants.$backgroundGray;
     text-align: center;
-    height: 180px;
     padding: 1rem;
     margin-bottom: 1rem;
 
@@ -124,10 +123,7 @@ main.assignment-stats {
       margin: 0.5rem;
 
       .stat-name {
-        max-height: 60px;
         display: -webkit-box;
-        overflow: hidden;
-        -webkit-line-clamp: 3;
         -webkit-box-orient: vertical;
       }
     }
@@ -164,6 +160,7 @@ main.assignment-stats {
     }
     .stat-name {
       text-align: center;
+      font-size: clamp(0.25rem, 0.8rem, 1rem);
     }
   }
 


### PR DESCRIPTION
this pr should update title/axis names in assignment stats page

currently it's reading config note's assignment_invitation content field to get invitation.edge.head.inGroup for the head name
when inGroup does not exist (for example role to paper matching) then it defaults to "papers"