### PR TITLE
Fix/ Terms updated date

### DIFF
--- a/components/profile/ProfileEditor.js
+++ b/components/profile/ProfileEditor.js
@@ -740,7 +740,7 @@ export default function ProfileEditor({
           <a href="/legal/terms" target="_blank" rel="noopener noreferrer">
             <strong>Terms of Use</strong>
           </a>
-          , last updated September 22, 2023.
+          , last updated September 24, 2024.
         </p>
       )}
 

--- a/pages/legal/terms.js
+++ b/pages/legal/terms.js
@@ -17,7 +17,7 @@ const Terms = () => (
 
     <div className="row">
       <div className="col-xs-12 col-md-10 col-md-offset-1">
-        <p className="text-muted">Last updated: September 22, 2023</p>
+        <p className="text-muted">Last updated: September 24, 2024</p>
         <p>
           These Terms of Use are a contract between you and OpenReview. OpenReview operates
           OpenReview.net and provides data, software and services, with the objective of

--- a/pages/login.js
+++ b/pages/login.js
@@ -80,7 +80,7 @@ const LoginForm = () => {
         <a href="/legal/terms" target="_blank" rel="noopener noreferrer">
           <strong>Terms of Use</strong>
         </a>
-        , last updated September 22, 2023.
+        , last updated September 24, 2024.
       </p>
       <button
         type="submit"

--- a/tests/issue.ts
+++ b/tests/issue.ts
@@ -67,3 +67,19 @@ test('login button to show tooltip when email is invalid', async (t) => {
         'Please enter a valid email address'
       ).exists).notOk()
 })
+
+test('terms and conditions date should be updated', async (t) => {
+  // terms page, privacy page, login page and signup page
+  await t
+    .navigateTo(`${homepageUrl}/legal/terms`)
+    .expect(Selector('p').withText('September 24, 2024').exists).ok()
+
+  await t
+    .navigateTo(`${homepageUrl}/legal/privacy`)
+    .expect(Selector('p').withText('September 24, 2024').exists).ok()
+
+  await t
+    .navigateTo(`${homepageUrl}/login`)
+    .expect(Selector('p').withText('September 24, 2024').exists).ok()
+
+})

--- a/tests/issue.ts
+++ b/tests/issue.ts
@@ -70,16 +70,17 @@ test('login button to show tooltip when email is invalid', async (t) => {
 
 test('terms and conditions date should be updated', async (t) => {
   // terms page, privacy page, login page and signup page
+  const lastUpdatedDate = 'September 24, 2024'
   await t
     .navigateTo(`${homepageUrl}/legal/terms`)
-    .expect(Selector('p').withText('September 24, 2024').exists).ok()
+    .expect(Selector('p').withText(lastUpdatedDate).exists).ok()
 
   await t
     .navigateTo(`${homepageUrl}/legal/privacy`)
-    .expect(Selector('p').withText('September 24, 2024').exists).ok()
+    .expect(Selector('p').withText(lastUpdatedDate).exists).ok()
 
   await t
     .navigateTo(`${homepageUrl}/login`)
-    .expect(Selector('p').withText('September 24, 2024').exists).ok()
+    .expect(Selector('p').withText(lastUpdatedDate).exists).ok()
 
 })

--- a/tests/registerPage.ts
+++ b/tests/registerPage.ts
@@ -435,6 +435,7 @@ test('update profile', async (t) => {
 
     .click(nextSectiomButtonSelector) // relation
     .click(nextSectiomButtonSelector) // last section expertise
+    .expect(Selector('p').withText("last updated September 24, 2024").exists).ok()
     .click(Selector('button').withText('Register for OpenReview'))
     .expect(messagePanelSelector.exists)
     .ok()


### PR DESCRIPTION
currently only the privacy page last updated date is changed.
this pr should make the last updated date in 
- login page
- terms and conditions page
- signup page

to be consistent with privacy page

this pr should also add a test to make sure the date in these pages are always consistent