### PR TITLE
Fix/ Invitation Editor (Invitation with invitation) - update cdate display

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -463,7 +463,7 @@ export async function getAllPapersByGroupId(profileId, accessToken) {
       )
       .then((notes) =>
         notes.map((note) => ({
-          id: notes.id,
+          id: note.id,
           title: titleNameTransformation(note.content.title?.value),
           authorCount: note.content.authors?.value.length,
           venue: note.content.venue.value,


### PR DESCRIPTION
currently the meta info text is fixed to be 
created: cdate

while tcdate should be "creation date" y cdate should be "activation date"

this pr should change creation date to show tcdate and activation date to show cdate
based on whether cdate has passed