### PR TITLE
Fix/ Venu config - show instruction of workflow invitation

### DIFF
--- a/components/group/WorkflowInvitations.js
+++ b/components/group/WorkflowInvitations.js
@@ -315,9 +315,9 @@ const WorkflowInvitationRow = ({
               <a>{isExpired ? 'Enable' : 'Disable'}</a>
             </div>
           </div>
-          {invitation.description && (
+          {(invitation.instruction ?? invitation.description) && (
             <div className="invitation-description">
-              <Markdown text={invitation.description} />
+              <Markdown text={invitation.instruction ?? invitation.description} />
             </div>
           )}
           {earliestDueDate && (

--- a/components/group/WorkflowInvitations.js
+++ b/components/group/WorkflowInvitations.js
@@ -317,7 +317,7 @@ const WorkflowInvitationRow = ({
           </div>
           {(invitation.instructions ?? invitation.description) && (
             <div className="invitation-description">
-              <Markdown text={invitation.instruction ?? invitation.description} />
+              <Markdown text={invitation.instructions ?? invitation.description} />
             </div>
           )}
           {earliestDueDate && (

--- a/components/group/WorkflowInvitations.js
+++ b/components/group/WorkflowInvitations.js
@@ -315,7 +315,7 @@ const WorkflowInvitationRow = ({
               <a>{isExpired ? 'Enable' : 'Disable'}</a>
             </div>
           </div>
-          {(invitation.instruction ?? invitation.description) && (
+          {(invitation.instructions ?? invitation.description) && (
             <div className="invitation-description">
               <Markdown text={invitation.instruction ?? invitation.description} />
             </div>


### PR DESCRIPTION
this pr should instruction of workflow invitation in workflow timeline
if instruction is not available, use description as a fallback value

rational of this change is to avoid showing the text for users (description) to pc (instruction)