### PR TITLE
Fix/ Moderation - add domain search

### DIFF
--- a/app/user/moderation/UserModerationTab.js
+++ b/app/user/moderation/UserModerationTab.js
@@ -27,7 +27,13 @@ import LoadingSpinner from '../../../components/LoadingSpinner'
 import ProfilePreviewModal from '../../../components/profile/ProfilePreviewModal'
 import api from '../../../lib/api-client'
 import { formatProfileData } from '../../../lib/profiles'
-import { formatDateTime, getRejectionReasons, inflect, prettyId } from '../../../lib/utils'
+import {
+  formatDateTime,
+  getRejectionReasons,
+  inflect,
+  isValidDomain,
+  prettyId,
+} from '../../../lib/utils'
 
 import styles from './moderation.module.scss'
 import {
@@ -290,6 +296,7 @@ const UserModerationQueue = ({
   showSortButton = false,
 }) => {
   const [profiles, setProfiles] = useState(null)
+  const [isMultiTermSearch, setIsMultiTermSearch] = useState(false)
   const [totalCount, setTotalCount] = useState(0)
   const [pageNumber, setPageNumber] = useState(1)
   const [filters, setFilters] = useState({})
@@ -314,28 +321,36 @@ const UserModerationQueue = ({
   ].map((p) => ({ label: p, value: p }))
   const twoWeeksAgo = dayjs().subtract(2, 'week').valueOf()
 
+  const buildSearchQuery = (token) => {
+    if (token.startsWith('~')) return { id: token }
+    if (token.includes('@')) return { email: token.toLowerCase() }
+    if (isValidDomain(token.toLowerCase())) return { affiliationDomain: token.toLowerCase() }
+    return { fullname: token.toLowerCase() }
+  }
+
+  const isStructuredToken = (token) =>
+    token.startsWith('~') || token.includes('@') || isValidDomain(token.toLowerCase())
+
   const getProfiles = async () => {
     const queryOptions = onlyModeration ? { needsModeration: true } : {}
     const cleanSearchTerm = filters.term?.trim()
     const shouldSearchProfile = profileStateOption === 'All' && cleanSearchTerm
     const sortKey = onlyModeration ? 'tmdate' : 'tcdate'
-    let searchQuery = { fullname: cleanSearchTerm?.toLowerCase() }
-    if (cleanSearchTerm?.startsWith('~')) searchQuery = { id: cleanSearchTerm }
-    if (cleanSearchTerm?.includes('@')) searchQuery = { email: cleanSearchTerm.toLowerCase() }
+    const searchQuery = cleanSearchTerm ? buildSearchQuery(cleanSearchTerm) : {}
 
     try {
       const searchTokens = cleanSearchTerm ? cleanSearchTerm.split(/\s+/) : []
       if (
         profileStateOption === 'All' &&
         searchTokens.length > 1 &&
-        searchTokens.every((t) => t.startsWith('~') || t.includes('@'))
+        searchTokens.every(isStructuredToken)
       ) {
         const results = await Promise.all(
           searchTokens.map((token) =>
             api.get(
               '/profiles/search',
               {
-                ...(token.startsWith('~') ? { id: token } : { email: token.toLowerCase() }),
+                ...buildSearchQuery(token),
                 es: true,
                 withBlocked: true,
                 trash: true,
@@ -350,6 +365,7 @@ const UserModerationQueue = ({
         )
         setTotalCount(merged.length)
         setProfiles(merged)
+        setIsMultiTermSearch(true)
         return
       }
 
@@ -371,6 +387,7 @@ const UserModerationQueue = ({
       )
       setTotalCount(result.count ?? 0)
       setProfiles(result.profiles ?? [])
+      setIsMultiTermSearch(false)
     } catch (error) {
       promptError(error.message)
     }
@@ -536,6 +553,11 @@ const UserModerationQueue = ({
     getProfiles()
   }, [pageNumber, filters, shouldReload, descOrder, pageSize, profileStateOption])
 
+  const profilesToDisplay =
+    isMultiTermSearch && profiles
+      ? profiles.slice((pageNumber - 1) * pageSize, pageNumber * pageSize)
+      : profiles
+
   return (
     <div style={{ marginBottom: '1.75rem' }}>
       <Flex align="center">
@@ -565,6 +587,7 @@ const UserModerationQueue = ({
           <Input
             type="text"
             className={styles.searchinput}
+            placeholder="Search by name, email, tilde id, or domain"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             onPressEnter={filterProfiles}
@@ -592,7 +615,7 @@ const UserModerationQueue = ({
 
       {profiles ? (
         <Flex vertical gap="small" style={{ marginBottom: '1.5rem' }}>
-          {profiles.map((profile) => {
+          {profilesToDisplay.map((profile) => {
             const name = profile.content.names?.[0]
             const state =
               profile.ddate && profile.state !== 'Merged' ? 'Deleted' : profile.state


### PR DESCRIPTION
this pr should allow domain (email domain + history domain) search in moderation page
this pr should also fix the display of results from multiple search keywords
- currently it just show all search results because searching by name/tilde id would not return many results
- but for domain search it can return many results so the pagination will do a local slice before showing the result

one potential problem is that when searching for names in the form of a valid domain, the search query will be wrong
if it become a real concern then need to implement a search category dropdown to checkbox to clearly indicate the search category intention instead of guessing based on search term

related to https://github.com/openreview/openreview-api/pull/1147