### PR TITLE
Fix/ AC console - fix messaging missing anon group when AC can't see anon reviewer group

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -340,7 +340,7 @@ const AreaChairConsole = ({ appContext }) => {
                     (t.id === r || t.members[0] === r)
                 )
                 return {
-                  anonymizedGroup: anonymousReviewerGroup?.id,
+                  anonymizedGroup: anonymousReviewerGroup?.id ?? r,
                   anonymousId: getIndentifierFromGroup(
                     anonymousReviewerGroup?.id || r,
                     anonReviewerName


### PR DESCRIPTION
fix messaging in AC Console when AC can't see anon reviewer group