### PR TITLE
Fix/ Reviewer Console - support review policy

### DIFF
--- a/components/webfield/ReviewerConsole.js
+++ b/components/webfield/ReviewerConsole.js
@@ -660,7 +660,7 @@ const ReviewerConsole = ({ appContext }) => {
     // #region get reviewer edges
     const getReviewerEdgesP = edgeInvitationIds.length
       ? Promise.all(
-          edgeInvitationIds.map((invitationId) =>
+          edgeInvitationIds.flatMap((invitationId) =>
             api
               .get(
                 '/edges',
@@ -672,13 +672,14 @@ const ReviewerConsole = ({ appContext }) => {
                 { accessToken }
               )
               .then((result) => {
+                if (!result.edges?.length) return []
                 const displayName = prettyInvitationId(invitationId)
                 const displayValue = result.edges
-                  ?.map((p) => {
+                  .map((p) => {
                     if ('label' in p) return p.label
                     return p.weight
                   })
-                  ?.join(', ')
+                  .join(', ')
                 return [{ displayName, displayValue }]
               })
           )
@@ -879,11 +880,13 @@ const ReviewerConsole = ({ appContext }) => {
         options={{
           extra: reviewerConsoleData.reviewerEdges?.length ? (
             <>
-              {reviewerConsoleData.reviewerEdges.map(({ displayName, displayValue }) => (
-                <p key={displayName} className="dark">
-                  {displayName}: <strong>{displayValue}</strong>
-                </p>
-              ))}
+              {reviewerConsoleData.reviewerEdges.map(
+                ({ displayName, displayValue }, index) => (
+                  <p key={`${displayName}${index}`} className="dark">
+                    {displayName}: <strong>{displayValue}</strong>
+                  </p>
+                )
+              )}
             </>
           ) : undefined,
         }}

--- a/unitTests/ReviewerConsole.test.js
+++ b/unitTests/ReviewerConsole.test.js
@@ -182,7 +182,7 @@ describe('ReviewerConsole', () => {
     ).toBeInTheDocument()
   })
 
-  test('show review policy when specified', async () => {
+  test('show review policy when specified in edgeInvitationIds', async () => {
     api.getAll = jest.fn(() => Promise.resolve([]))
     api.get = jest.fn((path, param) => {
       switch (path) {
@@ -208,6 +208,11 @@ describe('ReviewerConsole', () => {
                 { label: 'Track Three' },
               ],
             })
+          } else if (
+            param.invitation ===
+            'AAAI.org/2025/Conference/Program_Committee/-/Review_Preference'
+          ) {
+            return Promise.resolve([])
           }
 
           return Promise.resolve({ edges: [] })
@@ -243,6 +248,7 @@ describe('ReviewerConsole', () => {
           'AAAI.org/2025/Conference/Program_Committee/-/Review_Policy',
           'AAAI.org/2025/Conference/Program_Committee/-/Review_Status',
           'AAAI.org/2025/Conference/Program_Committee/-/Review_Track',
+          'AAAI.org/2025/Conference/Program_Committee/-/Review_Preference', // no edges returned
         ],
         reviewLoad: '',
         hasPaperRanking: false,
@@ -261,6 +267,7 @@ describe('ReviewerConsole', () => {
       expect(screen.getByText('Review Status:')).toBeInTheDocument()
       expect(screen.getByText('Review Status:').lastChild.textContent).toBe('0')
       expect(screen.getByText('Track One, Track Two, Track Three')).toBeInTheDocument()
+      expect(screen.queryByText('Preferences:')).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
this pr should add a new config edgeInvitationIds to reviewer console
and use the invitation ids defined in it to load edges and display the label/weight in header

this pr should also update loading of  custom max papers edges to use profile.id