### PR TITLE
Fix/ Random order in Reviewer properties

### DIFF
--- a/components/browser/ProfileEntity.js
+++ b/components/browser/ProfileEntity.js
@@ -6,6 +6,7 @@
 import { nanoid } from 'nanoid'
 import React, { useContext } from 'react'
 import copy from 'copy-to-clipboard'
+import { sortBy } from 'lodash'
 import api from '../../lib/api-client'
 import {
   getInterpolatedValues,
@@ -65,12 +66,16 @@ export default function ProfileEntity(props) {
       if (!browseEdges?.find((q) => q.invitation === p.id)) {
         browseEdges = browseEdges.concat({
           id: nanoid(),
+          invitation: p.id,
           name: p.name,
           label: p.defaultLabel,
           weight: p.defaultWeight,
         })
       }
     })
+    browseEdges = sortBy(browseEdges, (edge) =>
+      browseInvitations.findIndex((p) => p.id === edge.invitation)
+    )
   }
 
   const isInviteAcceptedProfile =


### PR DESCRIPTION
when a browse invitation is ignore head invitation and it has a default value,
the default value was added to profile entity if the entity does not have such an edge.

currently these ignore head invitation default values edges are added to the end

this pr should sort the browse edges based on browse invitation so that they will be in the same sequence as in entities which has all the edges