### PR TITLE
Fix/ IEEE Copyright Form fix

### DIFF
--- a/components/webfield/NoteMetaReviewStatus.js
+++ b/components/webfield/NoteMetaReviewStatus.js
@@ -13,10 +13,10 @@ import { getProfileLink } from '../../lib/webfield-utils'
 const IEEECopyrightForm = ({ note, isV2Note }) => {
   const { showIEEECopyright, IEEEPublicationTitle, IEEEArtSourceCode } =
     useContext(WebFieldContext)
-  const { user } = useUser()
+  const { user, isRefreshing } = useUser()
   const noteContent = isV2Note ? getNoteContentValues(note.content) : note.content
 
-  if (showIEEECopyright && IEEEPublicationTitle && IEEEArtSourceCode) {
+  if (showIEEECopyright && IEEEPublicationTitle && IEEEArtSourceCode && !isRefreshing) {
     return (
       <form action="https://ecopyright.ieee.org/ECTT/IntroPage.jsp" method="post">
         <input type="hidden" name="PubTitle" value={IEEEPublicationTitle} />


### PR DESCRIPTION
when token is being refreshed, reading user.profile.preferredEmail would lead to error

this pr should show copyright button only when user is ready