### PR TITLE
Fix/ Profile page - publication published/modified date discrepancy in client rendering

### DIFF
--- a/components/ClientForumDate.js
+++ b/components/ClientForumDate.js
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { forumDate } from '../lib/utils'
+
+export default function ClientForumDate({ note }) {
+  const [isClientRendering, setIsClientRendering] = useState(false)
+
+  useEffect(() => {
+    setIsClientRendering(true)
+  }, [])
+
+  if (!isClientRendering) return null
+  return forumDate(
+    note.cdate,
+    note.tcdate,
+    note.mdate,
+    note.tmdate,
+    note.content?.year?.value,
+    note.pdate
+  )
+}

--- a/components/Note.js
+++ b/components/Note.js
@@ -5,6 +5,7 @@ import NoteContent, { NoteContentV2 } from './NoteContent'
 import Icon from './Icon'
 import { prettyId, forumDate, inflect } from '../lib/utils'
 import Collapse from './Collapse'
+import ClientForumDate from './ClientForumDate'
 
 const Note = ({ note, invitation, options }) => {
   const privatelyRevealed = options.showPrivateIcon && !note.readers.includes('everyone')
@@ -173,13 +174,17 @@ export const NoteV2 = ({ note, options }) => {
 
       <ul className="note-meta-info list-inline">
         <li>
-          {forumDate(
-            note.cdate,
-            note.tcdate,
-            note.mdate,
-            note.tmdate,
-            note.content?.year?.value,
-            note.pdate
+          {options.clientRenderingOnly ? (
+            <ClientForumDate note={note} />
+          ) : (
+            forumDate(
+              note.cdate,
+              note.tcdate,
+              note.mdate,
+              note.tmdate,
+              note.content?.year?.value,
+              note.pdate
+            )
           )}
         </li>
         <li>

--- a/components/profile/ProfilePublications.js
+++ b/components/profile/ProfilePublications.js
@@ -20,6 +20,7 @@ const ProfilePublications = ({
     htmlLink: false,
     showContents: false,
     showPrivateIcon: true,
+    clientRenderingOnly: true,
     referrer:
       preferredName &&
       profileId &&


### PR DESCRIPTION
Some notes in profile publications page may be rendered to different dates in server and client
and cause hydration error

this pr should render the publication dates in profile page only in the browser