### PR TITLE
Feat: Temporal text in about page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -18,6 +18,12 @@ const About = () => (
     <div className="row">
       <div className="col-xs-12 col-md-10 col-md-offset-1">
         <p>
+          OpenReview project is now a 501(c)(3) organization under the name OpenReview Foundation.
+        </p>
+        <p>
+          For inquiries, please contact <a href="mailto:hello@openreview-foundation.org">hello@openreview-foundation.org</a> or <a href="mailto:info@openreview.net">info@openreview.net</a>.
+        </p>
+        <p>
           OpenReview aims to promote openness in scientific communication, particularly the
           peer review process, by providing a flexible cloud-based web interface and underlying
           database API enabling the following:


### PR DESCRIPTION
For the new Foundation, Google requires us to have a reference from openreview.net to openreview-foundation.org. We can remove it once we have been approved.