### PR TITLE
Fix/ Fix github action error caused by python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             openreview-api/package-lock.json
             openreview-web/package-lock.json
       - name: Set up Python 3.10
-        - uses: actions/setup-python@v5
+        uses: actions/setup-python@v5
           with:
             python-version: '3.10'
       - name: Setup openreview-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
             openreview-web/package-lock.json
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
-          with:
-            python-version: '3.10'
+        with:
+          python-version: '3.10'
       - name: Setup openreview-py
         run: |
           cd openreview-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,10 @@ jobs:
           cache-dependency-path: |
             openreview-api/package-lock.json
             openreview-web/package-lock.json
+      - name: Set up Python 3.10
+        - uses: actions/setup-python@v5
+          with:
+            python-version: '3.10'
       - name: Setup openreview-py
         run: |
           cd openreview-py


### PR DESCRIPTION
ubuntu-latest image used by github actions now has python 3.12.3 which is not compatible with openreview-py

so need to add a step to install an older version 3.10