### PR TITLE
Fix/ PC/SAC Console - Add latest reply column in paper status tab

### DIFF
--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -25,6 +25,7 @@ import {
   pluralizeString,
   getSingularRoleName,
   getRoleHashFragment,
+  buildNoteTitle,
 } from '../../lib/utils'
 import { referrerLink, venueHomepageLink } from '../../lib/banner-links'
 import AreaChairConsoleMenuBar from './AreaChairConsoleMenuBar'
@@ -571,6 +572,7 @@ const AreaChairConsole = ({ appContext }) => {
                   value,
                 }
               }),
+              signature: latestReply?.signatures?.[0],
             }
           }),
         }

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -2,13 +2,14 @@
 
 import { useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+import { orderBy } from 'lodash'
 import WebFieldContext from '../WebFieldContext'
 import BasicHeader from './BasicHeader'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '../Tabs'
 import Table from '../Table'
 import ErrorDisplay from '../ErrorDisplay'
 import NoteSummary from './NoteSummary'
-import { AcPcConsoleNoteReviewStatus } from './NoteReviewStatus'
+import { AcPcConsoleNoteReviewStatus, LatestReplies } from './NoteReviewStatus'
 import { AreaChairConsoleNoteMetaReviewStatus } from './NoteMetaReviewStatus'
 import useUser from '../../hooks/useUser'
 import useQuery from '../../hooks/useQuery'
@@ -46,6 +47,7 @@ const AssignedPaperRow = ({
   showCheckbox = true,
   additionalMetaReviewFields,
   activeTabId,
+  displayReplyInvitations,
 }) => {
   const { note, metaReviewData, ithenticateEdge } = rowData
   const referrerUrl = encodeURIComponent(
@@ -91,6 +93,11 @@ const AssignedPaperRow = ({
           submissionName={submissionName}
         />
       </td>
+      {displayReplyInvitations?.length && (
+        <td>
+          <LatestReplies rowData={rowData} referrerUrl={referrerUrl} />
+        </td>
+      )}
       <td>
         <AreaChairConsoleNoteMetaReviewStatus
           note={note}
@@ -150,6 +157,7 @@ const AreaChairConsole = ({ appContext }) => {
     preferredEmailInvitationId,
     ithenticateInvitationId,
     sortOptions,
+    displayReplyInvitations,
   } = useContext(WebFieldContext)
   const {
     showEdgeBrowserUrl,
@@ -545,6 +553,25 @@ const AreaChairConsole = ({ appContext }) => {
             ithenticateWeight:
               ithenticateEdges.find((p) => p.head === note.id)?.weight ?? 'N/A',
           }),
+          displayReplies: displayReplyInvitations?.map((p) => {
+            const displayInvitaitonId = p.id.replaceAll('{number}', note.number)
+            const latestReply = orderBy(
+              note.details.replies.filter((q) => q.invitations.includes(displayInvitaitonId)),
+              ['mdate'],
+              'desc'
+            )?.[0]
+            return {
+              id: latestReply?.id,
+              invitationId: displayInvitaitonId,
+              values: p.fields.map((field) => {
+                const value = latestReply?.content?.[field]?.value?.toString()
+                return {
+                  field,
+                  value,
+                }
+              }),
+            }
+          }),
         }
       })
 
@@ -661,6 +688,15 @@ const AreaChairConsole = ({ appContext }) => {
               content: `${prettyField(officialReviewName)} Progress`,
               width: '34%',
             },
+            ...(displayReplyInvitations?.length
+              ? [
+                  {
+                    id: 'latestReplies',
+                    content: 'Latest Replies',
+                    width: '50%',
+                  },
+                ]
+              : []),
             {
               id: 'metaReviewStatus',
               content: `${prettyField(officialMetaReviewName)} Status`,
@@ -683,6 +719,7 @@ const AreaChairConsole = ({ appContext }) => {
               shortPhrase={shortPhrase}
               additionalMetaReviewFields={additionalMetaReviewFields}
               activeTabId={activeTabId}
+              displayReplyInvitations={displayReplyInvitations}
             />
           ))}
         </Table>
@@ -711,6 +748,15 @@ const AreaChairConsole = ({ appContext }) => {
               content: `${prettyField(officialReviewName)} Progress`,
               width: '34%',
             },
+            ...(displayReplyInvitations?.length
+              ? [
+                  {
+                    id: 'latestReplies',
+                    content: 'Latest Replies',
+                    width: '50%',
+                  },
+                ]
+              : []),
             {
               id: 'metaReviewStatus',
               content: `${prettyField(officialMetaReviewName)} Status`,
@@ -732,6 +778,7 @@ const AreaChairConsole = ({ appContext }) => {
               showCheckbox={false}
               additionalMetaReviewFields={additionalMetaReviewFields}
               activeTabId={activeTabId}
+              displayReplyInvitations={displayReplyInvitations}
             />
           ))}
         </Table>

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -562,6 +562,7 @@ const AreaChairConsole = ({ appContext }) => {
             )?.[0]
             return {
               id: latestReply?.id,
+              date: latestReply?.mdate,
               invitationId: displayInvitaitonId,
               values: p.fields.map((field) => {
                 const value = latestReply?.content?.[field]?.value?.toString()

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -15,7 +15,7 @@ import ErrorAlert from '../ErrorAlert'
 import LoadingSpinner from '../LoadingSpinner'
 import NoteList from '../NoteList'
 import WebFieldContext from '../WebFieldContext'
-import { pluralizeString, prettyField, prettyInvitationId } from '../../lib/utils'
+import { pluralizeString, prettyField, prettyId, prettyInvitationId } from '../../lib/utils'
 import { getProfileLink } from '../../lib/webfield-utils'
 
 dayjs.extend(relativeTime)
@@ -682,22 +682,23 @@ export const LatestReplies = ({ rowData, referrerUrl }) => {
   const { note, displayReplies } = rowData
   return displayReplies?.map((reply) => {
     if (!reply.id) return null
+    const { id, invitationId, date, values, signature } = reply
     return (
-      <div key={reply.id}>
+      <div key={id}>
         <strong>
           <a
-            href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
+            href={`/forum?id=${note.id}&noteId=${id}&referrer=${referrerUrl}`}
             target="_blank"
             rel="noreferrer"
           >
-            {prettyInvitationId(reply.invitationId)}
+            {prettyInvitationId(invitationId)}
           </a>
         </strong>{' '}
-        {reply.date && `created ${dayjs(reply.date).fromNow()}`}
-        {reply.values.map((value) => {
+        {signature && `by ${prettyId(signature, true)}`} {date && ` ${dayjs(date).fromNow()}`}
+        {values.map((value) => {
           if (!value.value) return null
           return (
-            <div key={value.field} className="mb-2">
+            <div key={value.field} className="mb-2 note-content">
               <strong className="mr-1">{prettyField(value.field)}:</strong>
               <span>{value.value}</span>
             </div>

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -5,6 +5,8 @@ import Link from 'next/link'
 import React, { useContext, useState } from 'react'
 import upperFirst from 'lodash/upperFirst'
 import copy from 'copy-to-clipboard'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import dayjs from 'dayjs'
 import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
 import BasicModal from '../BasicModal'
@@ -16,6 +18,8 @@ import WebFieldContext from '../WebFieldContext'
 import { pluralizeString, prettyField, prettyInvitationId } from '../../lib/utils'
 import { getProfileLink } from '../../lib/webfield-utils'
 import Markdown from '../EditorComponents/Markdown'
+
+dayjs.extend(relativeTime)
 
 // modified from noteReviewStatus.hbs handlebar template
 export const ReviewerConsoleNoteReviewStatus = ({
@@ -677,26 +681,29 @@ export const EthicsReviewStatus = ({
 
 export const LatestReplies = ({ rowData, referrerUrl }) => {
   const { note, displayReplies } = rowData
-  return displayReplies?.map((reply) => (
-    <div key={reply.id}>
-      <strong>{prettyInvitationId(reply.invitationId)}</strong>
-      {reply.values.map((value) => {
-        if (!value.value) return null
-        return (
-          <div key={value.field}>
-            <strong>{value.field}</strong>:<Markdown text={value.value} />
-          </div>
-        )
-      })}
-      <div>
-        <a
-          href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          Read {prettyInvitationId(reply.invitationId)}
-        </a>
+  return displayReplies?.map((reply) => {
+    if (!reply.id) return null
+    return (
+      <div key={reply.id}>
+        <strong>
+          <a
+            href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {prettyInvitationId(reply.invitationId)}
+          </a>
+        </strong>{' '}
+        {reply.date && `created ${dayjs(reply.date).fromNow()}`}
+        {reply.values.map((value) => {
+          if (!value.value) return null
+          return (
+            <div key={value.field}>
+              <strong>{value.field}</strong>:<Markdown text={value.value} />
+            </div>
+          )
+        })}
       </div>
-    </div>
-  ))
+    )
+  })
 }

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -17,7 +17,6 @@ import NoteList from '../NoteList'
 import WebFieldContext from '../WebFieldContext'
 import { pluralizeString, prettyField, prettyInvitationId } from '../../lib/utils'
 import { getProfileLink } from '../../lib/webfield-utils'
-import Markdown from '../EditorComponents/Markdown'
 
 dayjs.extend(relativeTime)
 
@@ -698,8 +697,9 @@ export const LatestReplies = ({ rowData, referrerUrl }) => {
         {reply.values.map((value) => {
           if (!value.value) return null
           return (
-            <div key={value.field}>
-              <strong>{value.field}</strong>:<Markdown text={value.value} />
+            <div key={value.field} className="mb-2">
+              <strong className="mr-1">{prettyField(value.field)}:</strong>
+              <span>{value.value}</span>
             </div>
           )
         })}

--- a/components/webfield/NoteReviewStatus.js
+++ b/components/webfield/NoteReviewStatus.js
@@ -13,8 +13,9 @@ import ErrorAlert from '../ErrorAlert'
 import LoadingSpinner from '../LoadingSpinner'
 import NoteList from '../NoteList'
 import WebFieldContext from '../WebFieldContext'
-import { pluralizeString, prettyField } from '../../lib/utils'
+import { pluralizeString, prettyField, prettyInvitationId } from '../../lib/utils'
 import { getProfileLink } from '../../lib/webfield-utils'
+import Markdown from '../EditorComponents/Markdown'
 
 // modified from noteReviewStatus.hbs handlebar template
 export const ReviewerConsoleNoteReviewStatus = ({
@@ -672,4 +673,30 @@ export const EthicsReviewStatus = ({
       </div>
     </div>
   )
+}
+
+export const LatestReplies = ({ rowData, referrerUrl }) => {
+  const { note, displayReplies } = rowData
+  return displayReplies?.map((reply) => (
+    <div key={reply.id}>
+      <strong>{prettyInvitationId(reply.invitationId)}</strong>
+      {reply.values.map((value) => {
+        if (!value.value) return null
+        return (
+          <div key={value.field}>
+            <strong>{value.field}</strong>:<Markdown text={value.value} />
+          </div>
+        )
+      })}
+      <div>
+        <a
+          href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Read {prettyInvitationId(reply.invitationId)}
+        </a>
+      </div>
+    </div>
+  ))
 }

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -1060,6 +1060,13 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
     loadData()
   }, [user, userLoading, group])
 
+  useEffect(
+    () => () => {
+      setLayoutOptions({ fullWidth: false, minimalFooter: false })
+    },
+    []
+  )
+
   useEffect(() => {
     const validTabIds = [
       '#venue-configuration',

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -2,6 +2,7 @@
 import { useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import groupBy from 'lodash/groupBy'
+import { orderBy } from 'lodash'
 import useUser from '../../hooks/useUser'
 import useQuery from '../../hooks/useQuery'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '../Tabs'
@@ -29,7 +30,6 @@ import ReviewerStatusTab from './ProgramChairConsole/ReviewerStatus'
 import ErrorDisplay from '../ErrorDisplay'
 import RejectedWithdrawnPapers from './ProgramChairConsole/RejectedWithdrawnPapers'
 import { formatProfileContent } from '../../lib/edge-utils'
-import { orderBy } from 'lodash'
 
 const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
   const {

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -528,7 +528,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
             'desc'
           )?.[0]
           return {
-            id: latestReply.id,
+            id: latestReply?.id,
             invitationId: displayInvitaitonId,
             values: p.fields.map((field) => {
               const value = latestReply?.content?.[field]?.value?.toString()

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -529,6 +529,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
           )?.[0]
           return {
             id: latestReply?.id,
+            date: latestReply?.mdate,
             invitationId: displayInvitaitonId,
             values: p.fields.map((field) => {
               const value = latestReply?.content?.[field]?.value?.toString()

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -538,6 +538,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
                 value,
               }
             }),
+            signature: latestReply?.signatures?.[0],
           }
         })
         officialReviewsByPaperNumberMap.set(note.number, officialReviews)

--- a/components/webfield/ProgramChairConsole/PaperStatus.js
+++ b/components/webfield/ProgramChairConsole/PaperStatus.js
@@ -5,7 +5,7 @@ import PaginationLinks from '../../PaginationLinks'
 import Table from '../../Table'
 import WebFieldContext from '../../WebFieldContext'
 import { ProgramChairConsolePaperAreaChairProgress } from '../NoteMetaReviewStatus'
-import { AcPcConsoleNoteReviewStatus } from '../NoteReviewStatus'
+import { AcPcConsoleNoteReviewStatus, LatestReplies } from '../NoteReviewStatus'
 import NoteSummary from '../NoteSummary'
 import PaperStatusMenuBar from './PaperStatusMenuBar'
 import { prettyField, prettyInvitationId } from '../../../lib/utils'
@@ -124,28 +124,7 @@ const PaperRow = ({
       )}
       {displayReplyInvitations?.length && (
         <td>
-          {rowData.displayReplies?.map((reply) => (
-            <div key={reply.id}>
-              <strong>{prettyInvitationId(reply.invitationId)}</strong>
-              {reply.values.map((value) => {
-                if (!value.value) return null
-                return (
-                  <div key={value.field}>
-                    <strong>{value.field}</strong>:<Markdown text={value.value} />
-                  </div>
-                )
-              })}
-              <div>
-                <a
-                  href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Read {prettyInvitationId(reply.invitationId)}
-                </a>
-              </div>
-            </div>
-          ))}
+          <LatestReplies rowData={rowData} referrerUrl={referrerUrl} />
         </td>
       )}
       {noteContentField && (
@@ -395,11 +374,15 @@ const PaperStatus = ({ pcConsoleData, loadReviewMetaReviewData, noteContentField
             width: '35px',
           },
           { id: 'number', content: '#', width: '55px' },
-          { id: 'summary', content: `${submissionName} Summary`, width: '30%' },
+          {
+            id: 'summary',
+            content: `${submissionName} Summary`,
+            width: displayReplyInvitations?.length ? '20%' : '30%',
+          },
           {
             id: 'reviewProgress',
             content: `${prettyField(officialReviewName)} Progress`,
-            width: '30%',
+            width: displayReplyInvitations?.length ? '15%' : '30%',
           },
           ...(areaChairsId ? [{ id: 'status', content: 'Status' }] : []),
           ...(displayReplyInvitations?.length
@@ -407,7 +390,7 @@ const PaperStatus = ({ pcConsoleData, loadReviewMetaReviewData, noteContentField
                 {
                   id: 'latestReplies',
                   content: 'Latest Replies',
-                  width: '35%',
+                  width: '45%',
                 },
               ]
             : []),

--- a/components/webfield/ProgramChairConsole/PaperStatus.js
+++ b/components/webfield/ProgramChairConsole/PaperStatus.js
@@ -129,6 +129,7 @@ const PaperRow = ({
               <div>
                 <strong>{prettyInvitationId(reply.invitationId)}</strong>
                 {reply.values.map((value) => {
+                  if (!value.value) return null
                   return (
                     <div>
                       <strong>{value.field}</strong>:<Markdown text={value.value} />

--- a/components/webfield/ProgramChairConsole/PaperStatus.js
+++ b/components/webfield/ProgramChairConsole/PaperStatus.js
@@ -124,30 +124,28 @@ const PaperRow = ({
       )}
       {displayReplyInvitations?.length && (
         <td>
-          {rowData.displayReplies?.map((reply) => {
-            return (
+          {rowData.displayReplies?.map((reply) => (
+            <div key={reply.id}>
+              <strong>{prettyInvitationId(reply.invitationId)}</strong>
+              {reply.values.map((value) => {
+                if (!value.value) return null
+                return (
+                  <div key={value.field}>
+                    <strong>{value.field}</strong>:<Markdown text={value.value} />
+                  </div>
+                )
+              })}
               <div>
-                <strong>{prettyInvitationId(reply.invitationId)}</strong>
-                {reply.values.map((value) => {
-                  if (!value.value) return null
-                  return (
-                    <div>
-                      <strong>{value.field}</strong>:<Markdown text={value.value} />
-                    </div>
-                  )
-                })}
-                <div>
-                  <a
-                    href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Read {prettyInvitationId(reply.invitationId)}
-                  </a>
-                </div>
+                <a
+                  href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Read {prettyInvitationId(reply.invitationId)}
+                </a>
               </div>
-            )
-          })}
+            </div>
+          ))}
         </td>
       )}
       {noteContentField && (

--- a/components/webfield/ProgramChairConsole/PaperStatus.js
+++ b/components/webfield/ProgramChairConsole/PaperStatus.js
@@ -8,9 +8,10 @@ import { ProgramChairConsolePaperAreaChairProgress } from '../NoteMetaReviewStat
 import { AcPcConsoleNoteReviewStatus } from '../NoteReviewStatus'
 import NoteSummary from '../NoteSummary'
 import PaperStatusMenuBar from './PaperStatusMenuBar'
-import { prettyField } from '../../../lib/utils'
+import { prettyField, prettyInvitationId } from '../../../lib/utils'
 import useUser from '../../../hooks/useUser'
 import SelectAllCheckBox from '../SelectAllCheckbox'
+import Markdown from '../../EditorComponents/Markdown'
 
 const PaperRow = ({
   rowData,
@@ -33,6 +34,7 @@ const PaperRow = ({
     metaReviewRecommendationName = 'recommendation',
     additionalMetaReviewFields = [],
     preferredEmailInvitationId,
+    displayReplyInvitations,
   } = useContext(WebFieldContext)
   const { note, metaReviewData, ithenticateEdge } = rowData
   const referrerUrl = encodeURIComponent(
@@ -118,6 +120,33 @@ const PaperRow = ({
             additionalMetaReviewFields={additionalMetaReviewFields}
             preferredEmailInvitationId={preferredEmailInvitationId}
           />
+        </td>
+      )}
+      {displayReplyInvitations?.length && (
+        <td>
+          {rowData.displayReplies?.map((reply) => {
+            return (
+              <div>
+                <strong>{prettyInvitationId(reply.invitationId)}</strong>
+                {reply.values.map((value) => {
+                  return (
+                    <div>
+                      <strong>{value.field}</strong>:<Markdown text={value.value} />
+                    </div>
+                  )
+                })}
+                <div>
+                  <a
+                    href={`/forum?id=${note.id}&noteId=${reply.id}&referrer=${referrerUrl}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Read {prettyInvitationId(reply.invitationId)}
+                  </a>
+                </div>
+              </div>
+            )
+          })}
         </td>
       )}
       {noteContentField && (
@@ -241,6 +270,7 @@ const PaperStatus = ({ pcConsoleData, loadReviewMetaReviewData, noteContentField
     officialReviewName,
     officialMetaReviewName = 'Meta_Review',
     submissionName,
+    displayReplyInvitations,
   } = useContext(WebFieldContext)
   const [pageNumber, setPageNumber] = useState(1)
   const [totalCount, setTotalCount] = useState(pcConsoleData.notes?.length ?? 0)
@@ -373,6 +403,15 @@ const PaperStatus = ({ pcConsoleData, loadReviewMetaReviewData, noteContentField
             width: '30%',
           },
           ...(areaChairsId ? [{ id: 'status', content: 'Status' }] : []),
+          ...(displayReplyInvitations?.length
+            ? [
+                {
+                  id: 'latestReplies',
+                  content: 'Latest Replies',
+                  width: '35%',
+                },
+              ]
+            : []),
           {
             id: noteContentField?.field ?? 'decision',
             content: noteContentField ? prettyField(noteContentField.field) : 'Decision',

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -567,6 +567,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
                   value,
                 }
               }),
+              signature: latestReply?.signatures?.[0],
             }
           })
 

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -680,6 +680,13 @@ const SeniorAreaChairConsole = ({ appContext }) => {
     }
   }, [query, venueId])
 
+  useEffect(
+    () => () => {
+      setLayoutOptions({ fullWidth: false, minimalFooter: false })
+    },
+    []
+  )
+
   useEffect(() => {
     if (userLoading || !user || !group || !venueId) return
     loadData()

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -558,6 +558,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
             )?.[0]
             return {
               id: latestReply?.id,
+              date: latestReply?.mdate,
               invitationId: displayInvitaitonId,
               values: p.fields.map((field) => {
                 const value = latestReply?.content?.[field]?.value?.toString()

--- a/components/webfield/SeniorAreaChairConsole/PaperStatus.js
+++ b/components/webfield/SeniorAreaChairConsole/PaperStatus.js
@@ -5,7 +5,7 @@ import PaginationLinks from '../../PaginationLinks'
 import Table from '../../Table'
 import WebFieldContext from '../../WebFieldContext'
 import { ProgramChairConsolePaperAreaChairProgress } from '../NoteMetaReviewStatus'
-import { AcPcConsoleNoteReviewStatus } from '../NoteReviewStatus'
+import { AcPcConsoleNoteReviewStatus, LatestReplies } from '../NoteReviewStatus'
 import NoteSummary from '../NoteSummary'
 import PaperStatusMenuBar from '../ProgramChairConsole/PaperStatusMenuBar'
 import { pluralizeString, prettyField } from '../../../lib/utils'
@@ -33,6 +33,7 @@ const PaperRow = ({
     metaReviewRecommendationName = 'recommendation',
     additionalMetaReviewFields = [],
     preferredEmailInvitationId,
+    displayReplyInvitations,
   } = useContext(WebFieldContext)
   const { note, ithenticateEdge } = rowData
   const referrerUrl = encodeURIComponent(
@@ -106,6 +107,11 @@ const PaperRow = ({
           preferredEmailInvitationId={preferredEmailInvitationId}
         />
       </td>
+      {displayReplyInvitations?.length && (
+        <td>
+          <LatestReplies rowData={rowData} referrerUrl={referrerUrl} />
+        </td>
+      )}
       <td className="console-decision">
         <h4 className="title">{decision}</h4>
         {venue && <span>{venue}</span>}
@@ -125,6 +131,7 @@ const PaperStatus = ({ sacConsoleData }) => {
     officialReviewName,
     areaChairName = 'Area_Chairs',
     officialMetaReviewName = 'Meta_Review',
+    displayReplyInvitations,
   } = useContext(WebFieldContext)
   const pageSize = 25
 
@@ -213,9 +220,18 @@ const PaperStatus = ({ sacConsoleData }) => {
           {
             id: 'reviewProgress',
             content: `${prettyField(officialReviewName)} Progress`,
-            width: '30%',
+            width: displayReplyInvitations?.length ? '20%' : '30%',
           },
           { id: 'status', content: 'Status' },
+          ...(displayReplyInvitations?.length
+            ? [
+                {
+                  id: 'latestReplies',
+                  content: 'Latest Replies',
+                  width: '35%',
+                },
+              ]
+            : []),
           { id: 'decision', content: 'Decision' },
         ]}
       >

--- a/styles/pages/group.scss
+++ b/styles/pages/group.scss
@@ -411,6 +411,10 @@ main.invitation {
     .download-pdf-link {
       margin-bottom: 0.5rem;
     }
+
+    th {
+      white-space: nowrap;
+    }
   }
 
   .author-console-mobile {

--- a/unitTests/SeniorAreaChairConsole.test.js
+++ b/unitTests/SeniorAreaChairConsole.test.js
@@ -56,7 +56,9 @@ describe('SeniorAreaChairConsole', () => {
   test('default to paper status tab when window.location does not contain any hash', async () => {
     const providerProps = { value: { submissionName: 'Submission' } }
     renderWithWebFieldContext(
-      <SeniorAreaChairConsole appContext={{ setBannerContent: jest.fn() }} />,
+      <SeniorAreaChairConsole
+        appContext={{ setBannerContent: jest.fn(), setLayoutOptions: jest.fn() }}
+      />,
       providerProps
     )
     expect(routerParams).toEqual('#submission-status')
@@ -66,7 +68,9 @@ describe('SeniorAreaChairConsole', () => {
     window.location.hash = '#some-unknown-tab'
     const providerProps = { value: { submissionName: 'Submission' } }
     renderWithWebFieldContext(
-      <SeniorAreaChairConsole appContext={{ setBannerContent: jest.fn() }} />,
+      <SeniorAreaChairConsole
+        appContext={{ setBannerContent: jest.fn(), setLayoutOptions: jest.fn() }}
+      />,
       providerProps
     )
     expect(routerParams).toEqual('#submission-status')
@@ -75,7 +79,9 @@ describe('SeniorAreaChairConsole', () => {
   test('show error message based on sac name when config is not complete', async () => {
     const providerProps = { value: { seniorAreaChairName: undefined } }
     const { rerender } = renderWithWebFieldContext(
-      <SeniorAreaChairConsole appContext={{ setBannerContent: jest.fn() }} />,
+      <SeniorAreaChairConsole
+        appContext={{ setBannerContent: jest.fn(), setLayoutOptions: jest.fn() }}
+      />,
       providerProps
     )
     expect(
@@ -85,7 +91,9 @@ describe('SeniorAreaChairConsole', () => {
     providerProps.value.seniorAreaChairName = 'Area_Chairs'
     reRenderWithWebFieldContext(
       rerender,
-      <SeniorAreaChairConsole appContext={{ setBannerContent: jest.fn() }} />,
+      <SeniorAreaChairConsole
+        appContext={{ setBannerContent: jest.fn(), setLayoutOptions: jest.fn() }}
+      />,
       providerProps
     )
     expect(
@@ -102,7 +110,9 @@ describe('SeniorAreaChairConsole', () => {
       },
     }
     const { rerender } = renderWithWebFieldContext(
-      <SeniorAreaChairConsole appContext={{ setBannerContent: jest.fn() }} />,
+      <SeniorAreaChairConsole
+        appContext={{ setBannerContent: jest.fn(), setLayoutOptions: jest.fn() }}
+      />,
       providerProps
     )
     expect(
@@ -112,7 +122,9 @@ describe('SeniorAreaChairConsole', () => {
     providerProps.value.seniorAreaChairName = 'Area_Chairs'
     reRenderWithWebFieldContext(
       rerender,
-      <SeniorAreaChairConsole appContext={{ setBannerContent: jest.fn() }} />,
+      <SeniorAreaChairConsole
+        appContext={{ setBannerContent: jest.fn(), setLayoutOptions: jest.fn() }}
+      />,
       providerProps
     )
     expect(


### PR DESCRIPTION
this pr should add in PC and SAC console paper status tab a new column (when displayReplyInvitations is specified) to show latest reply of the invitation and content fields specified.

sample config
```javascript
displayReplyInvitations: [
  {
    id: "acmmm.org/ACMMM/2024/Conference/Submission{number}/-/Official_Review",
    fields: ["summary", "limitations"],
  },
  {
    id: "acmmm.org/ACMMM/2024/Conference/Submission{number}/-/Public_Comment",
    fields: ["strengths", "suitability"],
  },
]
``` 
