### PR TITLE
Fix/ Forum - replace polling with event

### DIFF
--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -89,6 +89,7 @@ export default function Forum({
   prefilledValues,
   query,
 }) {
+  const { isRefreshing, accessToken } = useUser()
   const [parentNote, setParentNote] = useState(forumNote)
   const [replyNoteMap, setReplyNoteMap] = useState(null)
   const [parentMap, setParentMap] = useState(null)
@@ -116,7 +117,6 @@ export default function Forum({
   const [confirmDeleteModalData, setConfirmDeleteModalData] = useState(null)
   const [scrolled, setScrolled] = useState(false)
   const [enableLiveUpdate, setEnableLiveUpdate] = useState(false)
-  const { isRefreshing, accessToken } = useUser(enableLiveUpdate)
   const [latestMdate, setLatestMdate] = useState(null)
   const [chatReplyNote, setChatReplyNote] = useState(null)
   const [notificationPermissions, setNotificationPermissions] = useState('loading')

--- a/hooks/useUser.js
+++ b/hooks/useUser.js
@@ -1,34 +1,20 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { clientAuth } from '../lib/clientAuth'
 
-export default function useUser(pollToken = false) {
+export default function useUser() {
   const [user, setUser] = useState(null)
   const [token, setToken] = useState(null)
   const [isRefreshing, setIsRefshing] = useState(true)
-  const tokenRef = useRef(null)
 
   const fetchData = async () => {
     const { user: userFromCookie, token: tokenFromCookie } = await clientAuth()
     setUser(userFromCookie)
     setToken(tokenFromCookie)
     setIsRefshing(false)
-    tokenRef.current = tokenFromCookie
   }
 
   useEffect(() => {
     fetchData()
-    let interval
-    if (pollToken) {
-      interval = setInterval(async () => {
-        const { token: tokenFromCookie } = await clientAuth()
-        if (tokenFromCookie !== tokenRef.current) {
-          fetchData()
-        }
-      }, 30000)
-    }
-    return () => {
-      if (interval) interval(interval)
-    }
   }, [])
 
   return { user, accessToken: token, isRefreshing }


### PR DESCRIPTION
this pr should remove useInterval call from forum page and use socket event instead

this pr should also revert changes of #2363 as it's not required anymore