### PR TITLE
Fix/ Temp fix of refresh token issue

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -89,7 +89,6 @@ export default function Forum({
   prefilledValues,
   query,
 }) {
-  const { isRefreshing, accessToken } = useUser()
   const [parentNote, setParentNote] = useState(forumNote)
   const [replyNoteMap, setReplyNoteMap] = useState(null)
   const [parentMap, setParentMap] = useState(null)
@@ -117,6 +116,7 @@ export default function Forum({
   const [confirmDeleteModalData, setConfirmDeleteModalData] = useState(null)
   const [scrolled, setScrolled] = useState(false)
   const [enableLiveUpdate, setEnableLiveUpdate] = useState(false)
+  const { isRefreshing, accessToken } = useUser(enableLiveUpdate)
   const [latestMdate, setLatestMdate] = useState(null)
   const [chatReplyNote, setChatReplyNote] = useState(null)
   const [notificationPermissions, setNotificationPermissions] = useState('loading')

--- a/hooks/useUser.js
+++ b/hooks/useUser.js
@@ -22,7 +22,6 @@ export default function useUser(pollToken = false) {
       interval = setInterval(async () => {
         const { token: tokenFromCookie } = await clientAuth()
         if (tokenFromCookie !== tokenRef.current) {
-          console.log('Token has changed, calling fetchData')
           fetchData()
         }
       }, 30000)

--- a/hooks/useUser.js
+++ b/hooks/useUser.js
@@ -1,20 +1,35 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { clientAuth } from '../lib/clientAuth'
 
-export default function useUser() {
+export default function useUser(pollToken = false) {
   const [user, setUser] = useState(null)
   const [token, setToken] = useState(null)
   const [isRefreshing, setIsRefshing] = useState(true)
+  const tokenRef = useRef(null)
 
   const fetchData = async () => {
     const { user: userFromCookie, token: tokenFromCookie } = await clientAuth()
     setUser(userFromCookie)
     setToken(tokenFromCookie)
     setIsRefshing(false)
+    tokenRef.current = tokenFromCookie
   }
 
   useEffect(() => {
     fetchData()
+    let interval
+    if (pollToken) {
+      interval = setInterval(async () => {
+        const { token: tokenFromCookie } = await clientAuth()
+        if (tokenFromCookie !== tokenRef.current) {
+          console.log('Token has changed, calling fetchData')
+          fetchData()
+        }
+      }, 30000)
+    }
+    return () => {
+      if (interval) interval(interval)
+    }
   }, [])
 
   return { user, accessToken: token, isRefreshing }


### PR DESCRIPTION
i think the issue with refresh token is chat making calls to check updates

this pr contains a temp fix to check for cookie token change so that the check updates call use new token instead of keep using expired token

currently the chat is the only place where polling (useInterval hook) is used
so the correct fix is to use web socket instead