### PR TITLE
Fix/ get count in getAll

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -288,7 +288,7 @@ const getAll = async (path, queryParam, options = {}) => {
   const remainingRequests = offsetList.map((p) =>
     get(
       path,
-      { ...queryObj, offset: p },
+      { ...queryObj, offset: p, count: false },
       { accessToken: options.accessToken, version: options.version }
     )
   )

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -246,7 +246,11 @@ const getCombined = async (path, data1 = {}, data2 = null, options = {}) => {
 }
 
 const getAll = async (path, queryParam, options = {}) => {
-  const queryObj = { ...queryParam, limit: Math.min(queryParam.limit ?? 1000, 1000) }
+  const queryObj = {
+    ...queryParam,
+    limit: Math.min(queryParam.limit ?? 1000, 1000),
+    count: true,
+  }
   const offset = queryParam.offset ?? 0
   let { resultsKey } = options
   if (!resultsKey) {


### PR DESCRIPTION
api requires the following conditions to return count:
 -  query have both limit and offset
 or
- query have count:true

in getAll function the count is required to determine whether to make subsequent api calls after offset 1000 so add count:true