### PR TITLE
Fix/ get count in getAll

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -249,7 +249,7 @@ const getAll = async (path, queryParam, options = {}) => {
   const queryObj = {
     ...queryParam,
     limit: Math.min(queryParam.limit ?? 1000, 1000),
-    count: true,
+    ...(options.version !== 1 && { count: true }),
   }
   const offset = queryParam.offset ?? 0
   let { resultsKey } = options
@@ -288,7 +288,7 @@ const getAll = async (path, queryParam, options = {}) => {
   const remainingRequests = offsetList.map((p) =>
     get(
       path,
-      { ...queryObj, offset: p, count: false },
+      { ...queryObj, offset: p, ...(options.version !== 1 && { count: false }) },
       { accessToken: options.accessToken, version: options.version }
     )
   )


### PR DESCRIPTION
related to #2224 

count param is not allowed in v1
so this pr should only pass count when version is not 1