### PR TITLE
Fix/ Parse whole string when there's no colon

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1574,7 +1574,7 @@ export function getVenueTabCountMessage(unrepliedCommentCount, notDeployedCount)
 export function parseNumberField(value) {
   if (typeof value === 'string') {
     const valueString = value.substring(0, value.indexOf(':'))
-    return valueString ? parseInt(valueString, 10) : null
+    return valueString ? parseInt(valueString, 10) : parseInt(value, 10)
   } else if (typeof value === 'number') {
     return value
   }

--- a/unitTests/utils.test.js
+++ b/unitTests/utils.test.js
@@ -1,6 +1,7 @@
 import {
   getDefaultTimezone,
   isInstitutionEmail,
+  parseNumberField,
   prettyInvitationId,
   stringToObject,
 } from '../lib/utils'
@@ -306,5 +307,17 @@ describe('utils', () => {
     invitationId = 'TestVenue/Paper1/-/~First_Last1_Volunteer_to_Review_Approval'
     expectedValue = 'First Last  Volunteer to Review Approval'
     expect(prettyInvitationId(invitationId)).toEqual(expectedValue)
+  })
+
+  test('return confidence number in parseNumberField', () => {
+    let confidenceString = '1 - Not Confident: not confident at all'
+    let expectedValue = 1
+
+    expect(parseNumberField(confidenceString)).toEqual(expectedValue)
+
+    confidenceString = '4 - High Confidence - Reviewer is Highly familiar with the topic' // no colon
+    expectedValue = 4
+
+    expect(parseNumberField(confidenceString)).toEqual(expectedValue)
   })
 })


### PR DESCRIPTION
this pr should update the parse number util function to handle colon typo in invitation