### PR TITLE
Fix/ Edge browser - pass domain to signature lookup call

### DIFF
--- a/components/browser/EdgeBrowser.js
+++ b/components/browser/EdgeBrowser.js
@@ -379,7 +379,11 @@ export default class EdgeBrowser extends React.Component {
         try {
           const interpolatedLookupResult = await api.get(
             '/groups',
-            { regex: interpolatedSignature, signatory: this.userId },
+            {
+              regex: interpolatedSignature,
+              signatory: this.userId,
+              ...(editInvitation.domain && { domain: editInvitation.domain }),
+            },
             { accessToken: this.accessToken, version: 1 } // Use only version 1 where regex is supported
           )
           editInvitationSignaturesMap.push({


### PR DESCRIPTION
edge browser is making a call to v1 to get groups that user can sign with when invitation specify regex

this pr should pass domain param to this call so that it can be faster
ui changes for [github.com/openreview/openreview-api-v1/pull/3053](https://github.com/openreview/openreview-api-v1/pull/3053)