### PR TITLE
Update password reset success message

### DIFF
--- a/pages/reset.js
+++ b/pages/reset.js
@@ -78,10 +78,11 @@ function Reset() {
 
         {emailSent ? (
           <Alert color="success">
-            An email with the subject &quot;OpenReview Password Reset&quot; has been sent to
+            Your request has been received. If an account matches the email
             {'  '}
-            <strong>{emailSent}</strong>. Please follow the link in this email to reset your
-            password.
+            <strong>{emailSent}</strong>, you will receive an email with the subject
+            &quot;OpenReview Password Reset&quot;. Please follow the link in this email to
+            reset your password.
           </Alert>
         ) : (
           <>


### PR DESCRIPTION
This updates the password reset success message so that users know they may not receive an email if an account is not associated with the email they entered.

We have been getting emails from users confused why they haven't received this email and this gives them one possible reason.

Ex:
<img width="500" alt="Screenshot 2024-10-16 at 2 10 09 PM" src="https://github.com/user-attachments/assets/340a5844-af53-46b2-a698-e1bea7601e9a">
