### PR TITLE
Fix/ Bidding Console - add enableSearch config to enable/disable search input

### DIFF
--- a/components/webfield/BidConsole.js
+++ b/components/webfield/BidConsole.js
@@ -40,6 +40,7 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
     submissionVenueId,
     subjectAreas,
     subjectAreasName,
+    enableSearch = true,
   } = useContext(WebFieldContext)
   const defaultSubjectArea = subjectAreasName
     ? `All ${prettyField(subjectAreasName)}`
@@ -343,21 +344,23 @@ const AllSubmissionsTab = ({ bidEdges, setBidEdges, conflictIds, bidOptions }) =
           }
         }}
       >
-        <div className="form-group search-content has-feedback">
-          <input
-            id="paper-search-input"
-            type="text"
-            className="form-control"
-            placeholder="Search by paper title and metadata"
-            autoComplete="off"
-            value={searchState.immediateSearchTerm}
-            onChange={(e) => {
-              setSearchState({ type: 'immediateSearchTerm', payload: e.target.value })
-              if (e.target.value.trim().length >= 3) delaySearch(e.target.value)
-            }}
-          />
-          <Icon name="search" extraClasses="form-control-feedback" />
-        </div>
+        {enableSearch && (
+          <div className="form-group search-content has-feedback">
+            <input
+              id="paper-search-input"
+              type="text"
+              className="form-control"
+              placeholder="Search by paper title and metadata"
+              autoComplete="off"
+              value={searchState.immediateSearchTerm}
+              onChange={(e) => {
+                setSearchState({ type: 'immediateSearchTerm', payload: e.target.value })
+                if (e.target.value.trim().length >= 3) delaySearch(e.target.value)
+              }}
+            />
+            <Icon name="search" extraClasses="form-control-feedback" />
+          </div>
+        )}
         {scoreIds?.length > 0 && (
           <div className="form-group score">
             <label htmlFor="score-dropdown">Sort By:</label>
@@ -659,6 +662,7 @@ const BidConsole = ({ appContext }) => {
     subjectAreas,
     subjectAreasName,
     submissionName = 'Submission',
+    enableSearch = true,
   } = useContext(WebFieldContext)
 
   const bidOptions = invitation.edge?.label?.param?.enum

--- a/unitTests/BidConsole.test.js
+++ b/unitTests/BidConsole.test.js
@@ -184,6 +184,9 @@ describe('BidConsole', () => {
         // label is using custom name
         'Primary Keyword:'
       )
+      expect(
+        screen.queryByPlaceholderText('Search by paper title and metadata')
+      ).toBeInTheDocument()
     })
 
     await userEvent.click(screen.getByRole('combobox'))
@@ -203,6 +206,56 @@ describe('BidConsole', () => {
     await waitFor(() => {
       expect(screen.queryByText('Note one')).not.toBeInTheDocument()
       expect(screen.getByText('Note two')).toBeInTheDocument()
+    })
+  })
+
+  test('not to show search input when enableSearch is set to false', async () => {
+    const providerProps = {
+      value: {
+        header: {
+          title: 'Program Committee Bidding Console',
+          instructions: '** some instructions **',
+        },
+        venueId: 'AAAI.org/2025/Conference',
+        submissionVenueId: 'AAAI.org/2025/Conference/Submission',
+        entity: bidInvitation,
+        scoreIds: [],
+        enableSearch: false,
+      },
+    }
+
+    api.getAll = jest.fn((path) => {
+      switch (path) {
+        case '/edges':
+          return Promise.resolve([])
+        case '/notes':
+          return Promise.resolve([])
+        default:
+          return null
+      }
+    })
+
+    api.get = jest.fn((path) => {
+      switch (path) {
+        case '/notes':
+          return Promise.resolve({
+            notes: [],
+            count: 0,
+          })
+        default:
+          return null
+      }
+    })
+
+    renderWithWebFieldContext(
+      <BidConsole appContext={{ setBannerContent: jest.fn() }} />,
+      providerProps
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.queryByPlaceholderText('Search by paper title and metadata')
+      ).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
this pr should add a config 
>enableSearch

which has default value true in bidding console to hide the search input (when set to false)

the use case is that the user should only see papers with a score edge