### PR TITLE
Fix/ Workflow invitations prefix

### DIFF
--- a/components/group/WorkflowInvitations.js
+++ b/components/group/WorkflowInvitations.js
@@ -968,7 +968,7 @@ const WorkFlowInvitations = ({ group }) => {
       .then((result) => result.groups)
 
     const getAllInvitationsP = await api.getAll('/invitations', {
-      prefix: groupId,
+      prefix: `${groupId}/`,
       expired: true,
       trash: true,
       type: 'all',


### PR DESCRIPTION
this pr should add / to the prefix param in get all invtitaitons
so that it does not get invitations of a venue where the id contains the group id the user is viewing