### PR TITLE
Sync static assets and move deployment.conf upload

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -123,7 +123,22 @@ jobs:
           sed -i "s/WEB_TAG=.*/WEB_TAG=\"$TAG\"/" ./deployment.conf
           sed -i '/^BUILD_ID=/d' ./deployment.conf
           echo "BUILD_ID=\"$build_id\"" >> ./deployment.conf
-          gsutil cp ./deployment.conf gs://openreview-general/conf/deployment.conf
+
+      - name: Sync static assets to GCS
+        if: steps.check-mapping.outputs.is_rollback == 'false'
+        env:
+          BUILD_ID: ${{ steps.build.outputs.build_id }}
+        run: |
+          if [ -d "$GITHUB_WORKSPACE/.next/static" ]; then
+            echo "$BUILD_ID" | gsutil cp - gs://openreview-general/static-upload-pending/${BUILD_ID}
+            gsutil -m rsync -r $GITHUB_WORKSPACE/.next/static/ gs://openreview-web-static/_next/static/
+            gsutil rm gs://openreview-general/static-upload-pending/${BUILD_ID}
+          elif gsutil -q stat "gs://openreview-general/static-upload-pending/${BUILD_ID}"; then
+            echo "ERROR: Static upload pending for ${BUILD_ID} from a previous failed run. Re-run with force_rebuild=true."
+            exit 1
+          else
+            echo "Build skipped and no pending upload — static files already in bucket."
+          fi
 
       - name: Setup Packer
         if: steps.check-mapping.outputs.is_rollback == 'false'
@@ -150,7 +165,9 @@ jobs:
         if: steps.check-mapping.outputs.is_rollback == 'false'
         env:
           IMAGE: ${{ steps.packer.outputs.image }}
-        run: echo "$IMAGE" | gsutil cp - gs://openreview-general/web-image-map/${TAG}
+        run: |
+          echo "$IMAGE" | gsutil cp - gs://openreview-general/web-image-map/${TAG}
+          gsutil cp $GITHUB_WORKSPACE/deployment.conf gs://openreview-general/conf/deployment.conf
 
       - name: Setup Terraform
         if: steps.check-mapping.outputs.is_rollback == 'false'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -134,8 +134,16 @@ jobs:
             gsutil -m rsync -r $GITHUB_WORKSPACE/.next/static/ gs://openreview-web-static/_next/static/
             gsutil rm gs://openreview-general/static-upload-pending/${BUILD_ID}
           elif gsutil -q stat "gs://openreview-general/static-upload-pending/${BUILD_ID}"; then
-            echo "ERROR: Static upload pending for ${BUILD_ID} from a previous failed run. Re-run with force_rebuild=true."
-            exit 1
+            if [ "${{ inputs.force_rebuild }}" = "true" ]; then
+              echo "Marker found with force_rebuild — extracting static files from existing artifact and retrying sync..."
+              gsutil cp "gs://openreview-general/openreview-web-builds/${BUILD_ID}.tar.gz" /tmp/${BUILD_ID}.tar.gz
+              tar -xzf /tmp/${BUILD_ID}.tar.gz -C /tmp/ "${BUILD_ID}/.next/static/"
+              gsutil -m rsync -r /tmp/${BUILD_ID}/.next/static/ gs://openreview-web-static/_next/static/
+              gsutil rm gs://openreview-general/static-upload-pending/${BUILD_ID}
+            else
+              echo "ERROR: Static upload pending for ${BUILD_ID} from a previous failed run. Re-run with force_rebuild=true."
+              exit 1
+            fi
           else
             echo "Build skipped and no pending upload — static files already in bucket."
           fi


### PR DESCRIPTION
## Summary

- Syncs `_next/static/` to `gs://openreview-web-static/_next/static/` before Packer runs, so content-hashed assets are available in GCS before MIG instances are replaced — eliminates rolling-update 404s on static chunks
- Moves `deployment.conf` upload from the build step to after Packer succeeds, so a rerun after a Packer failure doesn't corrupt the stored build ID

## How the static sync works

Static files are synced after the build and before Packer. A GCS marker (`static-upload-pending/${BUILD_ID}`) is written before the rsync and deleted on success. If the step fails mid-sync and is re-run, the marker is detected and the workflow fails loudly with instructions to use `force_rebuild=true` rather than silently leaving the bucket in a partial state.

If the build was skipped (artifact already exists), `.next/static/` won't be present. The step falls through to the marker check — no marker means files were already synced in a previous successful run, so it's a no-op.

The GCS bucket (`gs://openreview-web-static`) is managed in openreview-cloud and serves `/_next/static/*` via Cloud CDN. Content-hashed filenames accumulate across builds — no overwrites, no stale file risk.

## Test plan

- [ ] Full deploy — verify static sync step runs and files appear in `gs://openreview-web-static/_next/static/`
- [ ] Re-run same tag — verify build skipped, static sync falls through cleanly
- [ ] Rollback — static sync step is skipped (`is_rollback == true`), MIG rolls directly
