### PR TITLE
Fix/ Add captcha to file upload widget and note editor

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,6 +17,14 @@
     "no-var": "warn",
     "prefer-destructuring": ["warn", { "object": true, "array": false }],
     "react/rules-of-hooks": "error",
-    "react/self-closing-comp": "error"
+    "react/self-closing-comp": "error",
+    "no-undef": "warn"
+  },
+  "globals": {
+    "promptMessage": "readonly",
+    "promptError": "readonly",
+    "promptLogin": "readonly",
+    "promptRefresh": "readonly",
+    "clearMessage": "readonly"
   }
 }

--- a/ThemeProvider.js
+++ b/ThemeProvider.js
@@ -70,6 +70,9 @@ const theme = {
       colorInfoBg: backgroundGray,
       colorText: subtleGray,
     },
+    Descriptions: {
+      paddingXs: 4,
+    },
     Notification: {
       colorErrorBg: '#f2dede',
       colorSuccessBg: '#dff0d8',

--- a/components/EditorComponents/FileUploadWidget.js
+++ b/components/EditorComponents/FileUploadWidget.js
@@ -1,13 +1,11 @@
-/* globals promptError: false */
-
-import { useContext, useRef, useState } from 'react'
 import { nanoid } from 'nanoid'
-import EditorComponentContext from '../EditorComponentContext'
-import SpinnerButton from '../SpinnerButton'
-import { TrashButton } from '../IconButton'
-import useUser from '../../hooks/useUser'
+import { useContext, useEffect, useRef, useState } from 'react'
+import useTurnstileToken from '../../hooks/useTurnstileToken'
 import api from '../../lib/api-client'
 import { prettyField } from '../../lib/utils'
+import EditorComponentContext from '../EditorComponentContext'
+import { TrashButton } from '../IconButton'
+import SpinnerButton from '../SpinnerButton'
 
 import styles from '../../styles/components/FileUploadWidget.module.scss'
 
@@ -17,53 +15,52 @@ const FileUploadWidget = () => {
   const fileInputRef = useRef(null)
   const [isLoading, setIsLoading] = useState(false)
   const [uploadPercentage, setUploadPercentage] = useState(2)
+  const [hasHumanVerificationError, setHasHumanVerificationError] = useState(false)
+  const { turnstileToken, turnstileContainerRef } = useTurnstileToken(
+    'fileUpload',
+    hasHumanVerificationError
+  )
+
+  const pendingFileRef = useRef(null)
 
   const fieldName = Object.keys(field)[0]
   const [fileName, setFileName] = useState(prettyField(fieldName))
   const maxSize = field[fieldName].value?.param?.maxSize
   const extensions = field[fieldName].value?.param?.extensions?.map((p) => `.${p}`)
 
-  const uploadSingleFileChunk = async (chunk, index, chunkCount, clientUploadId) => {
-    try {
-      const data = new FormData()
-      data.append('invitationId', invitation.id)
-      data.append('name', fieldName)
-      data.append('chunkIndex', index + 1)
-      data.append('totalChunks', chunkCount)
-      data.append('clientUploadId', clientUploadId)
-      data.append('file', chunk)
+  const uploadSingleFileChunk = async (chunk, index, chunkCount, clientUploadId, token) => {
+    const data = new FormData()
+    data.append('invitationId', invitation.id)
+    data.append('name', fieldName)
+    data.append('chunkIndex', index + 1)
+    data.append('totalChunks', chunkCount)
+    data.append('clientUploadId', clientUploadId)
+    data.append('file', chunk)
 
-      const result = noteEditorPreview
-        ? await Promise.resolve({ url: 'preview url' })
-        : await api.put('/attachment/chunk', data, {
-            contentType: 'unset',
-          })
-      if (result.url) {
-        // upload is completed
-        onChange({ fieldName, value: result.url })
-        clearError?.()
-        setUploadPercentage(2)
-      } else {
-        setUploadPercentage(
-          (
-            (Object.values(result).filter((p) => p === 'completed').length * 100) /
-            Object.values(result).length
-          ).toFixed(0)
-        )
-      }
-    } catch (apiError) {
-      promptError(apiError.message)
-      fileInputRef.current.value = ''
+    const result = noteEditorPreview
+      ? await Promise.resolve({ url: 'preview url' })
+      : await api.put('/attachment/chunk', data, {
+          contentType: 'unset',
+          'cf-turnstile-token': token,
+        })
+    if (result.url) {
+      // upload is completed
+      onChange({ fieldName, value: result.url })
+      clearError?.()
+      setUploadPercentage(2)
+    } else {
+      setUploadPercentage(
+        (
+          (Object.values(result).filter((p) => p === 'completed').length * 100) /
+          Object.values(result).length
+        ).toFixed(0)
+      )
     }
   }
 
-  const handleFileSelected = async (e) => {
+  const uploadFile = async (file, token) => {
+    setIsLoading(true)
     try {
-      const file = e.target.files[0]
-      if (!file) return
-      if (maxSize && file.size > 1024 * 1000 * maxSize)
-        throw new Error(`File is too large. File size limit is ${maxSize} mb`)
-      setIsLoading(true)
       const chunkSize = 1024 * 1000 * 5 // 5mb
       const chunkCount = Math.ceil(file.size / chunkSize)
       const clientUploadId = nanoid()
@@ -79,23 +76,49 @@ const FileUploadWidget = () => {
       const sendChunksPromises = chunks.reduce(
         (oldPromises, currentChunk, i) =>
           oldPromises.then(() =>
-            uploadSingleFileChunk(currentChunk, i, chunkCount, clientUploadId)
+            uploadSingleFileChunk(currentChunk, i, chunkCount, clientUploadId, token)
           ),
         Promise.resolve()
       )
       await sendChunksPromises
       setFileName(file.name)
+      pendingFileRef.current = null
     } catch (apiError) {
-      promptError(apiError.message)
-      fileInputRef.current.value = ''
+      if (apiError.name === 'HumanVerificationRequiredError' && !noteEditorPreview) {
+        pendingFileRef.current = file
+        setHasHumanVerificationError(true)
+      } else {
+        promptError(apiError.message)
+        fileInputRef.current.value = ''
+      }
     }
-
     setIsLoading(false)
+  }
+
+  useEffect(() => {
+    if (!(turnstileToken && hasHumanVerificationError && pendingFileRef.current)) return
+
+    setHasHumanVerificationError(false)
+    uploadFile(pendingFileRef.current, turnstileToken)
+
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
+  }, [turnstileToken, hasHumanVerificationError])
+
+  const handleFileSelected = async (e) => {
+    const file = e.target.files[0]
+    if (!file) return
+    if (maxSize && file.size > 1024 * 1000 * maxSize) {
+      promptError(`File is too large. File size limit is ${maxSize} mb`)
+      return
+    }
+    await uploadFile(file, turnstileToken)
   }
 
   const handleDeleteFile = () => {
     onChange({ fieldName, value: undefined })
     fileInputRef.current.value = ''
+    pendingFileRef.current = null
+    setHasHumanVerificationError(false)
   }
 
   return (
@@ -111,7 +134,7 @@ const FileUploadWidget = () => {
         type="primary"
         className={`${styles.selectFileButton} ${error ? styles.invalidValue : ''}`}
         onClick={() => fileInputRef.current?.click()}
-        disabled={isLoading}
+        disabled={isLoading || hasHumanVerificationError}
         loading={isLoading}
       >{`Choose ${prettyField(fieldName)}`}</SpinnerButton>
       {isLoading && (
@@ -125,6 +148,7 @@ const FileUploadWidget = () => {
           />
         </div>
       )}
+      <div ref={turnstileContainerRef} />
       {value && (
         <>
           <span className={styles.fileUrl}>{`${fileName} (${value})`}</span>

--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -1,28 +1,27 @@
-/* globals promptError, promptLogin, view2, clearMessage: false */
-
-import React, { useEffect, useCallback, useReducer, useState, useContext } from 'react'
-import throttle from 'lodash/throttle'
 import { intersection, isEmpty } from 'lodash'
-import EditorComponentContext from './EditorComponentContext'
-import EditorComponentHeader from './EditorComponents/EditorComponentHeader'
-import EditorWidget from './webfield/EditorWidget'
-import SpinnerButton from './SpinnerButton'
-import LoadingSpinner from './LoadingSpinner'
-import Signatures from './Signatures'
-import { NewNoteReaders, NewReplyEditNoteReaders } from './NoteEditorReaders'
-import Icon from './Icon'
+import throttle from 'lodash/throttle'
+import { useEffect, useCallback, useReducer, useState, useContext, useRef } from 'react'
+import useTurnstileToken from '../hooks/useTurnstileToken'
 import useUser from '../hooks/useUser'
 import api from '../lib/api-client'
+import { getNoteContentValues } from '../lib/forum-utils'
 import { getAutoStorageKey, prettyField, prettyInvitationId, classNames } from '../lib/utils'
 import { getErrorFieldName, isNonDeletableError } from '../lib/webfield-utils'
-import { getNoteContentValues } from '../lib/forum-utils'
+import EditorComponentContext from './EditorComponentContext'
+import DatePickerWidget from './EditorComponents/DatePickerWidget'
+import EditorComponentHeader from './EditorComponents/EditorComponentHeader'
+import LicenseWidget from './EditorComponents/LicenseWidget'
+import Markdown from './EditorComponents/Markdown'
+import EditSignatures from './EditSignatures'
+import Icon from './Icon'
+import LoadingSpinner from './LoadingSpinner'
+import { NewNoteReaders, NewReplyEditNoteReaders } from './NoteEditorReaders'
+import Signatures from './Signatures'
+import SpinnerButton from './SpinnerButton'
+import EditorWidget from './webfield/EditorWidget'
+import WebFieldContext from './WebFieldContext'
 
 import styles from '../styles/components/NoteEditor.module.scss'
-import LicenseWidget from './EditorComponents/LicenseWidget'
-import DatePickerWidget from './EditorComponents/DatePickerWidget'
-import EditSignatures from './EditSignatures'
-import Markdown from './EditorComponents/Markdown'
-import WebFieldContext from './WebFieldContext'
 
 const ExistingNoteReaders = NewReplyEditNoteReaders
 
@@ -268,6 +267,11 @@ const NoteEditor = ({
   const [autoStorageKeys, setAutoStorageKeys] = useState([])
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errors, setErrors] = useState([])
+  const [hasHumanVerificationError, setHasHumanVerificationError] = useState(false)
+  const { turnstileToken, turnstileContainerRef } = useTurnstileToken(
+    'noteEditor',
+    hasHumanVerificationError
+  )
   const { noteEditorPreview } = useContext(WebFieldContext) ?? {}
   if (noteEditorPreview)
     customValidator = () => ({
@@ -581,7 +585,9 @@ const NoteEditor = ({
             invitationObj: invitation,
             noteObj: note,
           })
-      const result = await api.post('/notes/edits', editToPost)
+      const result = await api.post('/notes/edits', editToPost, {
+        'cf-turnstile-token': turnstileToken,
+      })
       const createdNote = await getCreatedNote(result.note)
       autoStorageKeys.forEach((key) => localStorage.removeItem(key))
       setNoteEditorData({ type: 'reset' })
@@ -589,6 +595,11 @@ const NoteEditor = ({
       closeNoteEditor()
       onNoteCreated(createdNote)
     } catch (error) {
+      if (error.name === 'HumanVerificationRequiredError' && !noteEditorPreview) {
+        setHasHumanVerificationError(true)
+        setIsSubmitting(false)
+        return
+      }
       if (error.errors) {
         setErrors(
           error.errors.map((p) => {
@@ -796,6 +807,8 @@ const NoteEditor = ({
           />
         </div>
       )}
+
+      <div className={styles.turnstileContainer} ref={turnstileContainerRef} />
 
       {Object.values(loading).some((p) => p) ? (
         <LoadingSpinner inline />

--- a/components/invitation/InvitationGeneral.js
+++ b/components/invitation/InvitationGeneral.js
@@ -1,5 +1,3 @@
-/* globals promptError,promptMessage: false */
-
 import { Descriptions } from 'antd'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
@@ -27,7 +25,10 @@ import { invitation as invitationStyles } from '../../lib/legacy-bootstrap-style
 dayjs.extend(timezone)
 dayjs.extend(utc)
 
-const CodeEditor = dynamic(() => import('../CodeEditor'))
+const CodeEditor = dynamic(() => import('../CodeEditor'), {
+  ssr: false,
+  loading: () => <LoadingSpinner inline text={null} extraClass="spinner-small" />,
+})
 const DatetimePicker = dynamic(() => import('../DatetimePicker'), {
   ssr: false,
   loading: () => <LoadingSpinner inline text={null} extraClass="spinner-small" />,
@@ -589,6 +590,7 @@ const InvitationGeneralEditV2 = ({
   isMetaInvitation,
 }) => {
   const [isSaving, setIsSaving] = useState(false)
+  const isNoteInvitation = invitation.edit?.note
   const generalInfoReducer = (state, action) => {
     switch (action.type) {
       case 'activationDateTimezone':
@@ -634,7 +636,7 @@ const InvitationGeneralEditV2 = ({
     expDateTimezone: getDefaultTimezone()?.value,
     deletionDateTimezone: getDefaultTimezone()?.value,
     signatures: invitation.signatures?.join(', '),
-    ...(invitation.edit?.note && {
+    ...(isNoteInvitation && {
       humanVerificationRequired: invitation.humanVerificationRequired
         ? JSON.stringify(invitation.humanVerificationRequired, null, 2)
         : null,
@@ -970,7 +972,6 @@ export const InvitationGeneralV2 = ({
   isMetaInvitation,
 }) => {
   const [isEditMode, setIsEditMode] = useState(false)
-  const isNoteInvitation = invitation.edit?.note
 
   return (
     <EditorSection title="General Info" className="general">

--- a/components/invitation/InvitationGeneral.js
+++ b/components/invitation/InvitationGeneral.js
@@ -1,14 +1,12 @@
 /* globals promptError,promptMessage: false */
 
-import React, { useReducer, useState } from 'react'
+import { Descriptions } from 'antd'
+import dayjs from 'dayjs'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import timezone from 'dayjs/plugin/timezone'
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-import SpinnerButton from '../SpinnerButton'
-import EditorSection from '../EditorSection'
-import GroupIdList, { InvitationIdList } from '../group/GroupIdList'
+import { useReducer, useState } from 'react'
 import api from '../../lib/api-client'
 import {
   formatDateTime,
@@ -19,11 +17,17 @@ import {
   trueFalseOptions,
   urlFromGroupId,
 } from '../../lib/utils'
+import EditorSection from '../EditorSection'
+import GroupIdList, { InvitationIdList } from '../group/GroupIdList'
 import LoadingSpinner from '../LoadingSpinner'
+import SpinnerButton from '../SpinnerButton'
+
+import { invitation as invitationStyles } from '../../lib/legacy-bootstrap-styles'
 
 dayjs.extend(timezone)
 dayjs.extend(utc)
 
+const CodeEditor = dynamic(() => import('../CodeEditor'))
 const DatetimePicker = dynamic(() => import('../DatetimePicker'), {
   ssr: false,
   loading: () => <LoadingSpinner inline text={null} extraClass="spinner-small" />,
@@ -164,108 +168,129 @@ export const InvitationGeneralViewV2 = ({ invitation, isMetaInvitation }) => {
   const parentGroupId = invitation.id.split('/-/')[0]
 
   return (
-    <div>
-      <div className="row d-flex">
-        <span className="info-title">Parent Group:</span>
-        <Link href={urlFromGroupId(parentGroupId, true)}>{prettyId(parentGroupId)}</Link>
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Invitations:</span>
-        <div>
-          <InvitationIdList invitationIds={invitation.invitations} />
-        </div>
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Readers:</span>
-        <div>
-          <GroupIdList groupIds={invitation.readers} />
-        </div>
-      </div>
-      {invitation.nonreaders?.length > 0 && (
-        <div className="row d-flex">
-          <span className="info-title">Non-readers:</span>
-          <div>
-            <GroupIdList groupIds={invitation.nonreaders} />
-          </div>
-        </div>
-      )}
-      <div className="row d-flex">
-        <span className="info-title">Writers:</span>
-        <div>
-          <GroupIdList groupIds={invitation.writers} />
-        </div>
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Invitees:</span>
-        <div>
-          <GroupIdList groupIds={invitation.invitees} />
-        </div>
-      </div>
-      {invitation.noninvitees?.length > 0 && (
-        <div className="row d-flex">
-          <span className="info-title">Non-Invitees:</span>
-          <div>
-            <GroupIdList groupIds={invitation.noninvitees} />
-          </div>
-        </div>
-      )}
-
-      {!isMetaInvitation && (
-        <div className="row d-flex">
-          <span className="info-title">Max Replies:</span>
-          {invitation.maxReplies}
-        </div>
-      )}
-      {!isMetaInvitation && (
-        <div className="row d-flex">
-          <span className="info-title">Min Replies:</span>
-          {invitation.minReplies}
-        </div>
-      )}
-      <div className="row d-flex">
-        <span className="info-title">Bulk:</span>
-        {invitation.bulk?.toString()}
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Signature:</span>
-        <div>
-          <GroupIdList groupIds={invitation.signatures} />
-        </div>
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Creation Date:</span>
-        {formatDateTime(invitation.tcdate, { month: 'long', timeZoneName: 'short' })}
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Activation Date:</span>
-        {formatDateTime(invitation.cdate, { month: 'long', timeZoneName: 'short' }) ??
-          formatDateTime(invitation.tcdate, { month: 'long', timeZoneName: 'short' })}
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Modified Date:</span>
-        {formatDateTime(invitation.mdate, { month: 'long', timeZoneName: 'short' }) ??
-          formatDateTime(invitation.tmdate, { month: 'long', timeZoneName: 'short' })}
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Due Date:</span>
-        {formatDateTime(invitation.duedate, { month: 'long', timeZoneName: 'short' })}
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Expiration Date:</span>
-        {formatDateTime(invitation.expdate, { month: 'long', timeZoneName: 'short' })}
-      </div>
-      <div className="row d-flex">
-        <span className="info-title">Last Modified:</span>
-        {formatDateTime(invitation.mdate, { month: 'long', timeZoneName: 'short' }) ??
-          formatDateTime(invitation.tmdate, { month: 'long', timeZoneName: 'short' })}
-      </div>
-      {invitation.ddate && (
-        <div className="row d-flex">
-          <span className="info-title">Deleted:</span>
-          {formatDateTime(invitation.ddate, { month: 'long', timeZoneName: 'short' })}
-        </div>
-      )}
-    </div>
+    <Descriptions
+      column={1}
+      size="small"
+      styles={{ label: invitationStyles.descriptionsLabel }}
+      items={[
+        {
+          label: 'Parent Group',
+          children: (
+            <Link href={urlFromGroupId(parentGroupId, true)}>{prettyId(parentGroupId)}</Link>
+          ),
+        },
+        {
+          label: 'Invitations',
+          children: <InvitationIdList invitationIds={invitation.invitations} />,
+        },
+        {
+          label: 'Readers',
+          children: <GroupIdList groupIds={invitation.readers} />,
+        },
+        ...(invitation.nonreaders?.length > 0
+          ? [
+              {
+                label: 'Non-readers',
+                children: <GroupIdList groupIds={invitation.nonreaders} />,
+              },
+            ]
+          : []),
+        {
+          label: 'Writers',
+          children: <GroupIdList groupIds={invitation.writers} />,
+        },
+        {
+          label: 'Invitees',
+          children: <GroupIdList groupIds={invitation.invitees} />,
+        },
+        ...(invitation.noninvitees?.length > 0
+          ? [
+              {
+                label: 'Non-Invitees',
+                children: <GroupIdList groupIds={invitation.noninvitees} />,
+              },
+            ]
+          : []),
+        ...(isMetaInvitation
+          ? []
+          : [
+              {
+                label: 'Max Replies',
+                children: invitation.maxReplies,
+              },
+              {
+                label: 'Min Replies',
+                children: invitation.minReplies,
+              },
+            ]),
+        {
+          label: 'Bulk',
+          children: invitation.bulk?.toString(),
+        },
+        {
+          label: 'Signature',
+          children: <GroupIdList groupIds={invitation.signatures} />,
+        },
+        {
+          label: 'Creation Date',
+          children: formatDateTime(invitation.tcdate, {
+            month: 'long',
+            timeZoneName: 'short',
+          }),
+        },
+        {
+          label: 'Activation Date',
+          children:
+            formatDateTime(invitation.cdate, { month: 'long', timeZoneName: 'short' }) ??
+            formatDateTime(invitation.tcdate, { month: 'long', timeZoneName: 'short' }),
+        },
+        {
+          label: 'Modified Date',
+          children:
+            formatDateTime(invitation.mdate, { month: 'long', timeZoneName: 'short' }) ??
+            formatDateTime(invitation.tmdate, { month: 'long', timeZoneName: 'short' }),
+        },
+        {
+          label: 'Due Date',
+          children: formatDateTime(invitation.duedate, {
+            month: 'long',
+            timeZoneName: 'short',
+          }),
+        },
+        {
+          label: 'Expiration Date',
+          children: formatDateTime(invitation.expdate, {
+            month: 'long',
+            timeZoneName: 'short',
+          }),
+        },
+        {
+          label: 'Last Modified',
+          children:
+            formatDateTime(invitation.mdate, { month: 'long', timeZoneName: 'short' }) ??
+            formatDateTime(invitation.tmdate, { month: 'long', timeZoneName: 'short' }),
+        },
+        ...(invitation.ddate
+          ? [
+              {
+                label: 'Deleted',
+                children: formatDateTime(invitation.ddate, {
+                  month: 'long',
+                  timeZoneName: 'short',
+                }),
+              },
+            ]
+          : []),
+        ...(invitation.humanVerificationRequired
+          ? [
+              {
+                label: 'Human Verification',
+                children: JSON.stringify(invitation.humanVerificationRequired),
+              },
+            ]
+          : []),
+      ]}
+    />
   )
 }
 
@@ -609,6 +634,9 @@ const InvitationGeneralEditV2 = ({
     expDateTimezone: getDefaultTimezone()?.value,
     deletionDateTimezone: getDefaultTimezone()?.value,
     signatures: invitation.signatures?.join(', '),
+    humanVerificationRequired: invitation.humanVerificationRequired
+      ? JSON.stringify(invitation.humanVerificationRequired, null, 2)
+      : null,
   })
 
   const constructInvitationEditToPost = () => {
@@ -632,6 +660,15 @@ const InvitationGeneralEditV2 = ({
       !generalInfo.minReplies || Number.isNaN(parseInt(generalInfo.minReplies, 10))
         ? { delete: true }
         : parseInt(generalInfo.minReplies, 10)
+
+    let humanVerificationRequired
+    if (generalInfo.humanVerificationRequired?.trim()) {
+      try {
+        humanVerificationRequired = JSON.parse(generalInfo.humanVerificationRequired)
+      } catch {
+        throw new Error('Human Verification must be valid JSON')
+      }
+    }
 
     const invitationEdit = {
       invitation: {
@@ -657,6 +694,7 @@ const InvitationGeneralEditV2 = ({
         nonreaders: stringToArray(generalInfo.nonreaders),
         readers: stringToArray(generalInfo.readers),
         writers: stringToArray(generalInfo.writers),
+        ...(humanVerificationRequired && { humanVerificationRequired }),
         ...(isMetaInvitation && { edit: true }),
       },
       readers: [profileId],
@@ -669,8 +707,8 @@ const InvitationGeneralEditV2 = ({
 
   const saveGeneralInfo = async () => {
     setIsSaving(true)
-    const requestBody = constructInvitationEditToPost()
     try {
+      const requestBody = constructInvitationEditToPost()
       if (!isMetaInvitation && !requestBody.invitations) {
         throw new Error('No meta invitation found')
       }
@@ -857,6 +895,21 @@ const InvitationGeneralEditV2 = ({
             className="form-control input-sm"
             value={generalInfo.signatures}
             onChange={(e) => setGeneralInfo({ type: 'signatures', payload: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="row d-flex">
+        <span className="info-title edit-title">Human Verification:</span>
+        <div className="info-edit-control">
+          <CodeEditor
+            code={generalInfo.humanVerificationRequired ?? ''}
+            onChange={(value) =>
+              setGeneralInfo({ type: 'humanVerificationRequired', payload: value })
+            }
+            isJson
+            minHeight="80px"
+            maxHeight="200px"
           />
         </div>
       </div>

--- a/components/invitation/InvitationGeneral.js
+++ b/components/invitation/InvitationGeneral.js
@@ -634,9 +634,11 @@ const InvitationGeneralEditV2 = ({
     expDateTimezone: getDefaultTimezone()?.value,
     deletionDateTimezone: getDefaultTimezone()?.value,
     signatures: invitation.signatures?.join(', '),
-    humanVerificationRequired: invitation.humanVerificationRequired
-      ? JSON.stringify(invitation.humanVerificationRequired, null, 2)
-      : null,
+    ...(invitation.edit?.note && {
+      humanVerificationRequired: invitation.humanVerificationRequired
+        ? JSON.stringify(invitation.humanVerificationRequired, null, 2)
+        : null,
+    }),
   })
 
   const constructInvitationEditToPost = () => {
@@ -662,7 +664,7 @@ const InvitationGeneralEditV2 = ({
         : parseInt(generalInfo.minReplies, 10)
 
     let humanVerificationRequired
-    if (generalInfo.humanVerificationRequired?.trim()) {
+    if (isNoteInvitation && generalInfo.humanVerificationRequired?.trim()) {
       try {
         humanVerificationRequired = JSON.parse(generalInfo.humanVerificationRequired)
       } catch {
@@ -899,20 +901,22 @@ const InvitationGeneralEditV2 = ({
         </div>
       </div>
 
-      <div className="row d-flex">
-        <span className="info-title edit-title">Human Verification:</span>
-        <div className="info-edit-control">
-          <CodeEditor
-            code={generalInfo.humanVerificationRequired ?? ''}
-            onChange={(value) =>
-              setGeneralInfo({ type: 'humanVerificationRequired', payload: value })
-            }
-            isJson
-            minHeight="80px"
-            maxHeight="200px"
-          />
+      {isNoteInvitation && (
+        <div className="row d-flex">
+          <span className="info-title edit-title">Human Verification:</span>
+          <div className="info-edit-control">
+            <CodeEditor
+              code={generalInfo.humanVerificationRequired ?? ''}
+              onChange={(value) =>
+                setGeneralInfo({ type: 'humanVerificationRequired', payload: value })
+              }
+              isJson
+              minHeight="80px"
+              maxHeight="200px"
+            />
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="row d-flex">
         <span className="info-title edit-title" />
@@ -966,6 +970,7 @@ export const InvitationGeneralV2 = ({
   isMetaInvitation,
 }) => {
   const [isEditMode, setIsEditMode] = useState(false)
+  const isNoteInvitation = invitation.edit?.note
 
   return (
     <EditorSection title="General Info" className="general">

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -105,6 +105,10 @@ const request = (httpMethod) => {
       defaultHeaders['X-Forwarded-For'] = options.remoteIpAddress
     }
 
+    if (options['cf-turnstile-token']) {
+      defaultHeaders['cf-turnstile-token'] = options['cf-turnstile-token']
+    }
+
     let query
     let methodOptions
     if (httpMethod === 'GET') {

--- a/lib/legacy-bootstrap-styles.js
+++ b/lib/legacy-bootstrap-styles.js
@@ -67,6 +67,18 @@ export const profile = {
   },
 }
 
+// --- Invitation page ---
+
+export const invitation = {
+  descriptionsLabel: {
+    fontWeight: 700,
+    color: 'inherit',
+    justifyContent: 'flex-end',
+    width: 140,
+    whiteSpace: 'nowrap',
+  },
+}
+
 // --- Moderation page ---
 
 export const moderation = {

--- a/styles/components/NoteEditor.module.scss
+++ b/styles/components/NoteEditor.module.scss
@@ -99,3 +99,8 @@
 .invalidValue {
   border-color: constants.$orRed;
 }
+
+.turnstileContainer {
+  margin-left: -0.5rem;
+  margin-top: 0.25rem;
+}

--- a/unitTests/FileUploadWidget.test.js
+++ b/unitTests/FileUploadWidget.test.js
@@ -1,13 +1,26 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import '@testing-library/jest-dom'
 import FileUploadWidget from '../components/EditorComponents/FileUploadWidget'
 import api from '../lib/api-client'
 import { renderWithEditorComponentContext } from './util'
+import '@testing-library/jest-dom'
+
+let useTurnstileTokenProps
 
 jest.mock('../lib/api-client')
 jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
 jest.mock('../hooks/useUser', () => () => ({ user: {}, accessToken: 'some token' }))
+jest.mock('../hooks/useTurnstileToken', () => (key, hasHumanVerificationError) => {
+  useTurnstileTokenProps(key, hasHumanVerificationError)
+  if (!hasHumanVerificationError) return {}
+  return {
+    turnstileToken: 'some token',
+  }
+})
+
+beforeEach(() => {
+  useTurnstileTokenProps = jest.fn()
+})
 
 describe('FileUploadWidget', () => {
   test('display choose file button', () => {
@@ -187,6 +200,92 @@ describe('FileUploadWidget', () => {
     expect(onChange).toHaveBeenCalledWith({
       fieldName: 'supplementary_material',
       value: undefined,
+    })
+  })
+
+  test('show turnstile token when api return human verfication error', async () => {
+    const humanVerificationError = new Error('Human verification required')
+    humanVerificationError.name = 'HumanVerificationRequiredError'
+    const onChange = jest.fn()
+    const clearError = jest.fn()
+    api.put = jest.fn(() => Promise.reject(humanVerificationError))
+
+    const providerProps = {
+      value: {
+        invitation: { id: 'invitationId' },
+        field: {
+          supplementary_material: {
+            value: {
+              param: {
+                type: 'file',
+              },
+            },
+          },
+        },
+        onChange,
+        clearError,
+      },
+    }
+    renderWithEditorComponentContext(<FileUploadWidget />, providerProps)
+
+    const fileInput = screen.getByLabelText('supplementary_material')
+    const file = new File(['some byte string'], 'test.pdf', { type: 'application/pdf' })
+    await userEvent.upload(fileInput, file)
+
+    expect(useTurnstileTokenProps).toHaveBeenCalledWith('fileUpload', true)
+  })
+
+  test('retry upload after HumanVerificationRequiredError and turnstile token obtained', async () => {
+    const humanVerificationError = new Error('Human verification required')
+    humanVerificationError.name = 'HumanVerificationRequiredError'
+    const onChange = jest.fn()
+    const clearError = jest.fn()
+    api.put = jest
+      .fn()
+      .mockRejectedValueOnce(humanVerificationError)
+      .mockResolvedValue({ url: 'test url' })
+
+    const providerProps = {
+      value: {
+        invitation: { id: 'invitationId' },
+        field: {
+          supplementary_material: {
+            value: {
+              param: {
+                type: 'file',
+              },
+            },
+          },
+        },
+        onChange,
+        clearError,
+      },
+    }
+    renderWithEditorComponentContext(<FileUploadWidget />, providerProps)
+
+    const fileInput = screen.getByLabelText('supplementary_material')
+    const file = new File(['some byte string'], 'test.pdf', { type: 'application/pdf' })
+    await userEvent.upload(fileInput, file)
+
+    // initial failure + retry with token
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledTimes(2)
+      expect(api.put).toHaveBeenNthCalledWith(
+        1,
+        '/attachment/chunk',
+        expect.anything(),
+        expect.objectContaining({
+          'cf-turnstile-token': undefined,
+        })
+      )
+      expect(api.put).toHaveBeenNthCalledWith(
+        2,
+        '/attachment/chunk',
+        expect.anything(),
+        expect.objectContaining({
+          'cf-turnstile-token': 'some token',
+        })
+      )
     })
   })
 })


### PR DESCRIPTION
this pr is related to https://github.com/openreview/openreview-api/pull/1051 and https://github.com/openreview/openreview-api/pull/1062
this pr should add captcha in file upload widget and note editor when HumanVerificationRequiredError is returned

file upload widget should retry the file upload when it failed halfway with HumanVerificationRequiredError

this pr should also add human verification to invitation admin general info section
and convert general info display to antd
general info edit is not changed to antd because it requires datetime picker to be changed first
