### PR TITLE
Fix/ PC/SAC/AC console - convert avg rating/confidence to number

### DIFF
--- a/components/webfield/AreaChairConsoleMenuBar.js
+++ b/components/webfield/AreaChairConsoleMenuBar.js
@@ -184,10 +184,14 @@ const AreaChairConsoleMenuBar = ({
       {
         label: `Average ${prettyField(ratingName)}`,
         value: `Average ${ratingName}`,
-        getValue: (p) =>
-          p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg === 'N/A'
-            ? 0
-            : p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg,
+        getValue: (p) => {
+          const stringAvgRatingValue = p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg
+          if (stringAvgRatingValue === 'N/A') return 0
+          const numberAvgRatingValue = Number(stringAvgRatingValue)
+          return Number.isNaN(numberAvgRatingValue)
+            ? stringAvgRatingValue
+            : numberAvgRatingValue
+        },
       },
       {
         label: `Max ${prettyField(ratingName)}`,
@@ -209,10 +213,14 @@ const AreaChairConsoleMenuBar = ({
     {
       label: 'Average Confidence',
       value: 'Average Confidence',
-      getValue: (p) =>
-        p.reviewProgressData?.confidenceAvg === 'N/A'
-          ? 0
-          : p.reviewProgressData?.confidenceAvg,
+      getValue: (p) => {
+        const stringAvgConfidenceValue = p.reviewProgressData?.confidenceAvg
+        if (stringAvgConfidenceValue === 'N/A') return 0
+        const numberAvgConfidenceValue = Number(stringAvgConfidenceValue)
+        return Number.isNaN(numberAvgConfidenceValue)
+          ? stringAvgConfidenceValue
+          : numberAvgConfidenceValue
+      },
     },
     {
       label: 'Max Confidence',

--- a/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
@@ -328,8 +328,15 @@ const PaperStatusMenuBar = ({
       {
         label: `Average ${prettyField(ratingName)}`,
         value: `Average ${ratingName}`,
-        getValue: (p) =>
-          getValueWithDefault(p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg),
+        getValue: (p) => {
+          const stringAvgRatingValue = getValueWithDefault(
+            p.reviewProgressData?.ratings?.[ratingName]?.ratingAvg
+          )
+          const numberAvgRatingValue = Number(stringAvgRatingValue)
+          return Number.isNaN(numberAvgRatingValue)
+            ? stringAvgRatingValue
+            : numberAvgRatingValue
+        },
       },
       {
         label: `Max ${prettyField(ratingName)}`,
@@ -354,7 +361,15 @@ const PaperStatusMenuBar = ({
     {
       label: 'Average Confidence',
       value: 'Average Confidence',
-      getValue: (p) => getValueWithDefault(p.reviewProgressData?.confidenceAvg),
+      getValue: (p) => {
+        const stringAvgConfidenceValue = getValueWithDefault(
+          p.reviewProgressData?.confidenceAvg
+        )
+        const numberAvgConfidenceValue = Number(stringAvgConfidenceValue)
+        return Number.isNaN(numberAvgConfidenceValue)
+          ? stringAvgConfidenceValue
+          : numberAvgConfidenceValue
+      },
     },
     {
       label: 'Max Confidence',


### PR DESCRIPTION
currently average rating/confidence is of type string to keep the two-digit formatting.
when rating/confidence is between 0-9 this is fine but when rating/confidence goes over 10 it will cause some rows to be wrongly sorted.

for example when sorted by average rating, row with average rating = 11.00 will be placed between rows with rating = 1.00 and rows with rating = 2.00

this pr should fix this issue by converting the avg value to number (if convertible) before sorting.