### PR TITLE
Fix/ OtherVersions - Update icon for privately revealed versions

### DIFF
--- a/components/forum/OtherVersions.js
+++ b/components/forum/OtherVersions.js
@@ -76,15 +76,15 @@ const OtherVersions = ({ note }) => {
               className={otherVersionNote.id === note.id ? 'disabled' : undefined}
             >
               <a href={`/forum?id=${otherVersionNote.id}`}>
+                {otherVersionNote.content.venue.value} (
+                {dayjs(otherVersionNote.pdate ?? otherVersionNote.cdate).format('LL')})
                 {otherVersionNote.privatelyRevealed && (
                   <Icon
-                    name="eye-close"
-                    extraClasses="mr-2"
+                    name="eye-open"
+                    extraClasses="ml-2"
                     tooltip="Privately revealed to you"
                   />
                 )}
-                {otherVersionNote.content.venue.value} (
-                {dayjs(otherVersionNote.pdate ?? otherVersionNote.cdate).format('LL')})
               </a>
             </li>
           ))}

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -4,7 +4,6 @@
 import { nanoid } from 'nanoid'
 import _ from 'lodash'
 import dayjs from 'dayjs'
-import Image from 'next/image'
 import api from './api-client'
 import { deburrString, getNameString } from './utils'
 
@@ -848,7 +847,7 @@ export function getImportSourceIcon(invitation) {
     case 'DBLP.org/-/Record':
     case `${process.env.SUPER_USER}/Public_Article/DBLP.org/-/Record`:
       return (
-        <Image
+        <img
           src="/images/dblp.svg"
           alt="DBLP"
           width={16}
@@ -858,7 +857,7 @@ export function getImportSourceIcon(invitation) {
       )
     case `${process.env.SUPER_USER}/Public_Article/ORCID.org/-/Record`:
       return (
-        <Image
+        <img
           src="/images/orcid.png"
           alt="ORCID"
           width={16}
@@ -868,7 +867,7 @@ export function getImportSourceIcon(invitation) {
       )
     case `${process.env.SUPER_USER}/Public_Article/arXiv.org/-/Record`:
       return (
-        <Image
+        <img
           src="/images/arxiv.png"
           alt="arXiv"
           width={16}


### PR DESCRIPTION
this pr should:
- use eye open icon in other versions dropdown to indicate this paper is NOT public
- move icon to end of dropdown option
- change source logo to plain img instead of next.js Image 