### PR TITLE
Fix/ ORCID import - post authorids in initial edit

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -804,54 +804,31 @@ export async function postOrUpdateOrcidPaper(
     )
   }
   // new paper
-  return api
-    .post(
-      '/notes/edits',
-      {
-        invitation: `${process.env.SUPER_USER}/Public_Article/ORCID.org/-/Record`,
-        signatures: [profileId],
-        content: {
-          json: {
-            value: publication.json,
-          },
-        },
-        note: {
-          content: {
-            title: { value: publication.title },
-            authors: { value: publication.authorNames },
-            authorids: { value: new Array(publication.authorNames.length).fill('') },
-            venue: { value: publication.venue },
-          },
-          externalId: publication.externalId,
+  const authorIds = Array(publication.authorNames.length).fill('')
+  authorIds[publication.authorIndex] =
+    profileNames?.find((p) => publication.authorNames?.includes(getNameString(p)))?.username ??
+    profileId
+
+  return api.post(
+    '/notes/edits',
+    {
+      invitation: `${process.env.SUPER_USER}/Public_Article/ORCID.org/-/Record`,
+      signatures: [profileId],
+      content: {
+        json: {
+          value: publication.json,
         },
       },
-      { accessToken }
-    )
-    .then(
-      (
-        edit // without this getAllOrcidPapers will not return the new paper immediately
-      ) =>
-        api.post(
-          '/notes/edits',
-          {
-            invitation: `${process.env.SUPER_USER}/Public_Article/-/Authorship_Claim`,
-            signatures: [profileId],
-            note: {
-              id: edit.note.id,
-            },
-            content: {
-              author_index: {
-                value: publication.authorIndex,
-              },
-              author_id: {
-                value:
-                  profileNames?.find((p) =>
-                    publication.authorNames?.includes(getNameString(p))
-                  )?.username ?? profileId,
-              },
-            },
-          },
-          { accessToken }
-        )
-    )
+      note: {
+        content: {
+          title: { value: publication.title },
+          authors: { value: publication.authorNames },
+          authorids: { value: authorIds },
+          venue: { value: publication.venue },
+        },
+        externalId: publication.externalId,
+      },
+    },
+    { accessToken }
+  )
 }


### PR DESCRIPTION
current process of orcid (new record) import is
1. post record with empty authorids
2. post authorship claim with profile id in authorids
3. record process function runs

it't possible that 3 runs before 2 then 3 populate authorids with search links instead of user's profile id (overwrite authorids posted in 2)

this pr should change 1 to post authorids and remove 2