### PR TITLE
Fix/Edge browser- update checkbox wording

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -288,12 +288,12 @@ export default function Column(props) {
     if (query.filter) {
       return (
         <>
-          {`Only show ${group} available for ${invitation} `}
+          {`Show ${group} available for ${invitation} `}
           <Icon name="info-sign" tooltip={query.filter} />
         </>
       )
     }
-    return `Only show ${group} with fewer than max assigned papers`
+    return `Show ${group} with fewer than max assigned papers`
   }
 
   // Adds either a new browse edge or an edit edge to an item


### PR DESCRIPTION
with changes in https://github.com/openreview/openreview-web/pull/1480

it's possible that checking the filter checkbox shows more entities which contradicts with user's intuition that checking the checkbox should show less items because the label says "Only show ..."

this pr should remove "only"