### PR TITLE
Fix/ Ethics Chair Console - remove ethicsReviewName from required fields

### DIFF
--- a/components/webfield/EthicsChairConsole.js
+++ b/components/webfield/EthicsChairConsole.js
@@ -69,7 +69,6 @@ const EthicsChairConsole = ({ appContext }) => {
     ethicsReviewersName,
     submissionId,
     submissionName,
-    ethicsReviewName,
     anonEthicsReviewerName,
     shortPhrase,
   })


### PR DESCRIPTION
ethicsReviewName is a required field to show meaningful info in ethics chair console

some ethics chairs would like to see the console before the ethics review stage start

so this pr should make ethicsReviewName optional so that ethics chair console loads(although empty)