### PR TITLE
Fix/ Missing reader logic with InGroup

### DIFF
--- a/unitTests/NoteEditor.test.js
+++ b/unitTests/NoteEditor.test.js
@@ -1,4 +1,5 @@
 import { getNoteReaderValues } from '../components/NoteEditor'
+import api from '../lib/api-client'
 
 const roleNames = {
   anonAreaChairName: 'Area_Chair_',
@@ -9,7 +10,7 @@ const roleNames = {
 }
 
 describe('NoteEditor', () => {
-  test('return correct reader value in getNoteReaderValues', () => {
+  test('return correct reader value in getNoteReaderValues', async () => {
     const invitation = {
       edit: {
         note: {
@@ -48,7 +49,36 @@ describe('NoteEditor', () => {
       ],
     }
 
-    const readerValue = getNoteReaderValues(roleNames, invitation, noteEditorData)
+    api.get = jest.fn(() =>
+      Promise.resolve({
+        groups: [
+          {
+            id: 'NeurIPS.cc/2025/Conference/Submission1/Reviewers',
+            members: [
+              'NeurIPS.cc/2025/Conference/Submission1/Reviewer_abcd',
+              'NeurIPS.cc/2025/Conference/Submission1/Reviewer_efgh',
+              'NeurIPS.cc/2025/Conference/Submission1/Reviewer_ijkl',
+              'NeurIPS.cc/2025/Conference/Submission1/Reviewer_mnop',
+            ],
+          },
+        ],
+      })
+    )
+
+    const readerValue = await getNoteReaderValues(
+      roleNames,
+      invitation,
+      noteEditorData,
+      'token'
+    )
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/groups',
+      {
+        id: 'NeurIPS.cc/2025/Conference/Submission1/Reviewers',
+      },
+      expect.anything()
+    )
     // signature should be added and reviewers group should not be added
     const expectedReaderValue = [
       'NeurIPS.cc/2025/Conference/Program_Chairs',


### PR DESCRIPTION
currently invitationNoteReaderValues handles value or prefix when passed to addMissingReaders
so when a reviewer did not select any reviewer related reader, the add missing readers logic will add /reviewers group
because it can't find a match of signature(anon reviewer group) in invitationNoteReaderValues because invitation has defined inGroup:/reviewers which contains all the anon reviewer group

this pr fix the issue by getting group members of the inGroup group so that addMissingReaders can find a match for signature(anon reviewer group)