### PR TITLE
Fix/ JSON editor - Update type of max length

### DIFF
--- a/components/EditorComponents/ContentFieldEditor.js
+++ b/components/EditorComponents/ContentFieldEditor.js
@@ -1,15 +1,16 @@
-import { useContext, useState } from 'react'
 import { get, set, unset } from 'lodash'
+import { useContext, useState } from 'react'
+import { convertToType } from '../../lib/webfield-utils'
+import Dropdown from '../Dropdown'
 import EditorComponentContext from '../EditorComponentContext'
+import Form from '../Form'
+import Icon from '../Icon'
+import NoteEditor from '../NoteEditor'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '../Tabs'
 import CodeEditorWidget from './CodeEditorWidget'
-import Dropdown from '../Dropdown'
-import Form from '../Form'
-import NoteEditor from '../NoteEditor'
 import EditorComponentHeader from './EditorComponentHeader'
+
 import styles from '../../styles/components/ContentFieldEditor.module.scss'
-import Icon from '../Icon'
-import { convertToType } from '../../lib/webfield-utils'
 
 const JsonEditor = ({ existingFields, onFieldChange }) => {
   const [mode, setMode] = useState('empty')
@@ -233,23 +234,23 @@ const JsonEditor = ({ existingFields, onFieldChange }) => {
       },
       valuePath: 'value.param.regex',
     },
-    range: {
-      order: 9,
-      description: 'Range of the field, for exmaple 1,99',
-      value: {
-        param: {
-          input: 'text',
-          type: 'string',
-          optional: true,
-        },
-      },
-      shouldBeShown: (formData) =>
-        ['integer', 'float'].includes(formData.dataType) && formData.inputType === 'text',
-      getValue: function (existingValue) {
-        return get(existingValue, this.valuePath)
-      },
-      valuePath: 'value.param.range',
-    },
+    // range: {
+    //   order: 9,
+    //   description: 'Range of the field, for exmaple 1,99',
+    //   value: {
+    //     param: {
+    //       input: 'text',
+    //       type: 'string',
+    //       optional: true,
+    //     },
+    //   },
+    //   shouldBeShown: (formData) =>
+    //     ['integer', 'float'].includes(formData.dataType) && formData.input === 'text',
+    //   getValue: function (existingValue) {
+    //     return get(existingValue, this.valuePath)
+    //   },
+    //   valuePath: 'value.param.range',
+    // },
     fieldName: {
       order: 9,
       description: 'The Text to display as name of the field',
@@ -272,7 +273,7 @@ const JsonEditor = ({ existingFields, onFieldChange }) => {
       value: {
         param: {
           input: 'text',
-          type: 'string',
+          type: 'integer',
           optional: true,
         },
       },
@@ -288,7 +289,7 @@ const JsonEditor = ({ existingFields, onFieldChange }) => {
       value: {
         param: {
           input: 'text',
-          type: 'string',
+          type: 'integer',
           optional: true,
         },
       },
@@ -304,7 +305,7 @@ const JsonEditor = ({ existingFields, onFieldChange }) => {
       value: {
         param: {
           input: 'text',
-          type: 'string',
+          type: 'integer',
           optional: true,
         },
       },
@@ -323,7 +324,7 @@ const JsonEditor = ({ existingFields, onFieldChange }) => {
       value: {
         param: {
           input: 'text',
-          type: 'string',
+          type: 'integer',
           optional: true,
         },
       },
@@ -390,7 +391,7 @@ const JsonEditor = ({ existingFields, onFieldChange }) => {
       description: 'The max file size allowed for user to upload',
       value: {
         param: {
-          type: 'number',
+          type: 'integer',
           input: 'text',
           optional: true,
         },

--- a/unitTests/ContentFieldEditor.test.js
+++ b/unitTests/ContentFieldEditor.test.js
@@ -1,8 +1,8 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import ContentFieldEditor from '../components/EditorComponents/ContentFieldEditor'
 import { renderWithEditorComponentContext } from './util'
 import '@testing-library/jest-dom'
-import ContentFieldEditor from '../components/EditorComponents/ContentFieldEditor'
 
 let mockedFormProps
 let onFormChange
@@ -172,7 +172,7 @@ describe('ContentFieldEditor', () => {
       })
     )
 
-    expect(Object.keys(mockedFormProps.mock.calls[0][0].fields)).toHaveLength(22) // 22 fields defined for a field (removed hidden)
+    expect(Object.keys(mockedFormProps.mock.calls[0][0].fields)).toHaveLength(21) // 21 fields defined for a field (removed hidden and range)
   })
 
   test('update invitation content editor when widget form is updated', async () => {


### PR DESCRIPTION
this pr should change the type of 
- minLength
- maxLength
- minimum
- maximum
- maxSize

in json editor widget to integer so that type conversion can convert the string value to the type api is expecting.

this pr should also fix a typo bug in range which cause range not be to shown at all
so looks like range is not used and the type conversion logic is a bit complex so comment it out for now

one thing to notice is that api expect number for maxSize but integer for minimum/maximum 
but the type conversion will not know whether to convert to integer or float so set them all to integer