### PR TITLE
Fix/ Invitation editor - avoid loading writablewith

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1179,7 +1179,7 @@ export function getDefaultTimezone() {
  * get meta invitation id to use when editing an invitation
  */
 export function getMetaInvitationId(invitation) {
-  const metaInvitationId = invitation?.details?.writableWith?.find((p) => p.edit === true)?.id
+  const metaInvitationId = `${invitation.domain}/-/Edit`
   return metaInvitationId
 }
 

--- a/pages/invitation/edit.js
+++ b/pages/invitation/edit.js
@@ -45,7 +45,7 @@ const InvitationEdit = ({ appContext }) => {
       const invitationObj = await api.getInvitationById(
         invitationId,
         accessToken,
-        { details: 'writable,writableWith', expired: true, trash: true },
+        { details: 'writable', expired: true, trash: true },
         { details: 'writable', expired: true }
       )
       if (invitationObj) {


### PR DESCRIPTION
invitation editor loads writableWith of the invitation (meta invitation)
which caused slowness of the page

this pr should remove loading writableWith and always use meta invitation