### PR TITLE
Fix/ PC Console overview - move invited groups logic to main loading

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -105,6 +105,10 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
   const areaChairUrlFormat = getRoleHashFragment(areaChairName)
   const reviewerUrlFormat = getRoleHashFragment(reviewerName)
 
+  const reviewersInvitedId = reviewersId ? `${reviewersId}/Invited` : null
+  const areaChairsInvitedId = areaChairsId ? `${areaChairsId}/Invited` : null
+  const seniorAreaChairsInvitedId = seniorAreaChairsId ? `${seniorAreaChairsId}/Invited` : null
+
   const loadData = async () => {
     if (isLoadingData) return
     setIsLoadingData(true)
@@ -232,6 +236,17 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         registrationForms,
       })
 
+      // #region get invited groups
+      const invitedGroupsP = await Promise.all(
+        [reviewersInvitedId, areaChairsInvitedId, seniorAreaChairsInvitedId].map(
+          (invitedId) =>
+            invitedId
+              ? api.getGroupById(invitedId, accessToken, { select: 'members' })
+              : Promise.resolve(null)
+        )
+      )
+      // #endregion
+
       // #region get Reviewer, AC, SAC members
       const committeeMemberResultsP = Promise.all(
         [reviewersId, areaChairsId, seniorAreaChairsId].map((id) =>
@@ -340,6 +355,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         bidCountResultsP,
         perPaperGroupResultsP,
         ithenticateEdgesP,
+        invitedGroupsP,
       ])
 
       const committeeMemberResults = results[0]
@@ -367,6 +383,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
       const acRecommendationsCount = results[2]
       const bidCountResults = results[3]
       const perPaperGroupResults = results[4]
+      const invitedGroupsResult = results[6]
 
       // #region categorize result of per paper groups
       const reviewerGroups = []
@@ -688,7 +705,6 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         displayReplyInvitationsByPaperNumberMap,
         withdrawnNotesCount,
         deskRejectedNotesCount,
-
         acRecommendationsCount,
         bidCounts: {
           reviewers: bidCountResults[0],
@@ -769,6 +785,9 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
           seniorAreaChairGroups,
         },
         ithenticateEdges,
+        reviewersInvitedCount: invitedGroupsResult[0]?.members?.length ?? 0,
+        areaChairsInvitedCount: invitedGroupsResult[1]?.members?.length ?? 0,
+        seniorAreaChairsInvitedCount: invitedGroupsResult[2]?.members?.length ?? 0,
         timeStamp: dayjs().valueOf(),
       }
       setDataLoadingStatusMessage(null)

--- a/components/webfield/ProgramChairConsole/Overview.js
+++ b/components/webfield/ProgramChairConsole/Overview.js
@@ -37,49 +37,19 @@ const renderStat = (numComplete, total) =>
 
 const RecruitmentStatsRow = ({ pcConsoleData }) => {
   const {
-    reviewersId,
     reviewerName = 'Reviewers',
     areaChairsId,
     areaChairName = 'Area_Chairs',
     seniorAreaChairsId,
     seniorAreaChairName = 'Senior_Area_Chairs',
   } = useContext(WebFieldContext)
-  const { accessToken } = useUser()
-  const [invitedCount, setInvitedCount] = useState({})
-  const [isLoading, setIsLoading] = useState(false)
-  const reviewersInvitedId = reviewersId ? `${reviewersId}/Invited` : null
-  const areaChairsInvitedId = areaChairsId ? `${areaChairsId}/Invited` : null
-  const seniorAreaChairsInvitedId = seniorAreaChairsId ? `${seniorAreaChairsId}/Invited` : null
+
   const singularReviewerName = getSingularRoleName(reviewerName)
   const singularAreaChairName = getSingularRoleName(areaChairName)
   const singularSeniorAreaChairName = getSingularRoleName(seniorAreaChairName)
 
-  const loadData = async () => {
-    setIsLoading(true)
-    try {
-      const result = await Promise.all(
-        [reviewersInvitedId, areaChairsInvitedId, seniorAreaChairsInvitedId].map(
-          (invitedId) =>
-            invitedId
-              ? api.getGroupById(invitedId, accessToken, { select: 'members' })
-              : Promise.resolve(null)
-        )
-      )
-      setInvitedCount({
-        reviewersInvitedCount: result[0]?.members?.length ?? 0,
-        areaChairsInvitedCount: result[1]?.members?.length ?? 0,
-        seniorAreaChairsInvitedCount: result[2]?.members?.length ?? 0,
-      })
-    } catch (error) {
-      promptError(error.message)
-    }
-    setIsLoading(false)
-  }
-
-  useEffect(() => {
-    if (!reviewersId) return
-    loadData()
-  }, [])
+  const { reviewersInvitedCount, areaChairsInvitedCount, seniorAreaChairsInvitedCount } =
+    pcConsoleData
 
   return (
     <>
@@ -88,8 +58,8 @@ const RecruitmentStatsRow = ({ pcConsoleData }) => {
           title={`${prettyField(singularReviewerName)} Recruitment`}
           hint="accepted / invited"
           value={
-            !isLoading && pcConsoleData.reviewers ? (
-              `${pcConsoleData.reviewers?.length} / ${invitedCount.reviewersInvitedCount}`
+            pcConsoleData.reviewers ? (
+              `${pcConsoleData.reviewers?.length} / ${reviewersInvitedCount}`
             ) : (
               <LoadingSpinner inline={true} text={null} />
             )
@@ -100,8 +70,8 @@ const RecruitmentStatsRow = ({ pcConsoleData }) => {
             title={`${prettyField(singularAreaChairName)} Recruitment`}
             hint="accepted / invited"
             value={
-              !isLoading && pcConsoleData.areaChairs ? (
-                `${pcConsoleData.areaChairs?.length} / ${invitedCount.areaChairsInvitedCount}`
+              pcConsoleData.areaChairs ? (
+                `${pcConsoleData.areaChairs?.length} / ${areaChairsInvitedCount}`
               ) : (
                 <LoadingSpinner inline={true} text={null} />
               )
@@ -113,8 +83,8 @@ const RecruitmentStatsRow = ({ pcConsoleData }) => {
             title={`${prettyField(singularSeniorAreaChairName)} Recruitment`}
             hint="accepted / invited"
             value={
-              !isLoading && pcConsoleData.seniorAreaChairs ? (
-                `${pcConsoleData.seniorAreaChairs?.length} / ${invitedCount.seniorAreaChairsInvitedCount}`
+              pcConsoleData.seniorAreaChairs ? (
+                `${pcConsoleData.seniorAreaChairs?.length} / ${seniorAreaChairsInvitedCount}`
               ) : (
                 <LoadingSpinner inline={true} text={null} />
               )


### PR DESCRIPTION
this pr should move calls to get invited groups to pc console main data loading
so that it can be cached

user may need to reload data if having old cache which does not include invited count