### PR TITLE
Fix/ Login page - add tooltip when email is invalid

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -1,5 +1,4 @@
-/* globals promptError: false */
-/* globals promptMessage: false */
+/* globals promptError,promptMessage,$: false */
 
 import { useState, useContext, useEffect } from 'react'
 import Link from 'next/link'
@@ -46,6 +45,10 @@ const LoginForm = () => {
     }
   }
 
+  useEffect(() => {
+    $('[data-toggle="tooltip"]').tooltip()
+  }, [])
+
   return (
     <form onSubmit={handleSubmit}>
       <div className="form-group">
@@ -83,6 +86,10 @@ const LoginForm = () => {
         type="submit"
         className="btn btn-login"
         disabled={!isValidEmail(email) || !password}
+        data-original-title={
+          email && !isValidEmail(email) ? 'Please enter a valid email address' : ''
+        }
+        data-toggle="tooltip"
       >
         Login to OpenReview
       </button>

--- a/tests/issue.ts
+++ b/tests/issue.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 import { Selector, ClientFunction } from 'testcafe'
 import { strongPassword } from './utils/api-helper'
 
@@ -8,7 +9,6 @@ const loginButton = Selector('button').withText('Login to OpenReview')
 const getLocation = ClientFunction(() => document.location.href)
 const homepageUrl = `http://localhost:${process.env.NEXT_PORT}`
 
-// eslint-disable-next-line no-unused-expressions
 fixture`#763 Login redirect is not cleared when user go back to homepage`
 test('user not redirected to group page', async (t) => {
   await t
@@ -44,4 +44,26 @@ routesToSkipRedirection.forEach((route) => {
       .expect(getLocation())
       .eql(`${homepageUrl}/`)
   })
+})
+
+fixture`miscellaneous issues`
+test('login button to show tooltip when email is invalid', async (t) => {
+  await t
+    .navigateTo(`${homepageUrl}/login`)
+    .typeText('#email-input', '~tilde_id1')
+    .typeText('#password-input', strongPassword)
+    .expect(loginButton.hasAttribute('disabled')).ok()
+    .expect(
+      loginButton.withAttribute(
+        'data-original-title',
+        'Please enter a valid email address'
+      ).exists).ok()
+
+  await t.typeText('#email-input', 'test@mail.com', { replace: true })
+    .expect(loginButton.hasAttribute('disabled')).notOk()
+    .expect(
+      loginButton.withAttribute(
+        'data-original-title',
+        'Please enter a valid email address'
+      ).exists).notOk()
 })


### PR DESCRIPTION
some users overlook the "Email" label and think they can use tild id or name to login

currently the login button is only disabled

this pr should add a tooltip when the email that user entered is invalid