### PR TITLE
Fix/ Mobile view wrong margin

### DIFF
--- a/components/WebfieldContainer.js
+++ b/components/WebfieldContainer.js
@@ -26,9 +26,7 @@ const WebfieldContainer = forwardRef((props, ref) => {
 
     if (href.match(/^\/(forum|group|profile|invitation|assignments)/)) {
       e.preventDefault()
-      // Need to manually scroll to top of page after using router.push,
-      // see https://github.com/vercel/next.js/issues/3249
-      router.push(href).then(() => window.scrollTo(0, 0))
+      router.push(href)
     } else if (href.startsWith('#') && target.getAttribute('data-modify-history') === 'true') {
       router.replace(window.location.pathname + window.location.search + href)
     }

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -32,6 +32,11 @@ body {
     flex-grow: 1;
     display: flex;
 
+    @media #{constants.$phone-only} {
+      margin-left: 15px;
+      margin-right: unset;
+    }
+
     .row {
       width: 100%;
     }


### PR DESCRIPTION
bootstrap adding auto margin causing the margin to be too large in mobile view
this pr should overwrite margin in mobile view

this pr should also remove out-dated code to scroll page