### PR TITLE
Fix/ Update count from /messages

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -158,11 +158,12 @@ export default class OpenReviewApp extends App {
     if (!userEmail || !accessToken) return
 
     try {
-      const { count } = await api.get(
+      const response = await api.get(
         '/messages',
         { to: userEmail, viewed: false, transitiveMembers: true },
         { accessToken }
       )
+      const count = response.messages?.length
       this.setState({ unreadNotifications: count ?? 0 })
     } catch (error) {
       this.setState({ unreadNotifications: 0 })

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -130,7 +130,7 @@ export default function Notifications({ appContext }) {
       confirmedEmails.map((email) =>
         api
           .get('/messages', { to: email, viewed: false }, { accessToken })
-          .then((apiRes) => apiRes.count ?? 0)
+          .then((apiRes) => apiRes.messages?.length ?? 0)
       )
     )
       .then((counts) => {


### PR DESCRIPTION
ui changes required for https://github.com/openreview/openreview-api/pull/647

notification page/notification nav bar is changed to read count from messages length

message page has been changed to:
1. use after instead of limit/offset so page in query param is removed because passing limit/offset will cause api to return count which would timeout
2. as api returns up to 1000 results so each time user click "last page" it loads up to 40 pages as the page does not know the number of messages so it could only dynamically update the pagination as data loads