### PR TITLE
Fix/ PC Console - Conditionally delete replies from note details based on cache usage

### DIFF
--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -686,7 +686,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
         // eslint-disable-next-line no-param-reassign
         note.replyCount = replies.length
         // eslint-disable-next-line no-param-reassign
-        delete note.details?.replies
+        if (useCache) delete note.details?.replies
       })
 
       const consoleData = {


### PR DESCRIPTION
so that the cache size can be reduced
while keeping the function of ARR

this pr is based on the assumption that ARR pc console does not enable cache