### PR TITLE
Fix/ PC Console overview - read v1 request form content

### DIFF
--- a/components/webfield/ProgramChairConsole/Overview.js
+++ b/components/webfield/ProgramChairConsole/Overview.js
@@ -716,8 +716,11 @@ const DescriptionTimelineOtherConfigRow = ({
   const referrerUrl = encodeURIComponent(
     `[Program Chair Console](/group?id=${venueId}/Program_Chairs)`
   )
-  const requestFormContent = getNoteContentValues(requestForm?.content)
-  const domainContentValues = getNoteContentValues(domainContent)
+  const requestFormContent = getNoteContentValues(
+    requestForm?.content,
+    requestForm?.apiVersion
+  )
+  const domainContentValues = getNoteContentValues(domainContent, requestForm?.apiVersion)
   const sacRoles = requestFormContent?.senior_area_chair_roles ??
     domainContentValues.senior_area_chair_roles ?? ['Senior_Area_Chairs']
   const acRoles = requestFormContent?.area_chair_roles ??

--- a/lib/forum-utils.js
+++ b/lib/forum-utils.js
@@ -194,9 +194,11 @@ export function formatNote(note, invitations) {
  * Get note content values
  *
  * @param {object} content
+ * @param {string} apiVersion
  * @returns object
  */
-export function getNoteContentValues(content) {
+export function getNoteContentValues(content, apiVersion) {
+  if (apiVersion === 1) return content || {}
   return Object.keys(content ?? {}).reduce((acc, key) => {
     const val = content[key].value
     acc[key] = val


### PR DESCRIPTION
this is to fix a side effect caused by #2318 
which assume request form is in v2

this pr should pass apiVersion from request form so that it works for both v1 and v2 venue requests