### PR TITLE
Fix/ Edge browser - conflicts are not returned

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -731,7 +731,7 @@ export default function Column(props) {
     editInvitations.forEach((editInvitation) =>
       addToEdgesPromiseMap(editInvitation, 'edit', edgesPromiseMap, true, false)
     )
-    addToEdgesPromiseMap(hideInvitation, 'hide', edgesPromiseMap, false, true)
+    addToEdgesPromiseMap(hideInvitation, 'hide', edgesPromiseMap, false, false)
     browseInvitations.forEach((browseInvitation) =>
       addToEdgesPromiseMap(browseInvitation, 'browse', edgesPromiseMap, false, false)
     )


### PR DESCRIPTION
conflicts all have weight = -1
so passing sort param to api may return inconsistent results omitting some edges when there are 1000+ edges (and offset is used)

this pr should fix this issue by not sorting hide invitations

the logic was first added in https://github.com/openreview/openreview-api-v1/pull/1847 and looks like a copy of existing code https://github.com/openreview/openreview-api-v1/pull/1847/files#diff-231c3aadd730fce22e2ee47cc6af9ab27bf0525a29607855d3c9226031e08098R226

didn't find anywhere using the sort so remove