### PR TITLE
Fix/ Forum - noindex meta tag for v2 DBLP

### DIFF
--- a/app/forum/page.js
+++ b/app/forum/page.js
@@ -160,8 +160,7 @@ export async function generateMetadata({ searchParams }) {
     if (
       noteInvitation.startsWith(process.env.SUPER_USER) ||
       noteInvitation.startsWith('dblp.org') ||
-      noteInvitation.startsWith('DBLP.org') ||
-      noteInvitation.startsWith(`${process.env.SUPER_USER}/Public_Article`)
+      noteInvitation.startsWith('DBLP.org')
     ) {
       metaData.other.robots = 'noindex'
     } else {


### PR DESCRIPTION
currently forum page does not add meta tags for v1 dblp papers (so that google scholar does not crawl them?)

the same logic should be applied to 
v2 dblp papers
~~dblp papers using new invitation (not implemented yet)~~
~~orcid papers~~
~~arxiv(doi) papers~~
above three the invitation su//Public_Article/{type}/-/Record is already handled