### PR TITLE
Fix/ Author activation status - Show more status

### DIFF
--- a/components/webfield/NoteSummary.js
+++ b/components/webfield/NoteSummary.js
@@ -52,7 +52,7 @@ const NoteSummary = ({
       return (
         <Icon
           name="minus-sign"
-          tooltip="Profile is not available"
+          tooltip="Profile status is not available"
           extraClasses="pl-1 text-default"
         />
       )

--- a/unitTests/NoteSummary.test.js
+++ b/unitTests/NoteSummary.test.js
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import NoteSummary from '../components/webfield/NoteSummary'
+
+jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
+
+describe('NoteSummary', () => {
+  test('show author status correctly', () => {
+    const props = {
+      isV2Note: true,
+      note: {
+        content: {
+          authors: {
+            value: ['Email Author', 'Active Author', 'Blocked Author', 'Inactive Author'],
+          },
+          authorids: {
+            value: [
+              'test@email.com',
+              '~Active_Author1',
+              '~Blocked_Author1',
+              '~Inactive_Author1',
+            ],
+          },
+        },
+      },
+      profileMap: {
+        '~Active_Author1': { active: true },
+        '~Inactive_Author1': { active: false },
+      },
+    }
+    render(<NoteSummary {...props} />)
+
+    expect(screen.getByText('Email Author').nextSibling).toHaveClass('glyphicon-question-sign')
+    expect(screen.getByText('Email Author').nextSibling).toHaveAttribute(
+      'title',
+      'Profile status is unknown'
+    )
+
+    screen.debug()
+    expect(screen.getByText('Active Author').nextSibling).toHaveClass('glyphicon-ok-sign')
+    expect(screen.getByText('Active Author').nextSibling).toHaveAttribute(
+      'title',
+      'Profile is active'
+    )
+
+    expect(screen.getByText('Blocked Author').nextSibling).toHaveClass('glyphicon-minus-sign')
+    expect(screen.getByText('Blocked Author').nextSibling).toHaveAttribute(
+      'title',
+      'Profile status is not available'
+    )
+
+    expect(screen.getByText('Inactive Author').nextSibling).toHaveClass(
+      'glyphicon-remove-sign'
+    )
+    expect(screen.getByText('Inactive Author').nextSibling).toHaveAttribute(
+      'title',
+      'Profile is not yet activated'
+    )
+  })
+})


### PR DESCRIPTION
email author won't be validated so this pr should update the activation status to provide more info
based on 
 - author id is tilde id or email
 - whether author has a profile
 - whether the profile is activated

and the following can happen

1. is email - won't validate
2. is tilde id but can't get any profile - profile is removed
3. is tilde id and can get profile but profile is not active - profile is inactive or rejected or pending moderation
4. profile is active 