### PR TITLE
Fix/ Moderation - pass id when rejecting

### DIFF
--- a/components/profile/ProfilePreviewModal.js
+++ b/components/profile/ProfilePreviewModal.js
@@ -209,7 +209,7 @@ const ProfilePreviewModal = ({
                 type="button"
                 className="btn"
                 onClick={async () => {
-                  await rejectUser(rejectionMessage)
+                  await rejectUser(rejectionMessage, profileToPreview.id)
                   showNextProfile(profileToPreview.id)
                 }}
               >

--- a/pages/user/moderation.js
+++ b/pages/user/moderation.js
@@ -1838,7 +1838,7 @@ const UserModerationQueue = ({
       await api.post(
         '/profile/moderate',
         {
-          id: profileToReject?.id ?? id,
+          id,
           decision: 'reject',
           reason: rejectionMessage,
         },
@@ -2250,7 +2250,7 @@ export const RejectionModal = ({ id, profileToReject, rejectUser, signedNotes })
       id={id}
       primaryButtonDisabled={!rejectionMessage}
       onPrimaryButtonClick={() => {
-        rejectUser(rejectionMessage)
+        rejectUser(rejectionMessage, profileToReject.id)
       }}
       onClose={() => {
         selectRef.current.clearValue()


### PR DESCRIPTION
currently rejection action relies on profileToReject property to get the id
when moderation use different rejection function this is may get out of sync

this pr should pass the id to the reject function

related to #2283 