### PR TITLE
Chore: Avoid deploying to the dev site when API PRs are merged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
 
     needs: build
 
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && (github.event_name != 'repository_dispatch' || github.event.action != 'openreview-api-updated')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a small update to the GitHub Actions workflow to refine the conditions under which the build job runs.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L157-R157): Updated the `if` condition for the `build` job to exclude cases where the event is a `repository_dispatch` with the action `openreview-api-updated`.