### PR TITLE
Fix/ Profile - handle Independent Researcher position in dropdowns and disable fields accordingly

### DIFF
--- a/app/profile/Profile.js
+++ b/app/profile/Profile.js
@@ -26,9 +26,14 @@ export default async function Profile({
     return (
       <div>
         {currentHistories?.map((history, index) => {
+          const isIndependentResearcher = history.position === 'Independent Researcher'
           const posititon = upperFirst(history.position).trim()
-          const department = history.institution.department?.trim()
-          const institutionName = history.institution.name?.trim()
+          const department = isIndependentResearcher
+            ? undefined
+            : history.institution.department?.trim()
+          const institutionName = isIndependentResearcher
+            ? undefined
+            : history.institution.name?.trim()
 
           return (
             <div

--- a/app/user/moderation/UserModerationTab.js
+++ b/app/user/moderation/UserModerationTab.js
@@ -89,12 +89,14 @@ export const RejectionModal = ({
       <Flex vertical gap="small" align="flex-start">
         <Select
           allowClear
+          mode="multiple"
           style={{ width: '100%' }}
-          placeholder="Choose a common reject reason..."
+          placeholder="Choose rejection reason(s)..."
           options={rejectionReasons}
+          getPopupContainer={(triggerNode) => triggerNode.parentElement}
           onChange={(value) => {
-            const rejectOption = rejectionReasons.find((r) => r.value === value)
-            setRejectionMessage(rejectOption?.rejectionText || '')
+            const rejectOptions = rejectionReasons.filter((r) => value.includes(r.value))
+            setRejectionMessage(rejectOptions.map((p) => p.rejectionText).join('\n\n'))
           }}
         />
         <Space wrap>

--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -72,10 +72,10 @@ const CustomMenuList = ({ children }) => (
   </List>
 )
 
-export const CreatableDropdown = (props) => {
+export const CreatableDropdown = ({ clientOnly, ...props }) => {
   const customTheme = createCustomTheme(props.height)
   const dropdownRef = useRef(null)
-  const [isClientRendering, setIsClientRendering] = useState(false)
+  const [isClientRendering, setIsClientRendering] = useState(clientOnly === true)
   let customComponents = {}
   if (props.hideArrow) {
     customComponents = {

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -1,12 +1,12 @@
+import { nanoid } from 'nanoid'
+import dynamic from 'next/dynamic'
 /* globals promptError,$: false */
 import { useEffect, useReducer, useState } from 'react'
-import dynamic from 'next/dynamic'
-import { nanoid } from 'nanoid'
-import Icon from '../Icon'
 import useBreakpoint from '../../hooks/useBreakPoint'
+import api from '../../lib/api-client'
 import { getStartEndYear } from '../../lib/utils'
 import Dropdown from '../Dropdown'
-import api from '../../lib/api-client'
+import Icon from '../Icon'
 
 const CreatableDropdown = dynamic(
   () => import('../Dropdown').then((mod) => mod.CreatableDropdown),
@@ -53,6 +53,7 @@ const EducationHistoryRow = ({
   const [isDomainClicked, setIsDomainClicked] = useState(false)
   const [isRegionClicked, setIsRegionClicked] = useState(false)
   const invalidFields = profileHistory?.find((q) => q.key === p.key)?.invalidFields
+  const isIndependentResearcher = p.position === 'Independent Researcher'
 
   const updateDomain = async (domain, key) => {
     if (!domain) {
@@ -96,6 +97,7 @@ const EducationHistoryRow = ({
         {isPositionClicked ? (
           <CreatableDropdown
             autofocus
+            clientOnly
             defaultMenuIsOpen
             hideArrow
             disableMouseMove
@@ -192,9 +194,10 @@ const EducationHistoryRow = ({
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-3">Institution Domain</div>}
-        {isDomainClicked ? (
+        {isDomainClicked && !isIndependentResearcher ? (
           <CreatableDropdown
             autofocus
+            clientOnly
             defaultMenuIsOpen
             hideArrow
             disableMouseMove
@@ -227,6 +230,7 @@ const EducationHistoryRow = ({
             }`}
             placeholder={institutionPlaceholder}
             value={p.institution?.domain}
+            disabled={isIndependentResearcher}
             onClick={() => setIsDomainClicked(true)}
             onFocus={() => setIsDomainClicked(true)}
             onChange={() => {}}
@@ -252,6 +256,7 @@ const EducationHistoryRow = ({
           }`}
           placeholder="Institution Name"
           value={p.institution?.name ?? ''}
+          disabled={isIndependentResearcher}
           onChange={(e) =>
             setHistory({
               type: institutionNameType,
@@ -402,7 +407,15 @@ const EducationHistorySection = ({
       case posititonType:
         return state.map((p) => {
           const recordCopy = { ...p }
-          if (p.key === action.data.key) recordCopy.position = action.data.value
+          if (p.key === action.data.key) {
+            recordCopy.position = action.data.value
+            if (action.data.value === 'Independent Researcher') {
+              recordCopy.institution = {
+                domain: 'independent.openreview.net',
+                name: 'Independent',
+              }
+            }
+          }
           return recordCopy
         })
       case institutionNameType:

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -412,7 +412,7 @@ const EducationHistorySection = ({
             if (action.data.value.toLowerCase().includes('independent')) {
               recordCopy.position = 'Independent Researcher'
               recordCopy.institution = {
-                domain: 'independent.openreview.net',
+                domain: 'independent-researcher.org',
                 name: 'Independent',
               }
             }

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -415,6 +415,14 @@ const EducationHistorySection = ({
                 domain: 'independent-researcher.org',
                 name: 'Independent',
               }
+            } else if (
+              p.position === 'Independent Researcher' &&
+              p.institution?.domain === 'independent-researcher.org'
+            ) {
+              recordCopy.institution = {
+                domain: '',
+                name: '',
+              }
             }
           }
           return recordCopy

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -409,7 +409,8 @@ const EducationHistorySection = ({
           const recordCopy = { ...p }
           if (p.key === action.data.key) {
             recordCopy.position = action.data.value
-            if (action.data.value === 'Independent Researcher') {
+            if (action.data.value.toLowerCase().includes('independent')) {
+              recordCopy.position = 'Independent Researcher'
               recordCopy.institution = {
                 domain: 'independent.openreview.net',
                 name: 'Independent',

--- a/components/profile/ProfilePreviewModal.js
+++ b/components/profile/ProfilePreviewModal.js
@@ -293,13 +293,14 @@ const ProfilePreviewModal = ({
             <Flex vertical gap="small" align="flex-start">
               <Select
                 allowClear
+                mode="multiple"
                 style={{ width: '100%' }}
-                placeholder="Choose a common reject reason..."
+                placeholder="Choose rejection reason(s)..."
                 options={rejectionReasons}
                 getPopupContainer={(triggerNode) => triggerNode.parentElement}
                 onChange={(value) => {
-                  const rejectOption = rejectionReasons.find((r) => r.value === value)
-                  setRejectionMessage(rejectOption?.rejectionText || '')
+                  const rejectOptions = rejectionReasons.filter((r) => value.includes(r.value))
+                  setRejectionMessage(rejectOptions.map((p) => p.rejectionText).join('\n\n'))
                 }}
               />
               <Space wrap>

--- a/components/profile/RelationsSection.js
+++ b/components/profile/RelationsSection.js
@@ -191,6 +191,7 @@ const RelationRow = ({
         {relationClicked ? (
           <CreatableDropdown
             autofocus
+            clientOnly
             defaultMenuIsOpen
             hideArrow
             disableMouseMove

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1778,12 +1778,6 @@ export function getRejectionReasons(currentInstitutionName) {
         "The homepage url provided in your profile is invalid or does not display your name/email used to register so your identity can't be determined.",
     },
     {
-      value: 'imPersonalHomepageAndEmail',
-      label: 'Homepage is invalid + no institution email',
-      rejectionText:
-        'A Homepage url which displays your name and institutional email matching your latest career/education history are required. Please confirm the institutional email by entering the verification token received after clicking confirm button next to the institutional email.',
-    },
-    {
       value: 'invalidName',
       label: 'Profile name is invalid',
       rejectionText:
@@ -1799,7 +1793,7 @@ export function getRejectionReasons(currentInstitutionName) {
       value: 'requestVouch',
       label: 'Request supervisor or coauthor to vouch',
       rejectionText:
-        'Please ask a supervisor or coauthor or colleague that already has an OpenReview profile to email us at info@openreview.net from the institutional email in their profile to vouch for your registration.\n\nThey should also add your profile ID to the Relations section of their profile.',
+        'Please ask a supervisor, coauthor, or colleague who already has an active OpenReview profile with a confirmed institutional email to vouch for you: they should add your profile ID to the Relations section of their profile, save their profile, and then click the vouch button next to your name. Your profile will be activated automatically once they vouch.',
     },
     {
       value: 'organizationProfile',


### PR DESCRIPTION
## Summary

Handles the **Independent Researcher** position in the profile editor. Extracted as a standalone PR from `fix/profile-edit-vouch-changes` (single atomic commit, no vouch/relations logic).

When a user's education-history position is set to `Independent Researcher` or any string containing independent:
- The institution domain auto-fills to `independent-researcher.org` / name `Independent`.
- The relevant institution fields are disabled (`EducationHistorySection.js`).
- Department/institution handling in `Profile.js` accounts for the independent-researcher case.
- Adds a `clientOnly` prop to `CreatableDropdown` (`Dropdown.js`) so the inline dropdown renders/focuses immediately instead of flashing a loading spinner; used by the position/relation dropdowns.


independent-researcher.org can later be used for independent researcher related update, for example a page listing research related submissions/tags