### PR TITLE
Add BUILD_ID to deployment.conf in production deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,10 +45,6 @@ jobs:
           skip_install: true
       - name: Run deploy script
         run: |
-          gsutil cp gs://openreview-general/conf/deployment.conf ./deployment.conf
-          sed -i "s/WEB_TAG=.*/WEB_TAG=\"$TAG\"/" ./deployment.conf
-          gsutil cp ./deployment.conf gs://openreview-general/conf/deployment.conf
-
           cd $GITHUB_WORKSPACE
           gsutil cp gs://openreview-general/conf/production.env $GITHUB_WORKSPACE/.env.local
           config_hash="$(sha1sum $GITHUB_WORKSPACE/.env.local | cut -d " " -f 1)"
@@ -72,6 +68,12 @@ jobs:
             gsutil cp "/tmp/${build_id}.tar.gz" "gs://openreview-general/openreview-web-builds/${build_id}.tar.gz"
             curl -s "https://cowsay.morecode.org/say?message=MOO%21%20YOU%20CREATED%20A%20BUILD%20SUCCESSFULLY&format=text"
           fi
+
+          gsutil cp gs://openreview-general/conf/deployment.conf ./deployment.conf
+          sed -i "s/WEB_TAG=.*/WEB_TAG=\"$TAG\"/" ./deployment.conf
+          sed -i '/^BUILD_ID=/d' ./deployment.conf
+          echo "BUILD_ID=\"$build_id\"" >> ./deployment.conf
+          gsutil cp ./deployment.conf gs://openreview-general/conf/deployment.conf
 
           instance_prefix='openreview-web-'
 


### PR DESCRIPTION
Move deployment.conf update to after the build/check block so BUILD_ID is only written once the tarball is confirmed in GCS. Add BUILD_ID alongside WEB_TAG using delete-then-append to handle both first deploy and subsequent updates.

This is so that the startup script uses the build_id created by github actions instead of having to clone the openreview-web repo in the instance