### PR TITLE
Consoles: Show Meta Review recommendation field only if the field exists in the note

### DIFF
--- a/components/webfield/NoteMetaReviewStatus.js
+++ b/components/webfield/NoteMetaReviewStatus.js
@@ -272,7 +272,7 @@ export const ProgramChairConsolePaperAreaChairProgress = ({
                     )}
                   </span>
                 </div>
-                {metaReview && (
+                {metaReview && recommendation && (
                   <div>
                     <span className="recommendation">
                       {prettyField(metaReviewRecommendationName)}: {recommendation}


### PR DESCRIPTION
Currently, if a meta review note doesn't contain a recommendation field the console will still show the field with an empty string next to it. This PR fixes it so that the field is only shown if the note contains the field. Ex:

Old:
<img width="264" alt="Previous" src="https://github.com/user-attachments/assets/dde15630-402a-40a2-8f35-8b1c722513fc" />

New:
<img width="265" alt="New" src="https://github.com/user-attachments/assets/e479fe5d-796d-45a6-8546-8ecea3dd9a19" />
