### PR TITLE
Fix/ Edge browser - replace dot in filter query

### DIFF
--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -616,9 +616,10 @@ export default function Column(props) {
         ['!=', '>=', '<=', '>', '<', '==', '='],
         editAndBrowserInvitationsUnique.reduce(
           (prev, curr) => {
+            // eslint-disable-next-line no-param-reassign
             prev[curr.id.replaceAll('.', '_')] = [
               `filterProperties.${curr.id.replaceAll('.', '_')}`,
-            ] // eslint-disable-line no-param-reassign
+            ]
             return prev
           },
           {

--- a/components/browser/Column.js
+++ b/components/browser/Column.js
@@ -596,14 +596,15 @@ export default function Column(props) {
             ...p,
             filterProperties: editAndBrowserInvitationsUnique.reduce(
               (prev, curr) => {
+                const invitaitonId = curr.id.replaceAll('.', '_')
                 const edge = [...p.browseEdges, ...p.editEdges].find(
                   (q) => q.invitation === curr.id
                 )
 
                 if (edge) {
-                  prev[curr.id] = getEdgeValue(edge) // eslint-disable-line no-param-reassign
+                  prev[invitaitonId] = getEdgeValue(edge) // eslint-disable-line no-param-reassign
                 } else {
-                  prev[curr.id] = curr.defaultWeight ?? curr.defaultLabel // eslint-disable-line no-param-reassign
+                  prev[invitaitonId] = curr.defaultWeight ?? curr.defaultLabel // eslint-disable-line no-param-reassign
                 }
                 return prev
               },
@@ -611,11 +612,13 @@ export default function Column(props) {
             ),
           }
         }),
-        `${query.filter} AND Quota=true`,
+        `${query.filter.replaceAll('.', '_')} AND Quota=true`,
         ['!=', '>=', '<=', '>', '<', '==', '='],
         editAndBrowserInvitationsUnique.reduce(
           (prev, curr) => {
-            prev[curr.id] = [`filterProperties.${curr.id}`] // eslint-disable-line no-param-reassign
+            prev[curr.id.replaceAll('.', '_')] = [
+              `filterProperties.${curr.id.replaceAll('.', '_')}`,
+            ] // eslint-disable-line no-param-reassign
             return prev
           },
           {


### PR DESCRIPTION
filter param in edge browser is in the form of 
browseInvitationId = value

where browse edges are added to row data as row.filterProperties.browseInvitationId

however when browseInvitationId contains dot (for example thecvf.com/...), the dot will be interpreted as a level of field in row and the filtering logic will compare the value of row[filterProperties][thecvf][com/...] and fail

this pr should replace all dot in filtering invitation to underscore