### PR TITLE
Fix/ Handle get inGroup member failure

### DIFF
--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -241,8 +241,12 @@ export const getNoteReaderValues = async (
       invitation.edit.note.readers?.param?.items?.map(async (p) => {
         if (p.value) return p.value
         if (p.inGroup) {
-          const result = await api.get('/groups', { id: p.inGroup }, { accessToken })
-          return result.groups[0]?.members
+          try {
+            const result = await api.get('/groups', { id: p.inGroup }, { accessToken })
+            return result.groups[0]?.members
+          } catch (error) {
+            return []
+          }
         }
         return p.prefix?.endsWith('*') ? p.prefix : `${p.prefix}.*`
       })
@@ -270,8 +274,12 @@ export const getEditReaderValues = async (
       invitation.edit.readers?.param?.items?.map(async (p) => {
         if (p.value) return p.value
         if (p.inGroup) {
-          const result = await api.get('/groups', { id: p.inGroup }, { accessToken })
-          return result.groups[0]?.members
+          try {
+            const result = await api.get('/groups', { id: p.inGroup }, { accessToken })
+            return result.groups[0]?.members
+          } catch (error) {
+            return []
+          }
         }
         return p.prefix?.endsWith('*') ? p.prefix : `${p.prefix}.*`
       })

--- a/components/NoteEditorReaders.js
+++ b/components/NoteEditorReaders.js
@@ -334,15 +334,18 @@ export const NewReplyEditNoteReaders = ({
             }))
           )
         if (p.inGroup) {
-          return api.get('/groups', { id: p.inGroup }, { accessToken }).then((result) => {
-            const groupMembers = result.groups[0]?.members
-            if (!groupMembers?.length) return []
-            return groupMembers.map((q) => ({
-              value: q,
-              description: prettyId(q, false),
-              optional: p.optional,
-            }))
-          })
+          return api
+            .get('/groups', { id: p.inGroup }, { accessToken })
+            .then((result) => {
+              const groupMembers = result.groups[0]?.members
+              if (!groupMembers?.length) return []
+              return groupMembers.map((q) => ({
+                value: q,
+                description: prettyId(q, false),
+                optional: p.optional,
+              }))
+            })
+            .catch(() => [])
         }
         return Promise.resolve([
           {

--- a/unitTests/NoteEditor.test.js
+++ b/unitTests/NoteEditor.test.js
@@ -88,4 +88,71 @@ describe('NoteEditor', () => {
     ]
     expect(readerValue).toEqual(expectedReaderValue)
   })
+
+  test('handle get inGroup member failure', async () => {
+    const invitation = {
+      edit: {
+        note: {
+          signatures: ['${3/signatures}'],
+          readers: {
+            param: {
+              items: [
+                { value: 'NeurIPS.cc/2025/Conference/Program_Chairs', optional: false },
+                {
+                  value: 'NeurIPS.cc/2025/Conference/Submission1/Senior_Area_Chairs',
+                  optional: false,
+                },
+                {
+                  value: 'NeurIPS.cc/2025/Conference/Submission1/Area_Chairs',
+                  optional: true,
+                },
+                { value: 'NeurIPS.cc/2025/Conference/Submission1/Reviewers', optional: true },
+                {
+                  inGroup: 'NeurIPS.cc/2025/Conference/Submission1/Reviewers',
+                  optional: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    // user selection
+    const noteEditorData = {
+      editSignatureInputValues: ['NeurIPS.cc/2025/Conference/Submission1/Reviewer_abcd'],
+      noteReaderValues: [
+        'NeurIPS.cc/2025/Conference/Program_Chairs',
+        'NeurIPS.cc/2025/Conference/Submission1/Senior_Area_Chairs',
+        'NeurIPS.cc/2025/Conference/Submission1/Area_Chairs',
+      ],
+    }
+
+    api.get = jest.fn(() =>
+      Promise.reject(new Error('API call failed probably because user cannot read this group'))
+    )
+
+    const readerValue = await getNoteReaderValues(
+      roleNames,
+      invitation,
+      noteEditorData,
+      'token'
+    )
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/groups',
+      {
+        id: 'NeurIPS.cc/2025/Conference/Submission1/Reviewers',
+      },
+      expect.anything()
+    )
+    // no match for anonymous reviewer group (signature) so all reviewers group is added
+    const expectedReaderValue = [
+      'NeurIPS.cc/2025/Conference/Program_Chairs',
+      'NeurIPS.cc/2025/Conference/Submission1/Senior_Area_Chairs',
+      'NeurIPS.cc/2025/Conference/Submission1/Area_Chairs',
+      'NeurIPS.cc/2025/Conference/Submission1/Reviewers',
+    ]
+    expect(readerValue).toEqual(expectedReaderValue)
+  })
 })


### PR DESCRIPTION
when user is not reader of the group defined by inGroup, getting inGroup member would fail preventing note editor from loading/ submitting

this pr should handle failure getting inGroup group members by returning empty array (like getting group by regex/prefix but didn't have any match)