### PR TITLE
Fix/ Server render fullmarkdown

### DIFF
--- a/components/NoteContent.js
+++ b/components/NoteContent.js
@@ -120,7 +120,7 @@ export function NoteContentValue({ content = '', enableMarkdown, className, full
     }
   }, [enableMarkdown, content, fullMarkdown])
 
-  if (enableMarkdown && fullMarkdown) {
+  if (fullMarkdown) {
     const html = marked(content, { renderer: new marked.Renderer() })
 
     return (

--- a/unitTests/NoteContent.test.js
+++ b/unitTests/NoteContent.test.js
@@ -136,20 +136,20 @@ describe('NoteContentV2', () => {
       },
       number: 1,
       presentation: [
-        { name: 'title', order: 1, type: 'string' },
+        { name: 'title', order: 1, type: 'string' }, // will be rendered as markdown too
         { name: 'post', order: 2, type: 'string', input: 'textarea', markdown: true },
       ],
       fullMarkdown: true,
     }
 
     render(<NoteContentV2 {...props} />)
-    expect(screen.getByText('local markdown output')).toBeInTheDocument() // call local imported version of marked for server rendering
+    expect(screen.getAllByText('local markdown output').length).toBe(2) // call local imported version of marked for server rendering
     expect(marked).toHaveBeenCalledWith(
       blogContent,
       expect.objectContaining({ renderer: expect.any(Object) })
     )
 
-    expect(marked.Renderer).toHaveBeenCalledTimes(1)
+    expect(marked.Renderer).toHaveBeenCalledTimes(2)
   })
 
   test('render valid external id as links', () => {


### PR DESCRIPTION
related to #2524 

intended function of 2524 was broken by commit to fix test [1fa0515](https://github.com/openreview/openreview-web/pull/2524/commits/1fa0515cc0864cdad9d9f1b69267a34eb9485dbd)
this pr should fix it by removing enableMarkdown checking which will be undefined on initial render