### PR TITLE
Fix/ ProfilePreviewModal - ArrowUp to previous profile

### DIFF
--- a/app/user/moderation/UserModerationTab.js
+++ b/app/user/moderation/UserModerationTab.js
@@ -518,6 +518,16 @@ const UserModerationQueue = ({
     }
   }
 
+  const showPreviousProfile = (currentProfileId) => {
+    const previousProfile =
+      profiles[profiles.findIndex((p) => p.id === currentProfileId) - 1]
+    if (previousProfile) {
+      setProfileToPreview(
+        formatProfileData(cloneDeep(previousProfile), { includePastStates: true })
+      )
+    }
+  }
+
   useEffect(() => {
     getProfiles()
   }, [pageNumber, filters, shouldReload, descOrder, pageSize, profileStateOption])
@@ -826,6 +836,7 @@ const UserModerationQueue = ({
           'tags',
         ]}
         showNextProfile={showNextProfile}
+        showPreviousProfile={showPreviousProfile}
         acceptUser={acceptUser}
         rejectUser={rejectUser}
       />

--- a/components/profile/ProfilePreviewModal.js
+++ b/components/profile/ProfilePreviewModal.js
@@ -16,6 +16,7 @@ const ProfilePreviewModal = ({
   contentToShow,
   sortFn,
   showNextProfile,
+  showPreviousProfile,
   acceptUser,
   rejectUser,
 }) => {
@@ -117,6 +118,9 @@ const ProfilePreviewModal = ({
       if (e.key === 'ArrowDown') {
         e.preventDefault()
         showNextProfile(profileToPreview.id)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        showPreviousProfile(profileToPreview.id)
       }
     }
     window.addEventListener('keydown', handleKeyDown)


### PR DESCRIPTION
Adds ArrowUp keyboard shortcut to navigate to the previous profile in the moderation queue, complementing the ArrowDown shortcut added in #2727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)