### PR TITLE
Fix/ OtherVersions -  Add privately revealed icon to other versions link

### DIFF
--- a/components/forum/OtherVersions.js
+++ b/components/forum/OtherVersions.js
@@ -5,6 +5,7 @@ import dayjs from 'dayjs'
 import useUser from '../../hooks/useUser'
 import api from '../../lib/api-client'
 import { inflect } from '../../lib/utils'
+import Icon from '../Icon'
 
 const OtherVersions = ({ note }) => {
   const { accessToken, isRefreshing } = useUser()
@@ -22,7 +23,13 @@ const OtherVersions = ({ note }) => {
       )
 
       const otherNoteVersions = orderBy(
-        result.notes.filter((p) => p.content?.venue?.value),
+        result.notes.flatMap((p) => {
+          if (!p.content?.venue?.value) return []
+          return {
+            ...p,
+            privatelyRevealed: !note.readers.includes('everyone'),
+          }
+        }),
         [(p) => p.pdate ?? p.cdate],
         'desc'
       )
@@ -69,6 +76,13 @@ const OtherVersions = ({ note }) => {
               className={otherVersionNote.id === note.id ? 'disabled' : undefined}
             >
               <a href={`/forum?id=${otherVersionNote.id}`}>
+                {otherVersionNote.privatelyRevealed && (
+                  <Icon
+                    name="eye-close"
+                    extraClasses="mr-2"
+                    tooltip="Privately revealed to you"
+                  />
+                )}
                 {otherVersionNote.content.venue.value} (
                 {dayjs(otherVersionNote.pdate ?? otherVersionNote.cdate).format('LL')})
               </a>


### PR DESCRIPTION
this pr should add privately revealed icon to other version link when the note is not public

the purpose is to indicate the note is visible to the user not public