### PR TITLE
Fix/ Allow Custom Author in ProfileSearchWithInstitutionWidget

### DIFF
--- a/ThemeProvider.js
+++ b/ThemeProvider.js
@@ -90,6 +90,9 @@ const theme = {
       colorInfoBg: '#dff0d8',
       width: '80vw',
     },
+    Tooltip: {
+      colorBgSpotlight: 'rgba(44, 58, 74, 0.9)',
+    },
   },
 }
 

--- a/components/EditorComponents/ProfileSearchWithInstitutionWidget.js
+++ b/components/EditorComponents/ProfileSearchWithInstitutionWidget.js
@@ -1,6 +1,3 @@
-/* globals promptError, $: false */
-
-import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import {
   DndContext,
   PointerSensor,
@@ -9,18 +6,21 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
-import { throttle, maxBy } from 'lodash'
 import { arrayMove, SortableContext, useSortable } from '@dnd-kit/sortable'
+import { throttle, maxBy } from 'lodash'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import useUser from '../../hooks/useUser'
-import EditorComponentContext from '../EditorComponentContext'
-import styles from '../../styles/components/ProfileSearchWidget.module.scss'
 import api from '../../lib/api-client'
 import { getProfileName, inflect, isValidEmail } from '../../lib/utils'
+import EditorComponentContext from '../EditorComponentContext'
 import Icon from '../Icon'
 import IconButton from '../IconButton'
-import MultiSelectorDropdown from '../MultiSelectorDropdown'
 import LoadingSpinner from '../LoadingSpinner'
+import MultiSelectorDropdown from '../MultiSelectorDropdown'
 import PaginationLinks from '../PaginationLinks'
+import SpinnerButton from '../SpinnerButton'
+
+import styles from '../../styles/components/ProfileSearchWidget.module.scss'
 
 const mapDisplayAuthorsToEditorValue = (displayAuthors, hasInstitutionProperty) =>
   displayAuthors.map((p) => ({
@@ -143,17 +143,28 @@ const Author = ({
           </div>
         )}
         <div className={styles.authorName}>
-          <a
-            href={`/profile?id=${profile.username}`}
-            data-original-title={isDragging ? null : username}
-            data-toggle="tooltip"
-            data-placement="top"
-            target="_blank"
-            rel="noreferrer"
-            className={styles.authorNameLink}
-          >
-            {profile.fullname}
-          </a>
+          {username?.startsWith('~') ? (
+            <a
+              href={`/profile?id=${profile.username}`}
+              data-original-title={isDragging ? null : username}
+              data-toggle="tooltip"
+              data-placement="top"
+              target="_blank"
+              rel="noreferrer"
+              className={styles.authorNameLink}
+            >
+              {profile.fullname}
+            </a>
+          ) : (
+            <span
+              className={styles.authorNameLink}
+              data-original-title={isDragging ? null : username}
+              data-toggle="tooltip"
+              data-placement="top"
+            >
+              {profile.fullname}
+            </span>
+          )}
         </div>
         <div className={styles.actionButtons}>
           {allowAddRemove && (
@@ -299,12 +310,14 @@ const ProfileSearchFormAndResults = ({
   onChange,
   clearError,
   hasInstitutionProperty,
+  allowEmailAuthor,
 }) => {
   const [searchTerm, setSearchTerm] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [pageNumber, setPageNumber] = useState(null)
   const [totalCount, setTotalCount] = useState(0)
   const [profileSearchResults, setProfileSearchResults] = useState(null)
+  const [showCustomAuthorForm, setShowCustomAuthorForm] = useState(false)
   const { accessToken } = useUser()
   const pageSize = 20
 
@@ -340,9 +353,8 @@ const ProfileSearchFormAndResults = ({
     if (showLoadingSpinner) setIsLoading(false)
   }
 
-  const displayResults = () => {
-    if (!profileSearchResults) return null
-    if (!profileSearchResults.length)
+  const displayCustomAuthorForm = (isEmptyResult) => {
+    if (!allowEmailAuthor && isEmptyResult)
       return (
         <div className={styles.noMatchingProfile}>
           <div className={styles.noMatchingProfileMessage}>
@@ -350,6 +362,43 @@ const ProfileSearchFormAndResults = ({
           </div>
         </div>
       )
+    if (!allowEmailAuthor) return null
+    return (
+      <div className={styles.noMatchingProfile}>
+        {showCustomAuthorForm ? (
+          <CustomAuthorForm
+            setTotalCount={setTotalCount}
+            setProfileSearchResults={setProfileSearchResults}
+            setSearchTerm={setSearchTerm}
+            displayAuthors={displayAuthors}
+            setDisplayAuthors={setDisplayAuthors}
+            fieldName={Object.keys(field ?? {})[0]}
+            onChange={onChange}
+            clearError={clearError}
+            hasInstitutionProperty={hasInstitutionProperty}
+          />
+        ) : (
+          <>
+            <div className={styles.noMatchingProfileMessage}>
+              {isEmptyResult
+                ? 'No results found for your search query.'
+                : 'Profile not found? Provide their information by clicking button below.'}
+            </div>
+            <button
+              className={`btn btn-xs ${styles.enterAuthorButton}`}
+              onClick={() => setShowCustomAuthorForm(true)}
+            >
+              Manually Enter Author Info
+            </button>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  const displayResults = () => {
+    if (!profileSearchResults) return null
+    if (!profileSearchResults.length) return displayCustomAuthorForm(true)
 
     return (
       <div className={styles.searchResults}>
@@ -376,6 +425,8 @@ const ProfileSearchFormAndResults = ({
             options={{ noScroll: true, showCount: false }}
           />
         </>
+
+        {(pageNumber ?? 1) * pageSize >= totalCount && displayCustomAuthorForm(false)}
       </div>
     )
   }
@@ -397,6 +448,7 @@ const ProfileSearchFormAndResults = ({
         className={styles.searchForm}
         onSubmit={(e) => {
           e.preventDefault()
+          setShowCustomAuthorForm(false)
           searchProfiles(searchTerm, 1)
           setPageNumber(null)
         }}
@@ -425,6 +477,77 @@ const ProfileSearchFormAndResults = ({
   )
 }
 
+const CustomAuthorForm = ({
+  setTotalCount,
+  setProfileSearchResults,
+  setSearchTerm,
+  displayAuthors,
+  setDisplayAuthors,
+  fieldName,
+  onChange,
+  clearError,
+  hasInstitutionProperty,
+}) => {
+  const [customAuthorName, setCustomAuthorName] = useState('')
+  const [customAuthorEmail, setCustomAuthorEmail] = useState('')
+
+  const disableAddButton =
+    !(customAuthorName.trim() && isValidEmail(customAuthorEmail)) ||
+    displayAuthors?.some((p) => p.username === customAuthorEmail.trim().toLowerCase())
+
+  const handleAddCustomAuthor = () => {
+    const cleanAuthorName = customAuthorName.trim()
+    const cleanAuthorEmail = customAuthorEmail.trim().toLowerCase()
+
+    clearError?.()
+    const updatedAuthors = displayAuthors.concat({
+      username: cleanAuthorEmail,
+      fullname: cleanAuthorName,
+      selectedInstitutions: [],
+      institutionOptions: [],
+    })
+    setDisplayAuthors(updatedAuthors)
+    onChange({
+      fieldName,
+      value: mapDisplayAuthorsToEditorValue(updatedAuthors, hasInstitutionProperty),
+    })
+
+    setTotalCount(0)
+    setProfileSearchResults(null)
+    setSearchTerm('')
+  }
+
+  return (
+    <form className={styles.customAuthorForm}>
+      <label htmlFor="fullName">Full Name:</label>
+      <input
+        type="text"
+        name="fullName"
+        className="form-control"
+        value={customAuthorName}
+        placeholder="Full name of the author to add"
+        onChange={(e) => setCustomAuthorName(e.target.value)}
+      />
+      <label htmlFor="email">Email:</label>
+      <input
+        type="email"
+        name="email"
+        className="form-control"
+        value={customAuthorEmail}
+        placeholder="Email of the author to add"
+        onChange={(e) => setCustomAuthorEmail(e.target.value)}
+      />
+      <SpinnerButton
+        className="btn btn-sm"
+        disabled={disableAddButton}
+        onClick={handleAddCustomAuthor}
+      >
+        Add
+      </SpinnerButton>
+    </form>
+  )
+}
+
 const ProfileSearchWithInstitutionWidget = () => {
   const { user, accessToken, isRefreshing } = useUser()
   const {
@@ -444,6 +567,12 @@ const ProfileSearchWithInstitutionWidget = () => {
     field?.authors?.value?.param?.properties?.institutions || // add institution
     field?.authors?.value?.param?.elements || // reorder with institution change
     (reorderOnly && field.authors.value?.[0]?.institutions) // reorder only institution exists
+
+  const allowEmailAuthor =
+    ((!hasInstitutionProperty ||
+      field?.authors?.value?.param?.properties?.institutions?.param?.optional) && // email author won't have institution
+      field?.authors?.value?.param?.properties?.username?.param?.regex?.includes('|')) ?? // username need to allow email
+    false
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor))
   const [displayAuthors, setDisplayAuthors] = useState(null)
@@ -473,11 +602,13 @@ const ProfileSearchWithInstitutionWidget = () => {
   }
 
   const getProfiles = async (authorIds) => {
+    const ids = authorIds.filter((p) => p.startsWith('~'))
+    if (!ids.length) return []
     try {
       const { profiles } = await api.post(
         '/profiles/search',
         {
-          ids: authorIds,
+          ids,
         },
         { accessToken }
       )
@@ -522,23 +653,25 @@ const ProfileSearchWithInstitutionWidget = () => {
         p.content.names.find((q) => q.username === author.username)
       )
       const institutionOptionsFromProfile = getCurrentInstitutionOptionsFromProfile(profile)
-      const institutionOptionsFromValue = author.institutions.flatMap((institution) => {
-        if (institutionOptionsFromProfile.find((p) => p.domain === institution.domain))
-          // institution selected before still exist in profile
-          return []
-        return {
-          label: `${institution.name} (${institution.domain})`,
-          value: institution.domain,
-          name: institution.name,
-          domain: institution.domain,
-          country: institution.country,
+      const institutionOptionsFromValue = (author.institutions ?? []).flatMap(
+        (institution) => {
+          if (institutionOptionsFromProfile.find((p) => p.domain === institution.domain))
+            // institution selected before still exist in profile
+            return []
+          return {
+            label: `${institution.name} (${institution.domain})`,
+            value: institution.domain,
+            name: institution.name,
+            domain: institution.domain,
+            country: institution.country,
+          }
         }
-      })
+      )
 
       return {
         username: author.username,
         fullname: author.fullname,
-        selectedInstitutions: author.institutions,
+        selectedInstitutions: author.institutions ?? [],
         institutionOptions: [...institutionOptionsFromValue, ...institutionOptionsFromProfile],
       }
     })
@@ -609,6 +742,7 @@ const ProfileSearchWithInstitutionWidget = () => {
           onChange={onChange}
           clearError={clearError}
           hasInstitutionProperty={hasInstitutionProperty}
+          allowEmailAuthor={allowEmailAuthor}
         />
       )}
     </div>

--- a/components/EditorComponents/ProfileSearchWithInstitutionWidget.js
+++ b/components/EditorComponents/ProfileSearchWithInstitutionWidget.js
@@ -457,7 +457,7 @@ const ProfileSearchFormAndResults = ({
           type="text"
           className={`form-control ${error ? styles.invalidValue : ''}`}
           value={searchTerm ?? ''}
-          placeholder="search profiles by email or name"
+          placeholder="search profiles by name or OpenReview profile ID"
           onChange={(e) => {
             setSearchTerm(e.target.value)
             setProfileSearchResults(null)

--- a/components/NoteAuthors.js
+++ b/components/NoteAuthors.js
@@ -246,14 +246,18 @@ export const NoteAuthorsWithInstitutions = ({ authors, noteReaders }) => {
         key={`${author.fullname} ${author.username}`}
         className="note-author-with-institutions"
       >
-        <Link
-          href={`/profile?id=${encodeURIComponent(author.username)}`}
-          title={author.username}
-          data-toggle="tooltip"
-          data-placement="top"
-        >
-          {author.fullname}
-        </Link>
+        {author.username.includes('@') ? (
+          <span>{author.fullname}</span>
+        ) : (
+          <Link
+            href={`/profile?id=${encodeURIComponent(author.username)}`}
+            title={author.username}
+            data-toggle="tooltip"
+            data-placement="top"
+          >
+            {author.fullname}
+          </Link>
+        )}
         {institutionNumbers.length > 0 && <sup>{institutionNumbers.join(',')}</sup>}
       </span>
     )

--- a/components/NoteAuthors.js
+++ b/components/NoteAuthors.js
@@ -1,3 +1,4 @@
+import { Tooltip } from 'antd'
 import isEqual from 'lodash/isEqual'
 /* globals $: false */
 import uniqBy from 'lodash/uniqBy'
@@ -223,17 +224,11 @@ export const NoteAuthorsWithInstitutions = ({ authors, noteReaders }) => {
     if (!author.username) return <span key={author.fullname}>{author.fullname}</span>
     if (author.username.startsWith('https://dblp.org')) {
       return (
-        <a
-          key={`${author.fullname} ${author.username}`}
-          href={author.username}
-          title={author.username}
-          data-toggle="tooltip"
-          data-placement="top"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {author.fullname}
-        </a>
+        <Tooltip key={`${author.fullname} ${author.username}`} title={author.username}>
+          <a href={author.username} target="_blank" rel="noopener noreferrer">
+            {author.fullname}
+          </a>
+        </Tooltip>
       )
     }
 
@@ -246,18 +241,15 @@ export const NoteAuthorsWithInstitutions = ({ authors, noteReaders }) => {
         key={`${author.fullname} ${author.username}`}
         className="note-author-with-institutions"
       >
-        {author.username.includes('@') ? (
-          <span>{author.fullname}</span>
-        ) : (
-          <Link
-            href={`/profile?id=${encodeURIComponent(author.username)}`}
-            title={author.username}
-            data-toggle="tooltip"
-            data-placement="top"
-          >
-            {author.fullname}
-          </Link>
-        )}
+        <Tooltip title={author.username}>
+          {author.username.includes('@') ? (
+            <span>{author.fullname}</span>
+          ) : (
+            <Link href={`/profile?id=${encodeURIComponent(author.username)}`}>
+              {author.fullname}
+            </Link>
+          )}
+        </Tooltip>
         {institutionNumbers.length > 0 && <sup>{institutionNumbers.join(',')}</sup>}
       </span>
     )

--- a/unitTests/NoteAuthors.test.js
+++ b/unitTests/NoteAuthors.test.js
@@ -49,6 +49,24 @@ describe('NoteAuthorsV2', () => {
     expect(screen.getByText(/Test Domain/)).toBeInTheDocument()
   })
 
+  // email author added with object author schema has no profile link
+  test('renders institution email author as plain text', () => {
+    const authors = {
+      value: [{ fullname: 'Custom Author', username: 'custom@author.com', institutions: [] }],
+      readers: ['everyone'],
+    }
+    render(
+      <NoteAuthorsV2
+        authors={authors}
+        authorIds={undefined}
+        noteReaders={['everyone']}
+        showAuthorInstitutions
+      />
+    )
+    expect(screen.getByText('Custom Author')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
   test('builds profile link with id param for ~ ids', () => {
     render(<NoteAuthorsV2 authors={['First Last']} authorIds={['~First_Last1']} />)
     expect(screen.getByRole('link', { name: 'First Last' })).toHaveAttribute(

--- a/unitTests/ProfileSearchWithInstitutionWidget.test.js
+++ b/unitTests/ProfileSearchWithInstitutionWidget.test.js
@@ -1,10 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ProfileSearchWithInstitutionWidget from '../components/EditorComponents/ProfileSearchWithInstitutionWidget'
+import api from '../lib/api-client'
 import { renderWithEditorComponentContext, reRenderWithEditorComponentContext } from './util'
 import '@testing-library/jest-dom'
-
-import api from '../lib/api-client'
 
 jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
 jest.mock('../hooks/useUser', () => () => ({
@@ -1476,5 +1475,474 @@ describe('ProfileSearchWithInstitutionWidget', () => {
         })
       )
     })
+  })
+
+  test('allow custom author when username regex allows email and institution does not exist', async () => {
+    api.post = jest.fn(() =>
+      Promise.resolve({
+        profiles: [
+          {
+            id: '~test_id1',
+            content: {
+              names: [{ fullname: 'Test First Test Last', username: '~test_id1' }],
+              preferredEmail: 'test@email.com',
+              history: [],
+            },
+          },
+        ],
+      })
+    )
+    api.get = jest.fn(() => Promise.resolve({ count: 0, profiles: [] }))
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          authors: {
+            value: {
+              param: {
+                type: 'author{}',
+                properties: {
+                  fullname: { param: { type: 'string' } },
+                  username: {
+                    param: {
+                      type: 'string',
+                      regex: '^~\\S+$|^.+@.+$',
+                    },
+                  },
+
+                  institutions: undefined,
+                },
+              },
+            },
+          },
+        },
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<ProfileSearchWithInstitutionWidget />, providerProps)
+
+    // current user is added on mount
+    await waitFor(() => expect(screen.getByText('Test First Test Last')).toBeInTheDocument())
+
+    // a search that returns nothing
+    await userEvent.type(
+      screen.getByPlaceholderText('search profiles by email or name'),
+      'Nonexistent Author'
+    )
+    await userEvent.click(screen.getByText('Search'))
+
+    // manual entry is offered because the username regex allows email
+    const manualButton = await screen.findByRole('button', {
+      name: 'Manually Enter Author Info',
+    })
+    await userEvent.click(manualButton)
+
+    await userEvent.type(
+      screen.getByPlaceholderText('Full name of the author to add'),
+      'New Author'
+    )
+    await userEvent.type(
+      screen.getByPlaceholderText('Email of the author to add'),
+      'New@Author.com'
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fieldName: 'authors',
+          value: expect.arrayContaining([
+            { username: 'new@author.com', fullname: 'New Author' },
+          ]),
+        })
+      )
+    })
+  })
+
+  test('allow custom author when username regex allows email and institution is optional', async () => {
+    api.post = jest.fn(() =>
+      Promise.resolve({
+        profiles: [
+          {
+            id: '~test_id1',
+            content: {
+              names: [{ fullname: 'Test First Test Last', username: '~test_id1' }],
+              preferredEmail: 'test@email.com',
+              history: [],
+            },
+          },
+        ],
+      })
+    )
+    api.get = jest.fn(() => Promise.resolve({ count: 0, profiles: [] }))
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          authors: {
+            value: {
+              param: {
+                type: 'author{}',
+                properties: {
+                  fullname: { param: { type: 'string' } },
+                  username: {
+                    param: {
+                      type: 'string',
+                      regex: '^~\\S+$|^.+@.+$',
+                    },
+                  },
+
+                  institutions: {
+                    param: {
+                      type: 'object{}',
+                      optional: true,
+                      properties: {
+                        name: { param: { type: 'string' } },
+                        domain: { param: { type: 'string' } },
+                        country: { param: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<ProfileSearchWithInstitutionWidget />, providerProps)
+
+    // current user is added on mount
+    await waitFor(() => expect(screen.getByText('Test First Test Last')).toBeInTheDocument())
+
+    // a search that returns nothing
+    await userEvent.type(
+      screen.getByPlaceholderText('search profiles by email or name'),
+      'Nonexistent Author'
+    )
+    await userEvent.click(screen.getByText('Search'))
+
+    // manual entry is offered because the username regex allows email
+    const manualButton = await screen.findByRole('button', {
+      name: 'Manually Enter Author Info',
+    })
+    await userEvent.click(manualButton)
+
+    await userEvent.type(
+      screen.getByPlaceholderText('Full name of the author to add'),
+      'New Author'
+    )
+    await userEvent.type(
+      screen.getByPlaceholderText('Email of the author to add'),
+      'New@Author.com'
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fieldName: 'authors',
+          value: expect.arrayContaining([
+            { username: 'new@author.com', fullname: 'New Author', institutions: [] },
+          ]),
+        })
+      )
+    })
+  })
+
+  test('do not show custom author form when email author is not allowed', async () => {
+    api.post = jest.fn(() =>
+      Promise.resolve({
+        profiles: [
+          {
+            id: '~test_id1',
+            content: {
+              names: [{ fullname: 'Test First Test Last', username: '~test_id1' }],
+              preferredEmail: 'test@email.com',
+              history: [],
+            },
+          },
+        ],
+      })
+    )
+    api.get = jest.fn(() => Promise.resolve({ count: 0, profiles: [] }))
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          authors: {
+            order: 2,
+            value: {
+              param: {
+                type: 'author{}',
+                properties: {
+                  fullname: {
+                    param: {
+                      type: 'string',
+                    },
+                  },
+                  username: {
+                    param: {
+                      type: 'string',
+                      regex: '|',
+                    },
+                  },
+                  institutions: {
+                    param: {
+                      type: 'object{}',
+                      optional: false,
+                      properties: {
+                        name: {
+                          param: {
+                            type: 'string',
+                          },
+                        },
+                        domain: {
+                          param: {
+                            type: 'string',
+                          },
+                        },
+                        country: {
+                          param: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            description: 'Authors of paper.',
+          },
+        },
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<ProfileSearchWithInstitutionWidget />, providerProps)
+
+    await waitFor(() => expect(screen.getByText('Test First Test Last')).toBeInTheDocument())
+
+    await userEvent.type(
+      screen.getByPlaceholderText('search profiles by email or name'),
+      'Nonexistent Author'
+    )
+    await userEvent.click(screen.getByText('Search'))
+
+    expect(
+      await screen.findByText('No results found for your search query.')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Manually Enter Author Info' })
+    ).not.toBeInTheDocument()
+  })
+
+  test('show email author as text without a profile link', async () => {
+    api.post = jest.fn(() => Promise.resolve({ profiles: [] }))
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          authors: {
+            value: {
+              param: {
+                type: 'author{}',
+                properties: {
+                  fullname: { param: { type: 'string' } },
+                  username: {
+                    param: {
+                      type: 'string',
+                      regex: '^~\\S+$|^.+@.+$',
+                    },
+                  },
+
+                  institutions: {
+                    param: {
+                      type: 'object{}',
+                      optional: true,
+                      properties: {
+                        name: { param: { type: 'string' } },
+                        domain: { param: { type: 'string' } },
+                        country: { param: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        value: [{ username: 'email@author.com', fullname: 'Email Author', institutions: [] }],
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<ProfileSearchWithInstitutionWidget />, providerProps)
+
+    await waitFor(() => expect(screen.getByText('Email Author')).toBeInTheDocument())
+
+    // rendered as a span, not a /profile link
+    expect(screen.getByText('Email Author')).not.toHaveAttribute('href')
+    // email is kept as the tooltip
+    expect(screen.getByText('Email Author')).toHaveAttribute(
+      'data-original-title',
+      'email@author.com'
+    )
+    // no institution to choose for an email-only author
+    expect(screen.getByRole('button', { name: 'No Active Institution' })).toBeDisabled()
+  })
+
+  test('load existing authors with a mix of tilde id and email', async () => {
+    global.promptError = jest.fn()
+    const apiPost = jest.fn(() =>
+      Promise.resolve({
+        profiles: [
+          {
+            id: '~test_id1',
+            content: {
+              names: [{ fullname: 'Test First Test Last', username: '~test_id1' }],
+              preferredEmail: 'test@email.com',
+              history: [],
+            },
+          },
+        ],
+      })
+    )
+    api.post = apiPost
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          authors: {
+            value: {
+              param: {
+                type: 'author{}',
+                properties: {
+                  fullname: { param: { type: 'string' } },
+                  username: {
+                    param: {
+                      type: 'string',
+                      regex: '^~\\S+$|^.+@.+$',
+                    },
+                  },
+
+                  institutions: {
+                    param: {
+                      type: 'object{}',
+                      optional: true,
+                      properties: {
+                        name: { param: { type: 'string' } },
+                        domain: { param: { type: 'string' } },
+                        country: { param: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        value: [
+          { username: '~test_id1', fullname: 'Test First Test Last', institutions: [] },
+          { username: 'email@author.com', fullname: 'Email Author', institutions: [] },
+        ],
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<ProfileSearchWithInstitutionWidget />, providerProps)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test First Test Last')).toBeInTheDocument()
+      expect(screen.getByText('Email Author')).toBeInTheDocument()
+    })
+
+    // tilde author keeps the profile link, email author is plain text
+    expect(screen.getByText('Test First Test Last')).toHaveAttribute(
+      'href',
+      '/profile?id=~test_id1'
+    )
+    expect(screen.getByText('Email Author')).not.toHaveAttribute('href')
+
+    // only the tilde id is sent to /profiles/search; the email is filtered out
+    expect(apiPost).toHaveBeenCalledWith(
+      '/profiles/search',
+      { ids: ['~test_id1'] },
+      expect.anything()
+    )
+    expect(global.promptError).not.toHaveBeenCalled()
+  })
+
+  test('disable add button for a duplicate email author', async () => {
+    // it's possible to duplicate by mixing tildeId and email though because can't get profile by email
+    api.post = jest.fn(() => Promise.resolve({ profiles: [] }))
+    api.get = jest.fn(() => Promise.resolve({ count: 0, profiles: [] }))
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: {
+          authors: {
+            value: {
+              param: {
+                type: 'author{}',
+                properties: {
+                  fullname: { param: { type: 'string' } },
+                  username: {
+                    param: {
+                      type: 'string',
+                      regex: '^~\\S+$|^.+@.+$',
+                    },
+                  },
+
+                  institutions: {
+                    param: {
+                      type: 'object{}',
+                      optional: true,
+                      properties: {
+                        name: { param: { type: 'string' } },
+                        domain: { param: { type: 'string' } },
+                        country: { param: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        value: [{ username: 'email@author.com', fullname: 'Email Author', institutions: [] }],
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<ProfileSearchWithInstitutionWidget />, providerProps)
+
+    await waitFor(() => expect(screen.getByText('Email Author')).toBeInTheDocument())
+
+    await userEvent.type(
+      screen.getByPlaceholderText('search profiles by email or name'),
+      'Nonexistent Author'
+    )
+    await userEvent.click(screen.getByText('Search'))
+
+    const manualButton = await screen.findByRole('button', {
+      name: 'Manually Enter Author Info',
+    })
+    await userEvent.click(manualButton)
+
+    await userEvent.type(
+      screen.getByPlaceholderText('Full name of the author to add'),
+      'Email Author'
+    )
+    await userEvent.type(
+      screen.getByPlaceholderText('Email of the author to add'),
+      'Email@Author.com'
+    )
+
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
   })
 })

--- a/unitTests/ProfileSearchWithInstitutionWidget.test.js
+++ b/unitTests/ProfileSearchWithInstitutionWidget.test.js
@@ -1527,7 +1527,7 @@ describe('ProfileSearchWithInstitutionWidget', () => {
 
     // a search that returns nothing
     await userEvent.type(
-      screen.getByPlaceholderText('search profiles by email or name'),
+      screen.getByPlaceholderText('search profiles by name or OpenReview profile ID'),
       'Nonexistent Author'
     )
     await userEvent.click(screen.getByText('Search'))
@@ -1620,7 +1620,7 @@ describe('ProfileSearchWithInstitutionWidget', () => {
 
     // a search that returns nothing
     await userEvent.type(
-      screen.getByPlaceholderText('search profiles by email or name'),
+      screen.getByPlaceholderText('search profiles by name or OpenReview profile ID'),
       'Nonexistent Author'
     )
     await userEvent.click(screen.getByText('Search'))
@@ -1728,7 +1728,7 @@ describe('ProfileSearchWithInstitutionWidget', () => {
     await waitFor(() => expect(screen.getByText('Test First Test Last')).toBeInTheDocument())
 
     await userEvent.type(
-      screen.getByPlaceholderText('search profiles by email or name'),
+      screen.getByPlaceholderText('search profiles by name or OpenReview profile ID'),
       'Nonexistent Author'
     )
     await userEvent.click(screen.getByText('Search'))
@@ -1924,7 +1924,7 @@ describe('ProfileSearchWithInstitutionWidget', () => {
     await waitFor(() => expect(screen.getByText('Email Author')).toBeInTheDocument())
 
     await userEvent.type(
-      screen.getByPlaceholderText('search profiles by email or name'),
+      screen.getByPlaceholderText('search profiles by name or OpenReview profile ID'),
       'Nonexistent Author'
     )
     await userEvent.click(screen.getByText('Search'))


### PR DESCRIPTION
this pr should allow custom author (fullname + email) to be added to profile search with institution widget
when the invitation specify that:
1. username can accept email, by checking username regex has pipe
2. institution is not defined or is optional so that validation does not fail for custom authors