### PR TITLE
Replace PAT with GitHub App token for private repo checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: openreview
           repositories: openreview-api-v1,openreview-api

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,14 @@ jobs:
         with:
           mongodb-version: 8.0
           mongodb-replica-set: rs0
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: openreview
+          repositories: openreview-api-v1,openreview-api
       - name: Checkout openreview-py
         uses: actions/checkout@v6
         with:
@@ -68,13 +76,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: openreview/openreview-api-v1
-          token: ${{ secrets.PAT_OPENREVIEW_IESL }}
+          token: ${{ steps.app-token.outputs.token }}
           path: openreview-api-v1
       - name: Checkout openreview-api
         uses: actions/checkout@v6
         with:
           repository: openreview/openreview-api
-          token: ${{ secrets.PAT_OPENREVIEW_IESL }}
+          token: ${{ steps.app-token.outputs.token }}
           path: openreview-api
       - name: Checkout openreview-web
         uses: actions/checkout@v6


### PR DESCRIPTION
Use actions/create-github-app-token@v3 to generate scoped, short-lived tokens instead of the PAT_OPENREVIEW_IESL personal access token for checking out openreview-api-v1 and openreview-api.