### PR TITLE
Fix/ Revisions page - Remove tauthor

### DIFF
--- a/pages/revisions/index.js
+++ b/pages/revisions/index.js
@@ -62,7 +62,7 @@ const RevisionsList = ({
   const router = useRouter()
   const [editToChange, setEditToChange] = useState(null)
   const [confirmDeleteModalData, setConfirmDeleteModalData] = useState(null)
-  const newNoteEditor = revisions?.some((p) => p?.[1]?.domain)
+  const newNoteEditor = revisions?.some((p) => p?.[0]?.domain)
 
   const toggleSelected = (idx, checked) => {
     if (checked) {


### PR DESCRIPTION
this pr should :
1. remove tauthor when loading revision edits so that AE can see paper revisions
2. fix new note editor logic to check any of the invitations has domain instead of the first edit