### PR TITLE
Fix/ Edge browser: support items to get the signatures of an edge

### DIFF
--- a/lib/edge-utils.js
+++ b/lib/edge-utils.js
@@ -436,7 +436,7 @@ export function getInterpolatedValues({
   return value
 }
 
-export function getInterpretedSignaturePrefix(value, paperNumber) {
+export function getInterpretedSignature(value, paperNumber) {
   const headPattern = /\${{\d+\/head}\/number}/g
   return value.replace(headPattern, paperNumber)
 }
@@ -488,13 +488,14 @@ export async function getSignatures(
   if (editInvitation.signatures.items) {
     const getGroupsP = editInvitation.signatures.items.map((p) => {
       if (p.prefix) {
-        const interpretedPrefix = getInterpretedSignaturePrefix(p.prefix, paperNumberToLookup)
+        const interpretedPrefix = getInterpretedSignature(p.prefix, paperNumberToLookup)
         return api
           .get('/groups', { prefix: interpretedPrefix, signatory: user?.id }, { accessToken })
           .then((result) => result.groups.map((q) => q.id))
       }
+      const interpretedValue = getInterpretedSignature(p.value, paperNumberToLookup)
       return api
-        .get('/groups', { id: p.value, signatory: user?.id }, { accessToken })
+        .get('/groups', { id: interpretedValue, signatory: user?.id }, { accessToken })
         .then((result) => result.groups.map((q) => q.id))
     })
     const signatureResults = (await Promise.all(getGroupsP)).flat()


### PR DESCRIPTION
support of items signature was added in #2338 

paper number is only replaced for prefix definition
this pr should replace for value definition too
