### PR TITLE
Fix/ Textbox cursor jumping when typing fast

### DIFF
--- a/components/EditorComponents/TextboxWidget.js
+++ b/components/EditorComponents/TextboxWidget.js
@@ -58,10 +58,6 @@ const TextboxWidget = () => {
   }, [displayValue])
 
   useEffect(() => {
-    setDisplayValue(initialValue)
-  }, [initialValue])
-
-  useEffect(() => {
     if (!isNil(value)) return
 
     let savedText


### PR DESCRIPTION
the code being removed was added in 
https://github.com/openreview/openreview-web/pull/1952/commits/6eb1b59fedccc4920db246ac8ada0c03f0130036#diff-84dd276a2477688d104491f2a2452446bf993556bccb816cad56f229e08ba43f

for json editor. exact purpose is not clear but implementation of json editor has been updated so i don't think it's necessary to keep it.

It's causing the textbox to update state too fast and break react rendering when user type fast enough in textbox.