### PR TITLE
Fix/ TestCafe configuration - reduce concurrency for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "build": "next build",
     "start": "next start --port $NEXT_PORT",
     "unit-test": "jest",
-    "test": "testcafe firefox tests/setup --concurrency 4 && (testcafe firefox:headless tests/e2e_1 & p1=$!; testcafe firefox:headless tests/e2e_2 & p2=$!; testcafe firefox:headless tests/e2e_3 & p3=$!; wait $p1 && wait $p2 && wait $p3) && testcafe firefox tests/setup_redbutton_venue && testcafe firefox:headless tests/e2e_redbutton",
+    "test": "testcafe firefox:headless tests/setup --concurrency 2 && (testcafe firefox:headless tests/e2e_1 & p1=$!; testcafe firefox:headless tests/e2e_2 & p2=$!; testcafe firefox:headless tests/e2e_3 & p3=$!; wait $p1 && wait $p2 && wait $p3) && testcafe firefox tests/setup_redbutton_venue && testcafe firefox:headless tests/e2e_redbutton",
     "doc": "jsdoc2md 'components/webfield/*Console.js' > webfieldconfig.md",
-    "test-setup": "testcafe firefox tests/setup --concurrency 4",
+    "test-setup": "testcafe firefox:headless tests/setup --concurrency 2",
     "templates": "handlebars client/templates/ -n 'window.Handlebars.templates' -f client/templates.js -e 'hbs'",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check"


### PR DESCRIPTION
reduce concurrency during setup to 2
use headless during setup