### PR TITLE
Fix/ Anon group readers when reviewer is unassigned

### DIFF
--- a/components/NoteEditorReaders.js
+++ b/components/NoteEditorReaders.js
@@ -324,25 +324,36 @@ export const NewReplyEditNoteReaders = ({
             description: p,
           }))
         : fieldDescription.param.items
-      const optionsP = enumItemsConfigOptions.map((p) =>
-        p.prefix
-          ? api.get('/groups', { prefix: p.prefix }, { accessToken }).then((result) =>
-              result.groups.map((q) => ({
-                value: q.id,
-                description: prettyId(q.id, false),
-                optional: p.optional,
-              }))
-            )
-          : Promise.resolve([
-              {
-                ...p,
-                description: prettyId(p.description ?? p.value)
-                  .split(/\{(\S+)\}/g)
-                  .filter((q) => q.trim())
-                  .join(),
-              },
-            ])
-      )
+      const optionsP = enumItemsConfigOptions.map((p) => {
+        if (p.prefix)
+          return api.get('/groups', { prefix: p.prefix }, { accessToken }).then((result) =>
+            result.groups.map((q) => ({
+              value: q.id,
+              description: prettyId(q.id, false),
+              optional: p.optional,
+            }))
+          )
+        if (p.inGroup) {
+          return api.get('/groups', { id: p.inGroup }, { accessToken }).then((result) => {
+            const groupMembers = result.groups[0]?.members
+            if (!groupMembers?.length) return []
+            return groupMembers.map((q) => ({
+              value: q,
+              description: prettyId(q, false),
+              optional: p.optional,
+            }))
+          })
+        }
+        return Promise.resolve([
+          {
+            ...p,
+            description: prettyId(p.description ?? p.value)
+              .split(/\{(\S+)\}/g)
+              .filter((q) => q.trim())
+              .join(),
+          },
+        ])
+      })
       const groupResults = await Promise.all(optionsP)
 
       const optionWithParentReaders = addEnumParentReaders(
@@ -397,9 +408,9 @@ export const NewReplyEditNoteReaders = ({
           }))
           parentReadersToAutoSelect = isDirectReplyToForum
             ? []
-            : replyToNote?.readers?.filter((p) =>
+            : (replyToNote?.readers?.filter((p) =>
                 optionWithParentReaders.find((q) => q.value === p)
-              ) ?? []
+              ) ?? [])
           defaultValues = fieldDescription?.param?.default ?? []
 
           if (!value && (defaultValues.length || parentReadersToAutoSelect.length))

--- a/unitTests/NoteEditorReaders.test.js
+++ b/unitTests/NoteEditorReaders.test.js
@@ -3710,4 +3710,68 @@ describe('NewReplyEditNoteReaders', () => {
       expect(clearError).toHaveBeenCalled()
     })
   })
+
+  test('show inGroup group members when items include inGroup', async () => {
+    const getInGroup = jest.fn(() =>
+      Promise.resolve({
+        groups: [
+          { members: ['venue/Submission1/Reviewer_aaaa', 'venue/Submission1/Reviewer_bbbb'] },
+        ],
+      })
+    )
+    api.get = getInGroup
+
+    const invitation = {
+      edit: {
+        note: {
+          readers: {
+            param: {
+              items: [
+                {
+                  value: 'venue/Submission1/Program_Chairs',
+                  optional: true,
+                },
+                {
+                  value: 'venue/Submission1/Area_Chairs',
+                  optional: true,
+                },
+                {
+                  inGroup: 'venue/Submission1/Reviewers',
+                  optional: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    render(
+      <NewReplyEditNoteReaders
+        replyToNote={undefined}
+        fieldDescription={invitation.edit.note.readers}
+        closeNoteEditor={jest.fn()}
+        value={null} // triggered by onChange of default value
+        onChange={jest.fn()}
+        setLoading={jest.fn()}
+        useCheckboxWidget={true}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('checkbox').length).toEqual(4)
+      expect(
+        screen.getByRole('checkbox', { name: 'Submission1 Program Chairs' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('checkbox', { name: 'Submission1 Area Chairs' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('checkbox', { name: 'Submission1 Reviewer aaaa' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('checkbox', { name: 'Submission1 Reviewer bbbb' })
+      ).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
this pr should add support of inGroup type in reply readers

members of the specified inGroup group will be added to options