### PR TITLE
Fix/ Donate - handle multiple max error

### DIFF
--- a/app/donate/page.js
+++ b/app/donate/page.js
@@ -63,6 +63,7 @@ const donationReducer = (state, action) => {
         disableDonateButton: false,
         donateButtonText: `Make a Donation of $${cleanValue.toFixed(2)}${state.mode === 'subscription' ? ' /month' : ''} through Stripe`,
         requireIRSReceipt: cleanValue >= 250 ? true : state.requireIRSReceipt,
+        maxAmountError: null,
       }
     }
     case 'TOGGLE_IRS_RECEIPT':


### PR DESCRIPTION
this pr should reset max amount error when user enter custom amount

this happens when
1. user enter >max amount
2. user close message or user wait for 8 seconds
3. user enter >max amount again
4. max amount message is **not** shown

effect of this pr is that if the user keeps entering >max amount it's possible that 2 same messages are shown