### PR TITLE
Fix/ ErrorDisplay in non-page component

### DIFF
--- a/components/ErrorDisplay.js
+++ b/components/ErrorDisplay.js
@@ -4,7 +4,7 @@
 import CommonLayout from '../app/CommonLayout'
 import api from '../lib/api-client'
 
-const ErrorDisplay = ({ statusCode, message }) => {
+const ErrorDisplay = ({ statusCode, message, withLayout = true }) => {
   const handleLogout = async () => {
     try {
       await api.post('/logout')
@@ -20,6 +20,21 @@ const ErrorDisplay = ({ statusCode, message }) => {
       })
       promptError(error.message)
     }
+  }
+
+  if (withLayout === false) {
+    return (
+      <div className="row error-display">
+        <header className="col-xs-12 col-md-10 col-md-offset-1 text-center">
+          <h1>Error</h1>
+          <hr />
+        </header>
+
+        <div className="col-xs-12 col-md-10 col-md-offset-1 text-center">
+          <pre className="error-message">{message}</pre>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/components/webfield/AreaChairConsole.js
+++ b/components/webfield/AreaChairConsole.js
@@ -926,7 +926,7 @@ const AreaChairConsole = ({ appContext }) => {
     const errorMessage = `${
       areaChairName ? `${prettyField(areaChairName)} ` : ''
     }Console is missing required properties: ${missingConfig.join(', ')}`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   return (

--- a/components/webfield/AuthorConsole.js
+++ b/components/webfield/AuthorConsole.js
@@ -692,7 +692,7 @@ const AuthorConsole = ({ appContext }) => {
     const errorMessage = `Author Console is missing required properties: ${
       missingConfig.length ? missingConfig.map((p) => p[0]).join(', ') : 'blindSubmissionId'
     }`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   return (

--- a/components/webfield/BidConsole.js
+++ b/components/webfield/BidConsole.js
@@ -812,7 +812,7 @@ const BidConsole = ({ appContext }) => {
     const errorMessage = `Bidding Console is missing required properties: ${missingConfig
       .map((p) => p[0])
       .join(', ')}`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   return (

--- a/components/webfield/EthicsChairConsole.js
+++ b/components/webfield/EthicsChairConsole.js
@@ -57,7 +57,7 @@ const EthicsChairConsole = ({ appContext }) => {
     const errorMessage = `Ethics Chair Console is missing required properties: ${missingConfig.join(
       ', '
     )}`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   return (

--- a/components/webfield/ProfileBidConsole.js
+++ b/components/webfield/ProfileBidConsole.js
@@ -501,7 +501,7 @@ const ProfileBidConsole = ({ appContext }) => {
     const errorMessage = `Bidding Console is missing required properties: ${missingConfig
       .map((p) => p[0])
       .join(', ')}`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   return (

--- a/components/webfield/ProgramChairConsole.js
+++ b/components/webfield/ProgramChairConsole.js
@@ -1315,7 +1315,7 @@ const ProgramChairConsole = ({ appContext, extraTabs = [] }) => {
     const errorMessage = `PC Console is missing required properties: ${
       missingConfig.length ? missingConfig.join(', ') : 'submissionVenueId'
     }`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   return (

--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -818,7 +818,7 @@ const ReviewerConsole = ({ appContext }) => {
     const errorMessage = `${
       reviewerName ? `${prettyId(reviewerName)} ` : ''
     }Console is missing required properties: ${missingConfig.map((p) => p[0]).join(', ')}`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
   return (
     <>

--- a/components/webfield/SeniorAreaChairConsole.js
+++ b/components/webfield/SeniorAreaChairConsole.js
@@ -727,7 +727,7 @@ const SeniorAreaChairConsole = ({ appContext }) => {
     const errorMessage = `${prettyField(
       seniorAreaChairName
     )} Console is missing required properties: ${missingConfig.join(', ')}`
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   return (

--- a/components/webfield/VenueHomepage.js
+++ b/components/webfield/VenueHomepage.js
@@ -267,7 +267,7 @@ export default function VenueHomepage({ appContext }) {
 
   if (!header || !tabs) {
     const errorMessage = 'Venue Homepage requires both header and tabs properties to be set'
-    return <ErrorDisplay statusCode="" message={errorMessage} />
+    return <ErrorDisplay statusCode="" message={errorMessage} withLayout={false} />
   }
 
   if (isRefreshing) return <LoadingSpinner />


### PR DESCRIPTION
this pr should add a property 
withLayout
to ErrorDisplay component with default value set to true

this property controls whether to render <CommonLayout> in error display

it's correct for error display to render common layout for page level components
but it will be wrong for non-page level components such as consoles because group page already have layout