### PR TITLE
Fix/ Add missing count param

### DIFF
--- a/app/assignments/V2Assignments.js
+++ b/app/assignments/V2Assignments.js
@@ -290,6 +290,7 @@ export default function V2Assignments({
         '/notes',
         {
           invitation: `${group}/-/Assignment_Configuration`,
+          count: true,
         },
         { accessToken, version: 2 }
       )


### PR DESCRIPTION
related to changes in https://github.com/openreview/openreview-api/pull/781

this pr should add missing count param which is required for assignments page to return count of assignment notes

Webfield2.api.getSubmissions should also be changed when webfield pass includeCount
but i think it's not used anymore so didn't change it