### PR TITLE
Fix/ Moderation - search enhancements

### DIFF
--- a/app/user/moderation/UserModerationTab.js
+++ b/app/user/moderation/UserModerationTab.js
@@ -1,11 +1,24 @@
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
+  CopyOutlined,
   PlusOutlined,
   StopOutlined,
   UndoOutlined,
 } from '@ant-design/icons'
-import { Button, Col, Flex, Input, Modal, Pagination, Row, Select, Space, Tag } from 'antd'
+import {
+  Button,
+  Col,
+  Flex,
+  Input,
+  Modal,
+  Pagination,
+  Row,
+  Select,
+  Space,
+  Tag,
+  Typography,
+} from 'antd'
 import dayjs from 'dayjs'
 import { cloneDeep, uniqBy } from 'lodash'
 import { useEffect, useReducer, useState } from 'react'
@@ -308,6 +321,35 @@ const UserModerationQueue = ({
     if (cleanSearchTerm?.includes('@')) searchQuery = { email: cleanSearchTerm.toLowerCase() }
 
     try {
+      const searchTokens = cleanSearchTerm ? cleanSearchTerm.split(/\s+/) : []
+      if (
+        profileStateOption === 'All' &&
+        searchTokens.length > 1 &&
+        searchTokens.every((t) => t.startsWith('~') || t.includes('@'))
+      ) {
+        const results = await Promise.all(
+          searchTokens.map((token) =>
+            api.get(
+              '/profiles/search',
+              {
+                ...(token.startsWith('~') ? { id: token } : { email: token.toLowerCase() }),
+                es: true,
+                withBlocked: true,
+                trash: true,
+              },
+              { cachePolicy: 'no-cache' }
+            )
+          )
+        )
+        const merged = uniqBy(
+          results.flatMap((r) => r.profiles ?? []),
+          'id'
+        )
+        setTotalCount(merged.length)
+        setProfiles(merged)
+        return
+      }
+
       const result = await api.get(
         shouldSearchProfile ? '/profiles/search' : '/profiles',
         {
@@ -512,6 +554,7 @@ const UserModerationQueue = ({
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             onPressEnter={filterProfiles}
+            allowClear
           />
           <Select
             className={styles.statefilter}
@@ -540,17 +583,43 @@ const UserModerationQueue = ({
             const state =
               profile.ddate && profile.state !== 'Merged' ? 'Deleted' : profile.state
             return (
-              <Row key={profile.id} align="middle" gutter={[15, 15]}>
+              <Row
+                key={profile.id}
+                align="middle"
+                gutter={[15, 15]}
+                className={styles.profilerow}
+              >
                 <Col xs={24} sm={12} md={6} lg={3} xl={3}>
-                  <a
-                    href={`/profile?id=${profile.id}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    title={profile.id}
-                    className={styles.profilenamelink}
-                  >
-                    {name?.fullname}
-                  </a>
+                  {onlyModeration ? (
+                    <a
+                      href={`/profile?id=${profile.id}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      title={profile.id}
+                      className={styles.profilenamelink}
+                    >
+                      {name?.fullname}
+                    </a>
+                  ) : (
+                    <Typography.Text
+                      copyable={{
+                        text: profile.id,
+                        tooltips: ['Copy tilde id', 'Tilde id copied'],
+                        icon: [<CopyOutlined key="copy" />, <CopyOutlined key="copied" />],
+                      }}
+                      className={styles.copyid}
+                    >
+                      <a
+                        href={`/profile?id=${profile.id}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        title={profile.id}
+                        className={styles.profilenamelink}
+                      >
+                        {name?.fullname}
+                      </a>
+                    </Typography.Text>
+                  )}
                 </Col>
                 <Col
                   xs={24}

--- a/app/user/moderation/moderation.module.scss
+++ b/app/user/moderation/moderation.module.scss
@@ -16,3 +16,19 @@
 .statefilter {
   flex: 2 1 150px;
 }
+
+.copyid {
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+}
+
+.copyid button {
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.profilerow:hover .copyid button,
+.profilerow:focus-within .copyid button {
+  opacity: 1;
+}


### PR DESCRIPTION
this pr should change the following in user moderation page:
1. allow searching multiple tilde id/emails
the moderator can now search multiple emails or tilde ids or email + tilde ids, they should be separated by space
if mixed with name or text which is not email/tilde id, it's treated as regular search (unlikely to return any results)

the use case is search the user to be vouched and the user doing the vouch or cases when multiple profiles are mentioned

2. allow tilde id to be copied
when first column of search results is hovered, it should show a copy button to copy the tilde id of the profile
used when adding vouch tag or performing profile merge (email may return the same profile)