### PR TITLE
Feature/ Venue homepage - Add arbitraryNoteList component

### DIFF
--- a/components/webfield/ArbitraryNoteList.js
+++ b/components/webfield/ArbitraryNoteList.js
@@ -1,0 +1,47 @@
+/* globals promptError: false */
+
+import { useEffect, useState } from 'react'
+import LoadingSpinner from '../LoadingSpinner'
+import api from '../../lib/api-client'
+import useUser from '../../hooks/useUser'
+import NoteList from '../NoteList'
+
+const ArbitraryNoteList = ({ noteIds, setHidden }) => {
+  const [allNotes, setAllNotes] = useState(null)
+  const { accessToken } = useUser()
+
+  const loadNotes = async () => {
+    try {
+      const result = await api.getAll(
+        '/notes',
+        { ids: noteIds.slice(0, 500), details: 'replyCount' },
+        { accessToken }
+      )
+      if (result.length === 0) setHidden(true)
+      setAllNotes(result)
+    } catch (error) {
+      promptError(error.message)
+      setHidden(true)
+    }
+  }
+
+  useEffect(() => {
+    loadNotes()
+  }, [noteIds])
+
+  if (!allNotes) return <LoadingSpinner />
+  return (
+    <NoteList
+      notes={allNotes}
+      displayOptions={{
+        showContents: true,
+        showPrivateIcon: true,
+        collapse: false,
+        replyCount: true,
+        extraClasses: 'arbitrary-note-list',
+      }}
+    />
+  )
+}
+
+export default ArbitraryNoteList

--- a/components/webfield/VenueHomepage.js
+++ b/components/webfield/VenueHomepage.js
@@ -1,5 +1,4 @@
-/* globals promptError: false */
-/* globals promptMessage: false */
+/* globals promptError, promptMessage: false */
 
 import { useState, useContext, useEffect, useReducer } from 'react'
 import Link from 'next/link'
@@ -17,6 +16,7 @@ import ErrorDisplay from '../ErrorDisplay'
 import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
 import { referrerLink, venueHomepageLink } from '../../lib/banner-links'
+import ArbitraryNoteList from './ArbitraryNoteList'
 
 function ConsolesList({ venueId, submissionInvitationId, setHidden, shouldReload }) {
   const [userConsoles, setUserConsoles] = useState(null)
@@ -157,6 +157,23 @@ export default function VenueHomepage({ appContext }) {
       )
     }
 
+    if (tabConfig.type === 'arbitraryNoteList') {
+      return (
+        <ArbitraryNoteList
+          noteIds={tabConfig.noteIds}
+          setHidden={(newHidden) => {
+            if (newHidden !== tabConfig.hidden) {
+              setFormattedTabs((currentTabs) =>
+                currentTabs.map((t) =>
+                  t.id === tabConfig.id ? { ...t, hidden: newHidden } : t
+                )
+              )
+            }
+          }}
+        />
+      )
+    }
+
     if (tabConfig.type === 'markdown') {
       return <Markdown text={tabConfig.content} />
     }
@@ -246,7 +263,8 @@ export default function VenueHomepage({ appContext }) {
     // Currently only the consoles and submission list tabs are loaded asynchronously
     setTabsLoaded(
       tabs.map(
-        (tab) => tab.type === 'activity' || tab.type === 'activity' || tab.links?.length > 0
+        (tab) =>
+          tab.type === 'activity' || tab.type === 'arbitraryNoteList' || tab.links?.length > 0
       )
     )
   }, [tabs])

--- a/styles/pages/group.scss
+++ b/styles/pages/group.scss
@@ -145,6 +145,10 @@ main.invitation {
         }
       }
     }
+
+    .arbitrary-note-list {
+      max-width: 80%;
+    }
   }
 
   .item {


### PR DESCRIPTION
this pr should allow arbitrary notes to be displayed as a list as tab in venue home page

example config:
```javascript
tabs.push({
  name: 'Some Notes', // the tab text
  type: 'arbitraryNoteList',
  noteIds: [...some note ids] // ids of notes to display
})
``` 

there's a limit of 500 notes to avoid the request header to exceed size limit
when there's no notes or all notes are invisible, the tab will be hidden
