### PR TITLE
Fix/ Refactor ProfileTags component placement

### DIFF
--- a/app/profile/Profile.js
+++ b/app/profile/Profile.js
@@ -94,13 +94,13 @@ export default async function Profile({ profile, publicProfile, remoteIpAddress 
       <div className="row equal-height-cols">
         <div className="col-md-12 col-lg-8">
           <BasicProfileView profile={profile} publicProfile={publicProfile} />
-        </div>
-        <div className="col-lg-8 hidden-xs hidden-sm hidden-md">
-          <ProfileTags
-            profileId={profile.id}
-            showProfileId={false}
-            isSuperUser={isSuperUser(user)}
-          />
+          <div className="hidden-xs hidden-sm hidden-md">
+            <ProfileTags
+              profileId={profile.id}
+              showProfileId={false}
+              isSuperUser={isSuperUser(user)}
+            />
+          </div>
         </div>
 
         <aside className="col-md-12 col-lg-4">


### PR DESCRIPTION
the tags takes space even when it's hidden, causing publications and coauthor to move the next row

this pr should fix this by removing col-lg-8 and move tags(desktop view) inside basic profile view column