### PR TITLE
Fix guest profile publications and co-authors not loading

### DIFF
--- a/app/profile/Profile.js
+++ b/app/profile/Profile.js
@@ -18,7 +18,7 @@ export default async function Profile({
   serviceRoles,
   remoteIpAddress,
 }) {
-  const { token, user } = await serverAuth()
+  const { token, user, clearanceToken } = await serverAuth()
   const getCurrentInstitutionInfo = () => {
     const currentHistories = profile?.history?.filter(
       (p) => !p.end || p.end >= new Date().getFullYear()
@@ -65,7 +65,7 @@ export default async function Profile({
         '/notes',
         queryParam,
         { ...queryParam, count: true },
-        { accessToken: token, remoteIpAddress }
+        { accessToken: token, remoteIpAddress, clearanceToken }
       )
       if (apiRes.notes) {
         const publications = apiRes.notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openreview-web",
-  "version": "1.15.22",
+  "version": "1.15.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openreview-web",
-      "version": "1.15.22",
+      "version": "1.15.23",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
         "@ant-design/nextjs-registry": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openreview-web",
-  "version": "1.15.22",
+  "version": "1.15.23",
   "private": true,
   "scripts": {
     "dev": "next dev --port $NEXT_PORT",


### PR DESCRIPTION
## Summary
Guest users (post-Turnstile clearance) saw an empty Publications and Co-Authors section on profile pages because the SSR fetch for publications never forwarded the clearance cookie. This threads the clearance token through that fetch so cleared guests aren't re-challenged.

## Changes
- **`app/profile/Profile.js`**: Destructure `clearanceToken` from `serverAuth()` and pass it into the `getCombined('/notes', ...)` call in `loadPublications()`. Without it, the API challenge gate returned a `ChallengeRequiredError` (403) that was silently swallowed, leaving publications — and the co-authors derived from them — empty. Completes the SSR clearance forwarding started in #2818, which covered the `/profiles` and forum `/notes` fetches but missed this second `/notes` fetch.