### PR TITLE
Fix/ Tasks page - Update API error handling

### DIFF
--- a/app/tasks/page.js
+++ b/app/tasks/page.js
@@ -142,9 +142,10 @@ export default function Page() {
         )
         .then((result) => result.invitations),
     ]
-    const domainResult = await Promise.all(invitationPromises).catch((apiError) =>
+    const domainResult = await Promise.all(invitationPromises).catch((apiError) => {
       setError(apiError)
-    )
+      return []
+    })
 
     const uniqueDomainsTypeMap = new Map()
     const processDomainResults = (invitations, type) => {


### PR DESCRIPTION
Currently tasks page stuck at loading state when code fails between api call and set domainTypeMap

it can happen when api call timeout for some users

this pr should fix by returning an empty array when api call fail so that code processing the api call result does not fail
