### PR TITLE
Fix/ Disable deployment to dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,8 @@ jobs:
 
     needs: build
 
-    if: github.ref == 'refs/heads/master' && (github.event_name != 'repository_dispatch' || github.event.action != 'openreview-api-updated')
+    if: false
+    #if: github.ref == 'refs/heads/master' && (github.event_name != 'repository_dispatch' || github.event.action != 'openreview-api-updated')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
this pr should pause deployment to dev server when pr is merged to master
so that workflow changes does not get overwritten

should be reverted when #2318 is merged