### PR TITLE
PC Console: save a reduced version of the profile in console data

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -345,15 +345,15 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
       const committeeMemberResults = results[0]
       const ithenticateEdges = results[5]
       const notes = []
-      const withdrawnNotes = []
-      const deskRejectedNotes = []
+      let withdrawnNotesCount = 0
+      let deskRejectedNotesCount = 0
       results[1].forEach((note) => {
         if (note.content?.venueid?.value === withdrawnVenueId) {
-          withdrawnNotes.push(note)
+          withdrawnNotesCount += 1
           return
         }
         if (note.content?.venueid?.value === deskRejectedVenueId) {
-          deskRejectedNotes.push(note)
+          deskRejectedNotesCount += 1
           return
         }
         notes.push({
@@ -529,7 +529,6 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
           usernames.concat(profile.email ?? []).forEach((key) => {
             allProfilesMap.set(key, reducedProfile)
           })
-
         })
       // #endregion
       const officialReviewsByPaperNumberMap = new Map()
@@ -580,13 +579,19 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
             }
 
             officialReviews.push({
-              ...reply,
+              content: reply.content,
+              id: reply.id,
+              signatures: reply.signatures,
+              forum: reply.forum,
               anonId: getIndentifierFromGroup(anonymousGroupId, anonReviewerName),
             })
           }
           if (reply.invitations.includes(officialMetaReviewInvitationId)) {
             metaReviews.push({
-              ...reply,
+              id: reply.id,
+              forum: reply.forum,
+              content: reply.content,
+              signatures: reply.signatures,
               anonId: getIndentifierFromGroup(reply.signatures[0], anonAreaChairName),
             })
           }
@@ -649,7 +654,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         if (officialReviews.length) {
           officialReviewsByPaperNumberMap.set(note.number, officialReviews)
         }
-        if (metaReviews.length){
+        if (metaReviews.length) {
           metaReviewsByPaperNumberMap.set(note.number, metaReviews)
         }
         if (decision) {
@@ -658,11 +663,13 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         if (customStageReviews.length) {
           customStageReviewsByPaperNumberMap.set(note.number, customStageReviews)
         }
-        if (latestDisplayReplies.length){
+        if (latestDisplayReplies.length) {
           displayReplyInvitationsByPaperNumberMap.set(note.number, latestDisplayReplies)
         }
+        // eslint-disable-next-line no-param-reassign
         note.replyCount = replies.length
-        delete note.details.replies
+        // eslint-disable-next-line no-param-reassign
+        delete note.details?.replies
       })
 
       const consoleData = {
@@ -679,8 +686,8 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         decisionByPaperNumberMap,
         customStageReviewsByPaperNumberMap,
         displayReplyInvitationsByPaperNumberMap,
-        withdrawnNotes,
-        deskRejectedNotes,
+        withdrawnNotesCount,
+        deskRejectedNotesCount,
 
         acRecommendationsCount,
         bidCounts: {
@@ -1043,7 +1050,8 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
             }
           }, {}),
         },
-        displayReplies: pcConsoleData.displayReplyInvitationsByPaperNumberMap.get(note.number),
+        displayReplies:
+          pcConsoleData.displayReplyInvitationsByPaperNumberMap.get(note.number) ?? [],
         decision,
         venue: note?.content?.venue?.value,
         messageSignature: programChairsId,

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -646,13 +646,21 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
           }
         })
 
-        officialReviewsByPaperNumberMap.set(note.number, officialReviews)
-        metaReviewsByPaperNumberMap.set(note.number, metaReviews)
-        decisionByPaperNumberMap.set(note.number, decision)
+        if (officialReviews.length) {
+          officialReviewsByPaperNumberMap.set(note.number, officialReviews)
+        }
+        if (metaReviews.length){
+          metaReviewsByPaperNumberMap.set(note.number, metaReviews)
+        }
+        if (decision) {
+          decisionByPaperNumberMap.set(note.number, decision)
+        }
         if (customStageReviews.length) {
           customStageReviewsByPaperNumberMap.set(note.number, customStageReviews)
         }
-        displayReplyInvitationsByPaperNumberMap.set(note.number, latestDisplayReplies)
+        if (latestDisplayReplies.length){
+          displayReplyInvitationsByPaperNumberMap.set(note.number, latestDisplayReplies)
+      }
       })
 
       const consoleData = {

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -660,7 +660,9 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         }
         if (latestDisplayReplies.length){
           displayReplyInvitationsByPaperNumberMap.set(note.number, latestDisplayReplies)
-      }
+        }
+        note.replyCount = replies.length
+        delete note.details.replies
       })
 
       const consoleData = {
@@ -984,7 +986,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
           confidenceAvg,
           confidenceMax,
           confidenceMin,
-          replyCount: note.details.replies?.length ?? 0,
+          replyCount: note.replyCount,
         },
         metaReviewData: {
           numAreaChairsAssigned: assignedAreaChairs.length,

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -649,7 +649,9 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         officialReviewsByPaperNumberMap.set(note.number, officialReviews)
         metaReviewsByPaperNumberMap.set(note.number, metaReviews)
         decisionByPaperNumberMap.set(note.number, decision)
-        customStageReviewsByPaperNumberMap.set(note.number, customStageReviews)
+        if (customStageReviews.length) {
+          customStageReviewsByPaperNumberMap.set(note.number, customStageReviews)
+        }
         displayReplyInvitationsByPaperNumberMap.set(note.number, latestDisplayReplies)
       })
 

--- a/components/webfield/ProgramChairConsole/Overview.js
+++ b/components/webfield/ProgramChairConsole/Overview.js
@@ -131,8 +131,8 @@ const SubmissionsStatsRow = ({ pcConsoleData }) => {
   const submissionByStatus = pcConsoleData.notes
     ? {
         activeSubmissionsCount: pcConsoleData.notes.length,
-        deskRejectedNotesCount: pcConsoleData.deskRejectedNotes.length,
-        withdrawnNotesCount: pcConsoleData.withdrawnNotes.length,
+        deskRejectedNotesCount: pcConsoleData.deskRejectedNotesCount,
+        withdrawnNotesCount: pcConsoleData.withdrawnNotesCount,
       }
     : null
 

--- a/lib/console-cache.js
+++ b/lib/console-cache.js
@@ -1,6 +1,29 @@
 import dayjs from 'dayjs'
+import { deflate, inflate } from 'pako'
 
 const storeName = 'console-cache'
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+const compress = (obj) => {
+  const json = JSON.stringify(obj, (_, value) =>
+    value instanceof Map ? { type: 'Map', entries: [...value.entries()] } : value
+  )
+  const bytes = textEncoder.encode(json)
+  return deflate(bytes)
+}
+
+const decompress = (bytes) => {
+  const inflated = inflate(bytes)
+  const json = textDecoder.decode(inflated)
+  return JSON.parse(json, (_, value) => {
+    if (value && value.type === 'Map' && Array.isArray(value.entries)) {
+      return new Map(value.entries)
+    }
+    return value
+  })
+}
 
 const connect = () =>
   new Promise((resolve, reject) => {
@@ -34,13 +57,23 @@ export const getCache = async (venueId) => {
       }
 
       request.onsuccess = () => {
-        const cacheData = request.result
-        if (!cacheData?.timeStamp || dayjs().diff(cacheData.timeStamp, 'hour') > 24) {
+        let cacheData = request.result
+        if (!cacheData) {
           resolve(null)
           return
         }
 
-        resolve(request.result)
+        if (cacheData.compressed) {
+          const original = decompress(cacheData.payload)
+          cacheData = { ...original, timeStamp: cacheData.timeStamp }
+        }
+
+        if (!cacheData.timeStamp || dayjs().diff(cacheData.timeStamp, 'hour') > 24) {
+          resolve(null)
+          return
+        }
+
+        resolve(cacheData)
       }
 
       transaction.oncomplete = () => {
@@ -58,7 +91,13 @@ export const setCache = async (venueId, data) => {
     return new Promise((resolve, reject) => {
       const transaction = db.transaction(storeName, 'readwrite')
       const objectStore = transaction.objectStore(storeName)
-      const request = objectStore.put(data, venueId)
+
+      const compressedData = {
+        timeStamp: data.timeStamp,
+        compressed: true,
+        payload: compress(data),
+      }
+      const request = objectStore.put(compressedData, venueId)
 
       request.onerror = (event) => {
         reject(event)

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "nanoid": "^5.0.4",
         "next": "^15.2.3",
         "next-build-id": "^3.0.0",
+        "pako": "^2.1.0",
         "query-string": "^7.1.3",
         "rc-picker": "^4.6.14",
         "rc-steps": "^6.0.1",
@@ -11874,6 +11875,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -24041,6 +24048,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "devOptional": true
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "nanoid": "^5.0.4",
     "next": "^15.2.3",
     "next-build-id": "^3.0.0",
+    "pako": "^2.1.0",
     "query-string": "^7.1.3",
     "rc-picker": "^4.6.14",
     "rc-steps": "^6.0.1",

--- a/unitTests/console-cache.test.js
+++ b/unitTests/console-cache.test.js
@@ -1,11 +1,49 @@
 import dayjs from 'dayjs'
-import { getCache } from '../lib/console-cache'
+import { TextEncoder, TextDecoder } from 'util'
+
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder
+
+let getCache
+
+beforeAll(async () => {
+  const module = await import('../lib/console-cache')
+  getCache = module.getCache
+})
 
 const normalDb = {
   transaction: jest.fn(() => ({
     objectStore: jest.fn(() => ({
       get: jest.fn(() => {
-        const request = { result: { timeStamp: dayjs().valueOf() } }
+        const request = { result: { timeStamp: dayjs().valueOf(), compressed: undefined } }
+        setTimeout(() => {
+          request.onsuccess()
+        }, 0)
+        return request
+      }),
+      put: jest.fn(),
+      openCursor: jest.fn(),
+    })),
+  })),
+  close: jest.fn(),
+}
+
+const compressedDb = {
+  transaction: jest.fn(() => ({
+    objectStore: jest.fn(() => ({
+      get: jest.fn(() => {
+        const request = {
+          result: {
+            timeStamp: dayjs().valueOf(),
+            compressed: true,
+            payload: [
+              // {someMap: {key:1}}
+              120, 156, 171, 86, 42, 206, 207, 77, 245, 77, 44, 80, 178, 170, 86, 42, 169, 44,
+              72, 85, 178, 82, 2, 241, 116, 148, 82, 243, 74, 138, 50, 83, 139, 149, 172, 162,
+              163, 149, 178, 83, 43, 149, 116, 12, 99, 99, 107, 107, 1, 136, 46, 15, 225,
+            ],
+          },
+        }
         setTimeout(() => {
           request.onsuccess()
         }, 0)
@@ -47,6 +85,18 @@ const normalIndexedDB = {
   }),
 }
 
+const compressedIndexedDB = {
+  open: jest.fn(() => {
+    const request = { result: compressedDb }
+
+    setTimeout(() => {
+      request.onsuccess()
+    }, 0)
+
+    return request
+  }),
+}
+
 const staleIndexedDB = {
   open: jest.fn(() => {
     const request = { result: staleDb }
@@ -67,6 +117,13 @@ describe('console-cache', () => {
   test('getCache should return cached data', async () => {
     const result = await getCache('testVenue')
     expect(result.timeStamp).toBeDefined()
+  })
+
+  test('getCache should return cached compressed data', async () => {
+    global.indexedDB = compressedIndexedDB
+    const result = await getCache('testVenue')
+    expect(result.timeStamp).toBeDefined()
+    expect(result.someMap.get('key')).toBe(1)
   })
 
   test('getCache should not return cached but stale data', async () => {


### PR DESCRIPTION
Summary of improvements:

- Reduce the size of `consoleData` object that is being stored in the browser db:
1. Remove `allProfiles` list, having `allProfilesMap` is enough
2. Keep a reduced version of the profile object: id, preferredName, title(extracted from current institution) and usernames
3. Keep the count of desk rejected and withdrawn notes instead of having the list of notes
4. Store the review list in the map only when it is not empty to avoid a large map with empty arrays. Same for metareviews, decisions, custom stages, etc
5. Keep a reduced version of each reply: id, forum, content, signatures. 
6. Remove `details.replies` from the note once the replies are being stored in each map(`officialReviewsByPaperNumberMap`, `metaReviewsByPaperNumberMap`, etc)
7. Precompute the `replyCount` instead of checking the length of note.details.replies

- Compress the object `consoleDate` before sending to the browser db to reduce their size
