### PR TITLE
Fix/ PC Console - show timeline section before data loading is completed

### DIFF
--- a/app/group/Group.module.scss
+++ b/app/group/Group.module.scss
@@ -167,6 +167,7 @@
       }
       .spinner-small {
         display: inline-block;
+        margin-bottom: 0;
         div {
           background-color: constants.$orRed;
         }

--- a/components/webfield/ProgramChairConsole/Overview.js
+++ b/components/webfield/ProgramChairConsole/Overview.js
@@ -681,7 +681,7 @@ const DescriptionTimelineOtherConfigRow = ({
   reviewersBidEnabled,
   areaChairsBidEnabled,
   seniorAreaChairsBidEnabled,
-  pcConsoleData,
+  timelineData,
   recommendationEnabled,
 }) => {
   const {
@@ -711,7 +711,7 @@ const DescriptionTimelineOtherConfigRow = ({
     domainContent,
   } = useContext(WebFieldContext)
 
-  const { requestForm, registrationForms, invitations } = pcConsoleData
+  const { requestForm, registrationForms, invitations } = timelineData
   const referrerUrl = encodeURIComponent(
     `[Program Chair Console](/group?id=${venueId}/Program_Chairs)`
   )
@@ -747,7 +747,7 @@ const DescriptionTimelineOtherConfigRow = ({
   const getAssignmentLink = (role) => {
     if (assignmentUrls?.[role]?.automaticAssignment === false) {
       return assignmentUrls?.[role]?.manualAssignmentUrl &&
-        pcConsoleData.invitations?.some((p) => p.id === `${venueId}/${role}/-/Assignment`)
+        invitations?.some((p) => p.id === `${venueId}/${role}/-/Assignment`)
         ? `${assignmentUrls[role].manualAssignmentUrl}&referrer=${referrerUrl}`
         : null
     }
@@ -1124,7 +1124,7 @@ const DescriptionTimelineOtherConfigRow = ({
   )
 }
 
-const Overview = ({ pcConsoleData }) => {
+const Overview = ({ pcConsoleData, timelineData }) => {
   const {
     areaChairsId,
     areaChairName = 'Area_Chairs',
@@ -1136,14 +1136,12 @@ const Overview = ({ pcConsoleData }) => {
   } = useContext(WebFieldContext)
 
   const isBidEnabled = (groupId) =>
-    bidName
-      ? pcConsoleData.invitations?.find((p) => p.id === `${groupId}/-/${bidName}`)
-      : false
+    bidName ? timelineData.invitations?.find((p) => p.id === `${groupId}/-/${bidName}`) : false
 
   const reviewersBidEnabled = isBidEnabled(reviewersId)
   const areaChairsBidEnabled = isBidEnabled(areaChairsId)
   const seniorAreaChairsBidEnabled = isBidEnabled(seniorAreaChairsId)
-  const recommendationEnabled = pcConsoleData.invitations?.find(
+  const recommendationEnabled = timelineData.invitations?.find(
     (p) => p.id === `${reviewersId}/-/${recommendationName}`
   )
   return (
@@ -1165,7 +1163,7 @@ const Overview = ({ pcConsoleData }) => {
         reviewersBidEnabled={reviewersBidEnabled}
         areaChairsBidEnabled={areaChairsBidEnabled}
         seniorAreaChairsBidEnabled={seniorAreaChairsBidEnabled}
-        pcConsoleData={pcConsoleData}
+        timelineData={timelineData}
         recommendationEnabled={recommendationEnabled}
       />
     </>


### PR DESCRIPTION
Some pcs go to pc console just to access links at the bottom of the overview tab

this pr should split the data loading logic for timeline section so that it does not need to wait for all notes info 