### PR TITLE
Fix/ DBLP import existing notes typo

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -463,7 +463,7 @@ export async function getAllPapersByGroupId(profileId, accessToken) {
       )
       .then((notes) =>
         notes.map((note) => ({
-          id: notes.id,
+          id: note.id,
           title: titleNameTransformation(note.content.title?.value),
           authorCount: note.content.authors?.value.length,
           venue: note.content.venue.value,


### PR DESCRIPTION
fix typo in id of existing notes loaded
so that imported papers can't be imported again