### PR TITLE
Fix/ Author display in edit

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1856,9 +1856,11 @@ export function getNoteAuthorIds(note, isV2Note) {
   if (!isV2Note) return note.content.authorids
   if (!note?.content?.authorids?.value) {
     // object author
-    return note?.content?.authors?.value?.map((p) => p.username)
+    const value = note?.content?.authors?.value
+    return Array.isArray(value) ? value.map((p) => p.username) : undefined
   }
-  return note?.content?.authorids?.value
+  const value = note?.content?.authorids?.value
+  return Array.isArray(value) ? value : undefined
 }
 
 /**
@@ -1871,7 +1873,8 @@ export function getNoteAuthorIds(note, isV2Note) {
 export function getNoteAuthors(note, isV2Note) {
   if (isV2Note) {
     if (note.content?.authorids?.value) return note.content?.authors?.value
-    return note.content?.authors?.value?.map((p) => p.fullname)
+    const value = note.content?.authors?.value
+    return Array.isArray(value) ? value.map((p) => p.fullname) : undefined
   }
   const noteAuthors = note.content?.authors
   const originalAuthors = note.details?.original?.content?.authors

--- a/unitTests/utils.test.js
+++ b/unitTests/utils.test.js
@@ -1,3 +1,4 @@
+import { screen, render } from '@testing-library/react'
 import {
   getDefaultTimezone,
   getTagDispayText,
@@ -9,8 +10,9 @@ import {
   stringToObject,
   buildNoteUrl,
   sanitizeRedirectUrl,
+  getNoteAuthorIds,
+  getNoteAuthors,
 } from '../lib/utils'
-import { screen, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
@@ -961,5 +963,182 @@ describe('utils', () => {
     redirect = 'javascript:alert("some alert")'
     expectedValue = '/'
     expect(sanitizeRedirectUrl(redirect)).toEqual(expectedValue)
+  })
+
+  test('return authorids correctly', () => {
+    let note, isV2Note, expectedValue, edit
+
+    // v1 note
+    note = {
+      content: {
+        authorids: ['~Test_User1', '~Test_User2'],
+      },
+    }
+    isV2Note = false
+    expectedValue = ['~Test_User1', '~Test_User2']
+    expect(getNoteAuthorIds(note, isV2Note)).toEqual(expectedValue)
+
+    // v2 note - authors+authorids schema
+    note = {
+      content: {
+        authors: { value: ['Test User1', 'Test User2'] },
+        authorids: { value: ['~Test_User1', '~Test_User2'] },
+      },
+    }
+    isV2Note = true
+    expectedValue = ['~Test_User1', '~Test_User2']
+    expect(getNoteAuthorIds(note, isV2Note)).toEqual(expectedValue)
+
+    // v2 note - object author schema
+    note = {
+      content: {
+        authors: {
+          value: [
+            { username: '~Test_User1', fullname: 'Test User1', institutions: [] },
+            { username: '~Test_User2', fullname: 'Test User2', institutions: [] },
+          ],
+        },
+      },
+    }
+    isV2Note = true
+    expectedValue = ['~Test_User1', '~Test_User2']
+    expect(getNoteAuthorIds(note, isV2Note)).toEqual(expectedValue)
+
+    // edit - author coreference for authors+authorids schema
+    edit = {
+      content: {},
+      note: {
+        content: {
+          authorids: {
+            value: {
+              replace: {
+                index: 0,
+                value: '',
+              },
+            },
+          },
+        },
+      },
+    }
+    isV2Note = true
+    expectedValue = undefined
+    expect(getNoteAuthorIds(edit.note, isV2Note)).toEqual(expectedValue)
+
+    // edit - author coreference for object author schema (use authors instead of authorids)
+    edit = {
+      content: {},
+      note: {
+        content: {
+          authors: {
+            value: {
+              replace: {
+                index: 0,
+                value: '',
+              },
+            },
+          },
+        },
+      },
+    }
+    isV2Note = true
+    expectedValue = undefined
+    expect(getNoteAuthorIds(edit.note, isV2Note)).toEqual(expectedValue)
+  })
+
+  test('return author names correctly', () => {
+    let note, isV2Note, expectedValue, edit
+
+    // v1 note
+    note = {
+      content: {
+        authors: ['Test User1', 'Test User2'],
+      },
+    }
+    isV2Note = false
+    expectedValue = ['Test User1', 'Test User2']
+    expect(getNoteAuthors(note, isV2Note)).toEqual(expectedValue)
+
+    // v1 note with original
+    note = {
+      content: {
+        authors: ['submission authors'],
+      },
+      details: {
+        original: {
+          content: {
+            authors: ['Test User1', 'Test User2'],
+          },
+        },
+      },
+    }
+    isV2Note = false
+    expectedValue = ['Test User1', 'Test User2']
+    expect(getNoteAuthors(note, isV2Note)).toEqual(expectedValue)
+
+    // v2 note - authors+authorids schema
+    note = {
+      content: {
+        authors: { value: ['Test User1', 'Test User2'] },
+        authorids: { value: ['~Test_User1', '~Test_User2'] },
+      },
+    }
+    isV2Note = true
+    expectedValue = ['Test User1', 'Test User2']
+    expect(getNoteAuthors(note, isV2Note)).toEqual(expectedValue)
+
+    // v2 note - object author schema
+    note = {
+      content: {
+        authors: {
+          value: [
+            { username: '~Test_User1', fullname: 'Test User1', institutions: [] },
+            { username: '~Test_User2', fullname: 'Test User2', institutions: [] },
+          ],
+        },
+      },
+    }
+    isV2Note = true
+    expectedValue = ['Test User1', 'Test User2']
+    expect(getNoteAuthors(note, isV2Note)).toEqual(expectedValue)
+
+    // edit - author coreference for authors+authorids schema
+    edit = {
+      content: {},
+      note: {
+        content: {
+          authorids: {
+            value: {
+              replace: {
+                index: 0,
+                value: '',
+              },
+            },
+          },
+        },
+      },
+    }
+    isV2Note = true
+    expectedValue = undefined
+    expect(getNoteAuthors(edit.note, isV2Note)).toEqual(expectedValue)
+
+    // edit - author coreference for object author schema (use authors instead of authorids)
+    edit = {
+      content: {},
+      note: {
+        content: {
+          authors: {
+            value: {
+              replace: {
+                index: 0,
+                value: '',
+              },
+            },
+          },
+        },
+      },
+    }
+    isV2Note = true
+    expectedValue = undefined
+    expect(getNoteAuthors(edit.note, isV2Note)).toEqual(expectedValue)
   })
 })


### PR DESCRIPTION
related to #2523

the authorship related invitation (OpenReview.net/Public_Article/-/Author_Removal) is changed to use note.content.authors instead of note.content.authorids

so the util function is trying to get author name from replace object which would throw an error

this pr should fix this issue by adding an array check and when the value is not array, return the expected value - undefined