### PR TITLE
Fix/ refreshtoken logging

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -35,8 +35,8 @@ const checkStatus = async (response, originalRequest) => {
       headers: {
         Accept: 'application/json,text/*;q=0.99',
         'Content-Type': 'application/json; charset=UTF-8',
+        Referer: 'api client',
         'X-Url': originalRequest.url,
-        'X-Source': 'api client',
       },
     })
     const data = await refreshResponse.json()

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -34,6 +34,8 @@ const checkStatus = async (response, originalRequest) => {
       headers: {
         Accept: 'application/json,text/*;q=0.99',
         'Content-Type': 'application/json; charset=UTF-8',
+        'X-Url': originalRequest.url,
+        'X-Source': 'api client',
       },
     })
     const data = await refreshResponse.json()

--- a/lib/clientAuth.js
+++ b/lib/clientAuth.js
@@ -32,6 +32,8 @@ async function clientRefreshToken() {
       headers: {
         Accept: 'application/json,text/*;q=0.99',
         'Content-Type': 'application/json; charset=UTF-8',
+        'X-Url': document.location.href,
+        'X-Source': 'client auth',
       },
       credentials: 'include',
     })

--- a/lib/clientAuth.js
+++ b/lib/clientAuth.js
@@ -50,8 +50,8 @@ async function clientRefreshToken() {
       headers: {
         Accept: 'application/json,text/*;q=0.99',
         'Content-Type': 'application/json; charset=UTF-8',
+        Referer: 'client auth',
         'X-Url': document.location.href,
-        'X-Source': 'client auth',
       },
       credentials: 'include',
     })

--- a/middleware.js
+++ b/middleware.js
@@ -23,10 +23,10 @@ export async function middleware(request) {
         Accept: 'application/json,text/*;q=0.99',
         Cookie: `${process.env.REFRESH_TOKEN_NAME}=${refreshToken?.value}`,
         'Content-Type': 'application/json; charset=UTF-8',
+        Referer: 'middleware',
         'X-Forwarded-For': request.headers.get('x-forwarded-for'),
         'X-Url': request.nextUrl.href,
         'X-User': decodedRefreshToken?.user?.profile?.id ?? decodedRefreshToken?.user?.id,
-        'X-Source': 'middleware',
       },
     })
 

--- a/middleware.js
+++ b/middleware.js
@@ -1,5 +1,5 @@
-import { headers } from 'next/headers'
 import { NextResponse } from 'next/server'
+import { getTokenPayload } from './lib/clientAuth'
 
 // eslint-disable-next-line import/prefer-default-export
 export async function middleware(request) {
@@ -14,6 +14,8 @@ export async function middleware(request) {
     return response
   }
 
+  const decodedRefreshToken = getTokenPayload(refreshToken.value)
+
   try {
     const tokenRefreshResponse = await fetch(`${process.env.API_V2_URL}/refreshToken`, {
       method: 'POST',
@@ -22,6 +24,9 @@ export async function middleware(request) {
         Cookie: `${process.env.REFRESH_TOKEN_NAME}=${refreshToken?.value}`,
         'Content-Type': 'application/json; charset=UTF-8',
         'X-Forwarded-For': request.headers.get('x-forwarded-for'),
+        'X-Url': request.nextUrl.href,
+        'X-User': decodedRefreshToken?.user?.profile?.id ?? decodedRefreshToken?.user?.id,
+        'X-Source': 'middleware',
       },
     })
 


### PR DESCRIPTION
this pr should send

url: page url or the api call url that failed before the /refreshtoken call
source: middleware or api client or client authentication
user: from refresh token (only for middleware)

in header of the call to /refreshtoken