### PR TITLE
Fix/ Profile editor - handle relations with no readers

### DIFF
--- a/components/profile/RelationsSection.js
+++ b/components/profile/RelationsSection.js
@@ -90,7 +90,9 @@ const RelationRow = ({
   const relationPlaceholder = 'Choose or type a relation'
   const [relationClicked, setRelationClicked] = useState(false)
   const relationReadersOptionWithExistingRelation = uniqBy(
-    relationReaderOptions.concat(relation.readers.map((r) => ({ value: r, label: r }))),
+    relationReaderOptions.concat(
+      (relation.readers ?? []).map((r) => ({ value: r, label: r }))
+    ),
     (p) => p.value
   )
 
@@ -279,7 +281,7 @@ const RelationRow = ({
             isMobile ? ' relation__multiple-select-mobile' : ''
           }`}
           options={relationReadersOptionWithExistingRelation}
-          selectedValues={relation.readers}
+          selectedValues={relation.readers ?? []}
           setSelectedValues={(values) =>
             setRelation({ type: readersType, data: { value: values, key: relation.key } })
           }


### PR DESCRIPTION
some old profiles have relations with no readers which will lead to error when user edit relations in profile edit

this pr should add a fallback value for relation readers