### PR TITLE
Fix/ Forum page - remove domain param

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -134,9 +134,6 @@ export default function Forum({
 
   const { id, details } = parentNote
   const repliesLoaded = replyNoteMap && displayOptionsMap && orderedReplies
-  const domain = !parentNote.domain?.startsWith(process.env.SUPER_USER)
-    ? parentNote.domain
-    : undefined
 
   // Process forum views config
   let replyForumViews = null
@@ -168,7 +165,7 @@ export default function Forum({
     return api
       .get(
         '/invitations',
-        { replyForum: forumId, expired: true, domain, ...extraParams },
+        { replyForum: forumId, expired: true, ...extraParams },
         { accessToken }
       )
       .then(({ invitations }) => {
@@ -198,7 +195,6 @@ export default function Forum({
         forum: forumId,
         trash: true,
         details: 'writable,signatures,invitation,presentation,tags',
-        domain,
       },
       { accessToken }
     )
@@ -292,7 +288,6 @@ export default function Forum({
           sort: 'tmdate:asc',
           details: 'writable',
           trash: true,
-          domain,
         },
         { accessToken }
       )


### PR DESCRIPTION
when the query contains replyForum or forum
the domain param is useless and is making the query timeout

this pr should remove domain param