### PR TITLE
Fix/ Markdown - force link to open in a new tab

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -285,6 +285,12 @@ export default class OpenReviewApp extends App {
     window._ = require('lodash')
     window.Handlebars = require('handlebars/runtime')
     window.marked = marked
+    DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+      if (node.tagName === 'A') {
+        node.setAttribute('target', '_blank')
+        node.setAttribute('rel', 'noopener noreferrer')
+      }
+    })
     window.DOMPurify = DOMPurify
     window.MathJax = mathjaxConfig
     window.nanoid = nanoid

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -285,7 +285,7 @@ export default class OpenReviewApp extends App {
     window._ = require('lodash')
     window.Handlebars = require('handlebars/runtime')
     window.marked = marked
-    DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+    DOMPurify.addHook('afterSanitizeAttributes', (node) => {
       if (node.tagName === 'A') {
         node.setAttribute('target', '_blank')
         node.setAttribute('rel', 'noopener noreferrer')


### PR DESCRIPTION
this pr should force link in all markdown content to open in a new tab