### PR TITLE
Fix/ Moderation - Allow moderating multiple profiles in preview modal

### DIFF
--- a/components/profile/BasicProfileView.js
+++ b/components/profile/BasicProfileView.js
@@ -37,7 +37,7 @@ const ProfileName = ({ name }) => (
 
 const ProfileEmail = ({ email, publicProfile, allowCopyEmail }) => {
   const copyEmailToClipboard = () => {
-    copy(`"${email.email}"`)
+    copy(`${email.email}`)
   }
   return (
     <ProfileItem itemMeta={email.meta}>

--- a/components/profile/ProfilePreviewModal.js
+++ b/components/profile/ProfilePreviewModal.js
@@ -1,5 +1,5 @@
 /* globals promptError,$: false */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import BasicModal from '../BasicModal'
 import BasicProfileView from './BasicProfileView'
@@ -8,8 +8,8 @@ import api from '../../lib/api-client'
 import ProfilePublications from './ProfilePublications'
 import ProfileViewSection from './ProfileViewSection'
 import MessagesSection from './MessagesSection'
-import { getRejectionReasons } from '../../pages/user/moderation'
 import Dropdown from '../Dropdown'
+import { getRejectionReasons } from '../../lib/utils'
 
 const ProfilePreviewModal = ({
   profileToPreview,

--- a/components/profile/ProfilePreviewModal.js
+++ b/components/profile/ProfilePreviewModal.js
@@ -1,5 +1,5 @@
 /* globals promptError,$: false */
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import BasicModal from '../BasicModal'
 import BasicProfileView from './BasicProfileView'
@@ -8,6 +8,8 @@ import api from '../../lib/api-client'
 import ProfilePublications from './ProfilePublications'
 import ProfileViewSection from './ProfileViewSection'
 import MessagesSection from './MessagesSection'
+import { getRejectionReasons } from '../../pages/user/moderation'
+import Dropdown from '../Dropdown'
 
 const ProfilePreviewModal = ({
   profileToPreview,
@@ -15,10 +17,26 @@ const ProfilePreviewModal = ({
   setLastPreviewedProfileId,
   contentToShow,
   sortFn,
+  showNextProfile,
+  acceptUser,
+  blockUser,
+  setProfileToReject,
+  rejectUser,
 }) => {
   const [publications, setPublications] = useState(null)
   const { accessToken } = useUser()
   const router = useRouter()
+  const [rejectionMessage, setRejectionMessage] = useState('')
+  const [isRejecting, setIsRejecting] = useState(false)
+  const [rejectionReasons, setRejectReasons] = useState([])
+  const needsModeration = profileToPreview?.state === 'Needs Moderation'
+
+  const updateMessageForPastRejectProfile = () => {
+    setRejectionMessage(
+      (p) =>
+        `Submitting invalid info is a violation of OpenReview's Terms and Conditions (https://openreview.net/legal/terms) which may result in terminating your access to the system.\n\n${p}`
+    )
+  }
 
   const loadPublications = async () => {
     let apiRes
@@ -44,6 +62,12 @@ const ProfilePreviewModal = ({
   }
 
   useEffect(() => {
+    setRejectionMessage('')
+    setIsRejecting(false)
+    const currentInstitutionName = profileToPreview?.history?.find(
+      (p) => !p.end || p.end >= new Date().getFullYear()
+    )?.institution?.name
+    setRejectReasons(getRejectionReasons(currentInstitutionName))
     if (profileToPreview && contentToShow?.includes('publications')) loadPublications()
   }, [profileToPreview?.id])
 
@@ -63,6 +87,7 @@ const ProfilePreviewModal = ({
         setProfileToPreview(null)
         setLastPreviewedProfileId(profileToPreview.id)
       }}
+      options={{ hideFooter: !!needsModeration }}
     >
       <BasicProfileView
         profile={profileToPreview}
@@ -80,7 +105,7 @@ const ProfilePreviewModal = ({
           name="messages"
           title={
             <a
-              href={`/messages?to=${profileToPreview.preferredEmail}&page=1`}
+              href={`/messages?to=${profileToPreview.preferredEmail}`}
               target="_blank"
               rel="noreferrer"
             >
@@ -94,6 +119,91 @@ const ProfilePreviewModal = ({
             rejectMessagesOnly
           />
         </ProfileViewSection>
+      )}
+      {needsModeration && (
+        <div className="modal-footer">
+          <div>
+            <div className="pull-left">
+              <button
+                type="button"
+                className="btn btn-sm"
+                onClick={() => showNextProfile(profileToPreview.id)}
+              >
+                Skip
+              </button>
+            </div>
+            <div>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  showNextProfile(profileToPreview.id)
+                  acceptUser(profileToPreview.id)
+                }}
+              >
+                Accept
+              </button>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  setIsRejecting(true)
+                  setProfileToReject(profileToPreview)
+                }}
+              >
+                Show Reject Options
+              </button>
+              <button
+                type="button"
+                className="btn"
+                onClick={async () => {
+                  await blockUser(profileToPreview)
+                  showNextProfile(profileToPreview.id)
+                }}
+              >
+                Block
+              </button>
+            </div>
+          </div>
+          {isRejecting && (
+            <div className="form-group form-rejection mt-2">
+              <Dropdown
+                name="rejection-reason"
+                instanceId="rejection-reason"
+                placeholder="Choose a common reject reason..."
+                options={rejectionReasons}
+                onChange={(p) => {
+                  setRejectionMessage(p?.rejectionText || '')
+                }}
+                isClearable
+              />
+
+              <button className="btn btn-xs" onClick={updateMessageForPastRejectProfile}>
+                Add Invalid Info Warning
+              </button>
+
+              <textarea
+                name="message"
+                className="form-control mt-2"
+                rows="10"
+                value={rejectionMessage}
+                onChange={(e) => {
+                  setRejectionMessage(e.target.value)
+                }}
+              />
+              <button
+                type="button"
+                className="btn"
+                onClick={async () => {
+                  await rejectUser(rejectionMessage)
+                  showNextProfile(profileToPreview.id)
+                }}
+              >
+                Reject
+              </button>
+            </div>
+          )}
+        </div>
       )}
     </BasicModal>
   )

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1638,3 +1638,61 @@ export function isInstitutionEmail(email, institutionDomains) {
     return false
   })
 }
+
+/**
+ * return profile rejection options
+ *
+ * @param {string} currentInstitutionName
+ * @returns Array
+ */
+export function getRejectionReasons(currentInstitutionName) {
+  const instructionText =
+    'Please go back to the sign up page, enter the same name and email, click the Resend Activation button and follow the activation link to update your information.'
+  const rejectionReasons = [
+    {
+      value: 'requestEmailVerification',
+      label: 'Institutional Email is missing',
+      rejectionText: `Please add and confirm an institutional email ${
+        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
+      }to your profile. Please make sure the verification token is entered and verified.\n\nIf your affiliation ${
+        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
+      } is not current, please update your profile with your current affiliation and associated institutional email.\n\n${instructionText}`,
+    },
+    {
+      value: 'requestEmailConfirmation',
+      label: 'Institutional Email is added but not confirmed',
+      rejectionText: `Please confirm the institutional email in your profile by clicking the "Confirm" button next to the email and enter the verification token received.\n\n${instructionText}`,
+    },
+    {
+      value: 'invalidDBLP',
+      label: 'DBLP link is a disambiguation page',
+      rejectionText: `The DBLP link you have provided is a disambiguation page and is not intended to be used as a bibliography. Please select the correct bibliography page listed under "Other persons with a similar name". If your page is not listed please contact the DBLP team so they can add your bibliography page. We recommend providing a different bibliography homepage when resubmitting to OpenReview moderation.\n\n${instructionText}`,
+    },
+    {
+      value: 'imPersonalHomepage',
+      label: 'Homepage is invalid',
+      rejectionText: `The homepage url provided in your profile is invalid or does not display your name/email used to register so your identity can't be determined.\n\n${instructionText}`,
+    },
+    {
+      value: 'imPersonalHomepageAndEmail',
+      label: 'Homepage is invalid + no institution email',
+      rejectionText: `A Homepage url which displays your name and institutional email matching your latest career/education history are required. Please confirm the institutional email by entering the verification token received after clicking confirm button next to the institutional email.\n\n${instructionText}`,
+    },
+    {
+      value: 'invalidName',
+      label: 'Profile name is invalid',
+      rejectionText: `The name in your profile does not match the name listed in your homepage or is invalid.\n\n${instructionText}`,
+    },
+    {
+      value: 'invalidORCID',
+      label: 'ORCID profile is incomplete',
+      rejectionText: `The ORCID profile you've provided as a homepage is empty or does not match the Career & Education history you've provided.\n\n${instructionText}`,
+    },
+    {
+      value: 'lastNotice',
+      label: 'Last notice before block',
+      rejectionText: `If invalid info is submitted again, your email will be blocked.\n\n${instructionText}`,
+    },
+  ]
+  return rejectionReasons
+}

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -16,6 +16,7 @@ import {
   inflect,
   getProfileStateLabelClass,
   getVenueTabCountMessage,
+  getRejectionReasons,
 } from '../../lib/utils'
 import BasicModal from '../../components/BasicModal'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '../../components/Tabs'
@@ -27,58 +28,6 @@ import Dropdown from '../../components/Dropdown'
 import ProfilePreviewModal from '../../components/profile/ProfilePreviewModal'
 
 dayjs.extend(relativeTime)
-
-export const getRejectionReasons = (currentInstitutionName) => {
-  const instructionText =
-    'Please go back to the sign up page, enter the same name and email, click the Resend Activation button and follow the activation link to update your information.'
-  const rejectionReasons = [
-    {
-      value: 'requestEmailVerification',
-      label: 'Institutional Email is missing',
-      rejectionText: `Please add and confirm an institutional email ${
-        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
-      }to your profile. Please make sure the verification token is entered and verified.\n\nIf your affiliation ${
-        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
-      } is not current, please update your profile with your current affiliation and associated institutional email.\n\n${instructionText}`,
-    },
-    {
-      value: 'requestEmailConfirmation',
-      label: 'Institutional Email is added but not confirmed',
-      rejectionText: `Please confirm the institutional email in your profile by clicking the "Confirm" button next to the email and enter the verification token received.\n\n${instructionText}`,
-    },
-    {
-      value: 'invalidDBLP',
-      label: 'DBLP link is a disambiguation page',
-      rejectionText: `The DBLP link you have provided is a disambiguation page and is not intended to be used as a bibliography. Please select the correct bibliography page listed under "Other persons with a similar name". If your page is not listed please contact the DBLP team so they can add your bibliography page. We recommend providing a different bibliography homepage when resubmitting to OpenReview moderation.\n\n${instructionText}`,
-    },
-    {
-      value: 'imPersonalHomepage',
-      label: 'Homepage is invalid',
-      rejectionText: `The homepage url provided in your profile is invalid or does not display your name/email used to register so your identity can't be determined.\n\n${instructionText}`,
-    },
-    {
-      value: 'imPersonalHomepageAndEmail',
-      label: 'Homepage is invalid + no institution email',
-      rejectionText: `A Homepage url which displays your name and institutional email matching your latest career/education history are required. Please confirm the institutional email by entering the verification token received after clicking confirm button next to the institutional email.\n\n${instructionText}`,
-    },
-    {
-      value: 'invalidName',
-      label: 'Profile name is invalid',
-      rejectionText: `The name in your profile does not match the name listed in your homepage or is invalid.\n\n${instructionText}`,
-    },
-    {
-      value: 'invalidORCID',
-      label: 'ORCID profile is incomplete',
-      rejectionText: `The ORCID profile you've provided as a homepage is empty or does not match the Career & Education history you've provided.\n\n${instructionText}`,
-    },
-    {
-      value: 'lastNotice',
-      label: 'Last notice before block',
-      rejectionText: `If invalid info is submitted again, your email will be blocked.\n\n${instructionText}`,
-    },
-  ]
-  return rejectionReasons
-}
 
 const UserModerationTab = ({ accessToken }) => {
   const [shouldReload, reload] = useReducer((p) => !p, true)

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -28,6 +28,58 @@ import ProfilePreviewModal from '../../components/profile/ProfilePreviewModal'
 
 dayjs.extend(relativeTime)
 
+export const getRejectionReasons = (currentInstitutionName) => {
+  const instructionText =
+    'Please go back to the sign up page, enter the same name and email, click the Resend Activation button and follow the activation link to update your information.'
+  const rejectionReasons = [
+    {
+      value: 'requestEmailVerification',
+      label: 'Institutional Email is missing',
+      rejectionText: `Please add and confirm an institutional email ${
+        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
+      }to your profile. Please make sure the verification token is entered and verified.\n\nIf your affiliation ${
+        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
+      } is not current, please update your profile with your current affiliation and associated institutional email.\n\n${instructionText}`,
+    },
+    {
+      value: 'requestEmailConfirmation',
+      label: 'Institutional Email is added but not confirmed',
+      rejectionText: `Please confirm the institutional email in your profile by clicking the "Confirm" button next to the email and enter the verification token received.\n\n${instructionText}`,
+    },
+    {
+      value: 'invalidDBLP',
+      label: 'DBLP link is a disambiguation page',
+      rejectionText: `The DBLP link you have provided is a disambiguation page and is not intended to be used as a bibliography. Please select the correct bibliography page listed under "Other persons with a similar name". If your page is not listed please contact the DBLP team so they can add your bibliography page. We recommend providing a different bibliography homepage when resubmitting to OpenReview moderation.\n\n${instructionText}`,
+    },
+    {
+      value: 'imPersonalHomepage',
+      label: 'Homepage is invalid',
+      rejectionText: `The homepage url provided in your profile is invalid or does not display your name/email used to register so your identity can't be determined.\n\n${instructionText}`,
+    },
+    {
+      value: 'imPersonalHomepageAndEmail',
+      label: 'Homepage is invalid + no institution email',
+      rejectionText: `A Homepage url which displays your name and institutional email matching your latest career/education history are required. Please confirm the institutional email by entering the verification token received after clicking confirm button next to the institutional email.\n\n${instructionText}`,
+    },
+    {
+      value: 'invalidName',
+      label: 'Profile name is invalid',
+      rejectionText: `The name in your profile does not match the name listed in your homepage or is invalid.\n\n${instructionText}`,
+    },
+    {
+      value: 'invalidORCID',
+      label: 'ORCID profile is incomplete',
+      rejectionText: `The ORCID profile you've provided as a homepage is empty or does not match the Career & Education history you've provided.\n\n${instructionText}`,
+    },
+    {
+      value: 'lastNotice',
+      label: 'Last notice before block',
+      rejectionText: `If invalid info is submitted again, your email will be blocked.\n\n${instructionText}`,
+    },
+  ]
+  return rejectionReasons
+}
+
 const UserModerationTab = ({ accessToken }) => {
   const [shouldReload, reload] = useReducer((p) => !p, true)
   const [configNote, setConfigNote] = useState(null)
@@ -1706,11 +1758,11 @@ const UserModerationQueue = ({
   const [signedNotes, setSignedNotes] = useState(0)
   const [idsLoading, setIdsLoading] = useState([])
   const [descOrder, setDescOrder] = useState(true)
-  const [pageSize, setPageSize] = useState(15)
+  const [pageSize, setPageSize] = useState(onlyModeration ? 200 : 15)
   const [profileToPreview, setProfileToPreview] = useState(null)
   const [lastPreviewedProfileId, setLastPreviewedProfileId] = useState(null)
   const modalId = `${onlyModeration ? 'new' : ''}-user-reject-modal`
-  const pageSizeOptions = [15, 30, 50, 100].map((p) => ({
+  const pageSizeOptions = [15, 30, 50, 100, 200].map((p) => ({
     label: `${p} items`,
     value: p,
   }))
@@ -1952,6 +2004,14 @@ const UserModerationQueue = ({
       promptMessage(`${profileId} is added to SDN exception group`)
     } catch (error) {
       promptError(error.message)
+    }
+  }
+
+  const showNextProfile = (currentProfileId) => {
+    const nextProfile = profiles[profiles.findIndex((p) => p.id === currentProfileId) + 1]
+    if (nextProfile) {
+      setProfileToPreview(formatProfileData(cloneDeep(nextProfile)))
+      setLastPreviewedProfileId(nextProfile.id)
     }
   }
 
@@ -2211,12 +2271,17 @@ const UserModerationQueue = ({
           'publications',
           'messages',
         ]}
+        showNextProfile={showNextProfile}
+        acceptUser={acceptUser}
+        blockUser={blockUnblockUser}
+        setProfileToReject={setProfileToReject}
+        rejectUser={rejectUser}
       />
     </div>
   )
 }
 
-const RejectionModal = ({ id, profileToReject, rejectUser, signedNotes }) => {
+export const RejectionModal = ({ id, profileToReject, rejectUser, signedNotes }) => {
   const [rejectionMessage, setRejectionMessage] = useState('')
   const selectRef = useRef(null)
 
@@ -2224,54 +2289,7 @@ const RejectionModal = ({ id, profileToReject, rejectUser, signedNotes }) => {
     (p) => !p.end || p.end >= new Date().getFullYear()
   )?.institution?.name
 
-  const instructionText =
-    'Please go back to the sign up page, enter the same name and email, click the Resend Activation button and follow the activation link to update your information.'
-  const rejectionReasons = [
-    {
-      value: 'requestEmailVerification',
-      label: 'Institutional Email is missing',
-      rejectionText: `Please add and confirm an institutional email ${
-        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
-      }to your profile. Please make sure the verification token is entered and verified.\n\nIf your affiliation ${
-        currentInstitutionName ? `issued by ${currentInstitutionName} ` : ''
-      } is not current, please update your profile with your current affiliation and associated institutional email.\n\n${instructionText}`,
-    },
-    {
-      value: 'requestEmailConfirmation',
-      label: 'Institutional Email is added but not confirmed',
-      rejectionText: `Please confirm the institutional email in your profile by clicking the "Confirm" button next to the email and enter the verification token received.\n\n${instructionText}`,
-    },
-    {
-      value: 'invalidDBLP',
-      label: 'DBLP link is a disambiguation page',
-      rejectionText: `The DBLP link you have provided is a disambiguation page and is not intended to be used as a bibliography. Please select the correct bibliography page listed under "Other persons with a similar name". If your page is not listed please contact the DBLP team so they can add your bibliography page. We recommend providing a different bibliography homepage when resubmitting to OpenReview moderation.\n\n${instructionText}`,
-    },
-    {
-      value: 'imPersonalHomepage',
-      label: 'Homepage is invalid',
-      rejectionText: `The homepage url provided in your profile is invalid or does not display your name/email used to register so your identity can't be determined.\n\n${instructionText}`,
-    },
-    {
-      value: 'imPersonalHomepageAndEmail',
-      label: 'Homepage is invalid + no institution email',
-      rejectionText: `A Homepage url which displays your name and institutional email matching your latest career/education history are required. Please confirm the institutional email by entering the verification token received after clicking confirm button next to the institutional email.\n\n${instructionText}`,
-    },
-    {
-      value: 'invalidName',
-      label: 'Profile name is invalid',
-      rejectionText: `The name in your profile does not match the name listed in your homepage or is invalid.\n\n${instructionText}`,
-    },
-    {
-      value: 'invalidORCID',
-      label: 'ORCID profile is incomplete',
-      rejectionText: `The ORCID profile you've provided as a homepage is empty or does not match the Career & Education history you've provided.\n\n${instructionText}`,
-    },
-    {
-      value: 'lastNotice',
-      label: 'Last notice before block',
-      rejectionText: `If invalid info is submitted again, your email will be blocked.\n\n${instructionText}`,
-    },
-  ]
+  const rejectionReasons = getRejectionReasons(currentInstitutionName)
 
   const updateMessageForPastRejectProfile = () => {
     setRejectionMessage(

--- a/styles/components.scss
+++ b/styles/components.scss
@@ -1207,6 +1207,7 @@ table.table-minimal {
   .form-rejection {
     display: flex;
     flex-flow: column;
+    text-align: left;
 
     .btn {
       align-self: flex-start;


### PR DESCRIPTION
this pr should implement an improvement @melisabok raised during meeting
to enable moderator to check and act on multiple profiles without leaving the profile preview modal
so that moderator does not need to click around