### PR TITLE
Fix/ PC Console - separate propertiesAllowed config for AC status tab

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -79,6 +79,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
     submissionContentFields = [],
     sacDirectPaperAssignment,
     propertiesAllowed,
+    areaChairStatusPropertiesAllowed,
     sacStatuspropertiesAllowed,
     messageAreaChairsInvitationId,
     messageSeniorAreaChairsInvitationId,

--- a/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/AreaChairStatusMenuBar.js
@@ -110,11 +110,11 @@ export const MessageACSACModal = ({
         return profile
           ? {
               id,
-              preferredName: profile.preferredName
+              preferredName: profile.preferredName,
             }
           : {
               id,
-              preferredName: id
+              preferredName: id,
             }
       })
     )
@@ -197,7 +197,7 @@ const AreaChairStatusMenuBar = ({
     acEmailFuncs,
     areaChairStatusExportColumns: exportColumnsConfig,
     filterOperators: filterOperatorsConfig,
-    propertiesAllowed: propertiesAllowedConfig,
+    areaChairStatusPropertiesAllowed,
     seniorAreaChairName = 'Senior_Area_Chairs',
     areaChairName = 'Area_Chairs',
     officialReviewName,
@@ -206,7 +206,7 @@ const AreaChairStatusMenuBar = ({
     reviewerName,
   } = useContext(WebFieldContext)
   const filterOperators = filterOperatorsConfig ?? ['!=', '>=', '<=', '>', '<', '==', '=']
-  const propertiesAllowed = propertiesAllowedConfig ?? {
+  const propertiesAllowed = areaChairStatusPropertiesAllowed ?? {
     number: ['number'],
     name: ['areaChairProfile.preferredName'],
     [camelCase(seniorAreaChairName)]: ['seniorAreaChair.seniorAreaChairId'],


### PR DESCRIPTION
this pr should add a config in PC console
> areaChairStatusPropertiesAllowed

which is the query search config overwrite for AC status tab

currently AC status tab reads the config "propertiesAllowed" which is for paper status tab but the data structure of paper status tab and ac status tab are different so it probably won't work.

the behavior of overwriting the default config is not changed because it's consistent with SAC status tab (direct paper assignment)