### PR TITLE
Fix/ Tasks - TEMP fix for completion status of AE recommendation task

### DIFF
--- a/pages/tasks.js
+++ b/pages/tasks.js
@@ -75,7 +75,6 @@ const Tasks = ({ appContext }) => {
             .get('/edges', {
               invitation: `${p.domain}/Action_Editors/-/Recommendation`,
               groupBy: 'head',
-              domain: p.domain,
             })
             .then((result) => result.groupedEdges)
         )


### PR DESCRIPTION
this pr is a temporary fix for:

AE recommendation task of TMLR is for author to recommend 3 AEs for each paper submitted
when the author recommend 3 AEs, the tasks is displayed as completed in author console but still pending in tasks page

the issue is caused by the edge being posted using the non paper specific AE recommendation invitation while the invitations loaded in tasks page (and author console tasks tab) are paper specific. the consequence is that the repliedEdges can't be loaded correctly in invitation details and the task status is pending

TMLR author console is working because a custom logic being added because it's not using component webfield.

this pr should serve as a temporary fix of the discrepancy between author console and tasks page

this pr assumes:
- ae recommendation invitation ends with /Action_Editors/-/Recommendation
- the venue domain is the same as venue id