### PR TITLE
Fix/ NoteAuthorsV2 - update logic for author institutions

### DIFF
--- a/components/NoteAuthors.js
+++ b/components/NoteAuthors.js
@@ -189,7 +189,7 @@ export const NoteAuthorsV2 = ({
           key="private-label"
           name="eye-open"
           extraClasses="private-contents-icon"
-          tooltip={`Identities privately revealed to ${authorIds?.readers
+          tooltip={`Identities privately revealed to ${authorIdsProp?.readers
             ?.map((p) => prettyId(p))
             .join(', ')}`}
         />

--- a/components/NoteAuthors.js
+++ b/components/NoteAuthors.js
@@ -103,7 +103,7 @@ export const NoteAuthorsV2 = ({
   noteReaders,
   showAuthorInstitutions,
 }) => {
-  if (showAuthorInstitutions && !authorIdsProp?.value) {
+  if (showAuthorInstitutions && authorsProp?.value && !authorIdsProp?.value) {
     return <NoteAuthorsWithInstitutions authors={authorsProp} noteReaders={noteReaders} />
   }
 
@@ -114,8 +114,11 @@ export const NoteAuthorsV2 = ({
 
   let showPrivateLabel = false
   const sortedReaders = noteReaders ? [...noteReaders].sort() : []
-  if (Array.isArray(authorIds?.readers) && !isEqual(sortedReaders, authorIds.readers.sort())) {
-    showPrivateLabel = !authorIds.readers.includes('everyone')
+  if (
+    Array.isArray(authorIdsProp?.readers) &&
+    !isEqual(sortedReaders, authorIdsProp.readers.sort())
+  ) {
+    showPrivateLabel = !authorIdsProp.readers.includes('everyone')
   }
 
   let authorsList

--- a/unitTests/NoteAuthors.test.js
+++ b/unitTests/NoteAuthors.test.js
@@ -135,6 +135,11 @@ describe('NoteAuthorsV2', () => {
         noteReaders={['everyone']}
       />
     )
-    expect(container.querySelector('.private-contents-icon')).toBeInTheDocument()
+    const icon = container.querySelector('.private-contents-icon')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveAttribute(
+      'title',
+      'Identities privately revealed to Conference Submission1 Reviewers'
+    )
   })
 })

--- a/unitTests/NoteAuthors.test.js
+++ b/unitTests/NoteAuthors.test.js
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react'
+import { NoteAuthorsV2 } from '../components/NoteAuthors'
+import '@testing-library/jest-dom'
+
+jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
+
+describe('NoteAuthorsV2', () => {
+  // Reviewer can see forum note but not authors/authorids
+  test('show signature when authors and authorIds are not visible', () => {
+    render(
+      <NoteAuthorsV2
+        authors={undefined}
+        authorIds={undefined}
+        signatures={['test/conference/Submission1/Authors']}
+        noteReaders={[
+          'test/Conference',
+          'test/Conference/Submission1/Reviewers',
+          'test/Conference/Submission1/Authors',
+        ]}
+        showAuthorInstitutions
+      />
+    )
+    expect(screen.getByText('Submission1 Authors')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  // object authors has no authorids field
+  test('renders institutions when there are only authors', () => {
+    const authors = {
+      value: [
+        {
+          fullname: 'First Last',
+          username: '~First_Last1',
+          institutions: [{ domain: 'test.domain', name: 'Test Domain' }],
+        },
+      ],
+      readers: ['everyone'],
+    }
+    const { container } = render(
+      <NoteAuthorsV2
+        authors={authors}
+        authorIds={undefined}
+        noteReaders={['everyone']}
+        showAuthorInstitutions
+      />
+    )
+    expect(container.querySelector('.note-authors-institutions')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'First Last' })).toBeInTheDocument()
+    expect(screen.getByText(/Test Domain/)).toBeInTheDocument()
+  })
+
+  test('builds profile link with id param for ~ ids', () => {
+    render(<NoteAuthorsV2 authors={['First Last']} authorIds={['~First_Last1']} />)
+    expect(screen.getByRole('link', { name: 'First Last' })).toHaveAttribute(
+      'href',
+      '/profile?id=~First_Last1'
+    )
+  })
+
+  test('builds profile link with email param for email ids', () => {
+    render(<NoteAuthorsV2 authors={['First Last']} authorIds={['first.last@test.domain']} />)
+    expect(screen.getByRole('link', { name: 'First Last' })).toHaveAttribute(
+      'href',
+      '/profile?email=first.last%40test.domain'
+    )
+  })
+
+  test('builds external link for dblp ids', () => {
+    render(
+      <NoteAuthorsV2
+        authors={['First Last']}
+        authorIds={['https://dblp.org/pid/f/First_Last']}
+      />
+    )
+    const link = screen.getByRole('link', { name: 'First Last' })
+    expect(link).toHaveAttribute('href', 'https://dblp.org/pid/f/First_Last')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  test('deduplicates repeated (author, authorId) pairs', () => {
+    render(
+      <NoteAuthorsV2
+        authors={['First Last', 'First Last']}
+        authorIds={['~First_Last1', '~First_Last1']}
+      />
+    )
+    expect(screen.getAllByRole('link')).toHaveLength(1)
+  })
+
+  test('unwraps .value from both authors and authorIds (v2 wrapper input)', () => {
+    render(
+      <NoteAuthorsV2
+        authors={{ value: ['First Last'], readers: ['everyone'] }}
+        authorIds={{ value: ['~First_Last1'], readers: ['everyone'] }}
+        noteReaders={['everyone']}
+      />
+    )
+    expect(screen.getByRole('link', { name: 'First Last' })).toHaveAttribute(
+      'href',
+      '/profile?id=~First_Last1'
+    )
+  })
+
+  test('not to show eye icon when authorIds.readers matches noteReaders', () => {
+    const { container } = render(
+      <NoteAuthorsV2
+        authors={{ value: ['First Last'], readers: ['everyone'] }}
+        authorIds={{ value: ['~First_Last1'], readers: ['everyone'] }}
+        noteReaders={['everyone']}
+      />
+    )
+    expect(container.querySelector('.private-contents-icon')).not.toBeInTheDocument()
+  })
+
+  test('not to show eye icon when readers differ but include "everyone"', () => {
+    const { container } = render(
+      <NoteAuthorsV2
+        authors={{ value: ['First Last'], readers: ['everyone'] }}
+        authorIds={{ value: ['~First_Last1'], readers: ['everyone'] }}
+        noteReaders={['test/Conference/Submission1/Reviewers', 'everyone']}
+      />
+    )
+    expect(container.querySelector('.private-contents-icon')).not.toBeInTheDocument()
+  })
+
+  test('shows private label when readers differ', () => {
+    const { container } = render(
+      <NoteAuthorsV2
+        authors={{ value: ['First Last'], readers: ['everyone'] }}
+        authorIds={{
+          value: ['~First_Last1'],
+          readers: ['test/Conference/Submission1/Reviewers'],
+        }}
+        noteReaders={['everyone']}
+      />
+    )
+    expect(container.querySelector('.private-contents-icon')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
this pr should fix the following 2 issues when the note is visible to reviewers but authors and authorids are not:
1. right now when there's no authorids it will show NoteAuthorsWithInstitutions
this is changed to have authors but not have authorids so that reviewers don't see empty authors
2. eye icon is not shown for the roles which can read the authors

this pr should also add some tests so that regressions like this can be caught