### PR TITLE
Fix/ PC console Paper Status: Don't show SAC name as a property in the query search modal if there are no SACs

### DIFF
--- a/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
+++ b/components/webfield/ProgramChairConsole/PaperStatusMenuBar.js
@@ -15,6 +15,7 @@ const PaperStatusMenuBar = ({
   setPaperStatusTabData,
   reviewRatingName,
   noteContentField,
+  defaultSeniorAreaChairName,
 }) => {
   const {
     metaReviewRecommendationName,
@@ -28,7 +29,7 @@ const PaperStatusMenuBar = ({
     customStageInvitations = [],
     additionalMetaReviewFields = [],
     reviewerName,
-    seniorAreaChairName = 'Senior_Area_Chairs',
+    seniorAreaChairName = defaultSeniorAreaChairName,
     officialReviewName,
     officialMetaReviewName = 'Meta_Review',
     areaChairName = 'Area_Chairs',
@@ -48,7 +49,7 @@ const PaperStatusMenuBar = ({
     author: ['note.content.authors.value', 'note.content.authorids.value'],
     keywords: ['note.content.keywords.value'],
     [formattedReviewerName]: ['reviewers'],
-    [formattedSACName]: ['metaReviewData.seniorAreaChairs'],
+    ...(formattedSACName && { [formattedSACName]: ['metaReviewData.seniorAreaChairs'] }),
     [`num${upperFirst(formattedReviewerName)}Assigned`]: [
       'reviewProgressData.numReviewersAssigned',
     ],

--- a/components/webfield/SeniorAreaChairConsole/PaperStatus.js
+++ b/components/webfield/SeniorAreaChairConsole/PaperStatus.js
@@ -194,6 +194,7 @@ const PaperStatus = ({ sacConsoleData }) => {
           setSelectedNoteIds={setSelectedNoteIds}
           setPaperStatusTabData={setPaperStatusTabData}
           reviewRatingName={reviewRatingName}
+          defaultSeniorAreaChairName="Senior_Area_Chairs"
         />
         <p className="empty-message">
           No {pluralizeString(submissionName.toLowerCase())} matching search criteria.
@@ -209,6 +210,7 @@ const PaperStatus = ({ sacConsoleData }) => {
         setSelectedNoteIds={setSelectedNoteIds}
         setPaperStatusTabData={setPaperStatusTabData}
         reviewRatingName={reviewRatingName}
+        defaultSeniorAreaChairName="Senior_Area_Chairs"
       />
 
       <Table


### PR DESCRIPTION
pass default value only for sac console
so that venues with no sac role won't have the sac search key