### PR TITLE
PC console: check if the edge.head is pointing to an active submission

### DIFF
--- a/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
@@ -279,8 +279,10 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaRev
     } else if (sacDirectPaperAssignment && !pcConsoleData.noteNumberReviewMetaReviewMap) {
       loadReviewMetaReviewData()
     } else {
-      // Optimization: build a map of notes by id
-      const notesById = new Map(pcConsoleData.notes.map(n => [n.id, n]))
+      // Optimization: build an object of notes by id
+      const notesById = {}
+      pcConsoleData.notes.forEach((n) => { notesById[n.id] = n })
+
       const tableRows = pcConsoleData.seniorAreaChairs.map((sacProfileId, index) => {
         let notes = []
         let acs = []
@@ -288,9 +290,9 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaRev
         if (sacDirectPaperAssignment) {
           notes =
             pcConsoleData.sacAcInfo.acBySacMap.get(sacProfileId)
-              ?.filter((noteId) => notesById.has(noteId))
+              ?.filter((noteId) => notesById[noteId])
               .map((noteId) => {
-                const note = notesById.get(noteId)
+                const note = notesById[noteId]
                 const noteNumber = note?.number
                 const reviewMetaReviewInfo =
                   pcConsoleData.noteNumberReviewMetaReviewMap.get(noteNumber) ?? {}

--- a/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
+++ b/components/webfield/ProgramChairConsole/SeniorAreaChairStatus.js
@@ -279,21 +279,23 @@ const SeniorAreaChairStatus = ({ pcConsoleData, loadSacAcInfo, loadReviewMetaRev
     } else if (sacDirectPaperAssignment && !pcConsoleData.noteNumberReviewMetaReviewMap) {
       loadReviewMetaReviewData()
     } else {
+      // Optimization: build a map of notes by id
+      const notesById = new Map(pcConsoleData.notes.map(n => [n.id, n]))
       const tableRows = pcConsoleData.seniorAreaChairs.map((sacProfileId, index) => {
         let notes = []
         let acs = []
 
         if (sacDirectPaperAssignment) {
           notes =
-            pcConsoleData.sacAcInfo.acBySacMap.get(sacProfileId)?.map((noteId) => {
-              const note = pcConsoleData.notes.find((p) => p.id === noteId)
-              if (!note) return null
-              const noteNumber = note?.number
-
-              const reviewMetaReviewInfo =
-                pcConsoleData.noteNumberReviewMetaReviewMap.get(noteNumber) ?? {}
-              return { note, noteNumber, ...reviewMetaReviewInfo }
-            }) ?? []
+            pcConsoleData.sacAcInfo.acBySacMap.get(sacProfileId)
+              ?.filter((noteId) => notesById.has(noteId))
+              .map((noteId) => {
+                const note = notesById.get(noteId)
+                const noteNumber = note?.number
+                const reviewMetaReviewInfo =
+                  pcConsoleData.noteNumberReviewMetaReviewMap.get(noteNumber) ?? {}
+                return { note, noteNumber, ...reviewMetaReviewInfo }
+              }) ?? []
         } else {
           acs =
             pcConsoleData.sacAcInfo.acBySacMap.get(sacProfileId)?.map((acProfileId) => {


### PR DESCRIPTION
This issue was reported by ARR and it is related to assigned papers that are not active anymore.

If the edge.head is pointing to a non active submission then we shouldn't add it to the list of notes for that SAC. 

I could reproduce the issue locally by desk-rejecting an assigned submission that doesn't have a meta review and try to remind the SAC with unsubmitted meta reviews.