### PR TITLE
Redirect legacy webfield guests through the API v1 scraping challenge gate

### DIFF
--- a/client/getChallengeRedirect.js
+++ b/client/getChallengeRedirect.js
@@ -1,0 +1,20 @@
+// Given a failed jQuery ajax XHR and the current page path, returns the URL of
+// the Turnstile challenge page a guest should be sent to when blocked by the
+// scraping challenge gate, or null when the error is not a challenge requirement.
+// Legacy $.ajax requests bypass the api-client checkStatus handler, so
+// client/globals.js uses this to redirect blocked guests.
+module.exports = function getChallengeRedirect(jqXhr, currentPath) {
+  if (jqXhr?.status !== 403) return null
+
+  let errorName = jqXhr.responseJSON?.name
+  if (!errorName && jqXhr.responseText) {
+    try {
+      errorName = JSON.parse(jqXhr.responseText)?.name
+    } catch {
+      errorName = null
+    }
+  }
+
+  if (errorName !== 'ChallengeRequiredError') return null
+  return '/challenge?redirect=' + encodeURIComponent(currentPath)
+}

--- a/client/globals.js
+++ b/client/globals.js
@@ -113,6 +113,22 @@ window.translateErrorMessage = function (error) {
   }
 }
 
+// Guest scraping challenge gate: legacy $.ajax requests bypass the api-client
+// checkStatus handler (lib/api-client.js), and some use handleErrors:false so
+// they never reach jqErrorCallback either. Catch the gate's 403 centrally here
+// and send the guest to the Turnstile challenge page, returning them to the
+// current page once cleared. Mirrors the client-side redirect in api-client.js.
+var getChallengeRedirect = require('./getChallengeRedirect')
+var challengeRedirecting = false
+$(document).ajaxError(function (event, jqXhr) {
+  if (challengeRedirecting) return
+  var redirectUrl = getChallengeRedirect(jqXhr, location.pathname + location.search)
+  if (redirectUrl) {
+    challengeRedirecting = true
+    location.href = redirectUrl
+  }
+})
+
 // Dropdowns
 $(document).on('click', function (event) {
   if (!$(event.target).closest('.dropdown').length) {

--- a/unitTests/ChallengeGateRedirect.test.js
+++ b/unitTests/ChallengeGateRedirect.test.js
@@ -1,0 +1,41 @@
+import getChallengeRedirect from '../client/getChallengeRedirect'
+
+// Legacy webfield/view code makes requests via jQuery $.ajax, which bypasses the
+// api-client checkStatus handler. client/globals.js installs a global ajaxError
+// handler that uses getChallengeRedirect to send guests blocked by the scraping
+// challenge gate to the Turnstile page. These tests cover that decision logic:
+// which XHR errors trigger a redirect and how the return URL is built.
+
+const currentPath = '/group?id=ICLR.cc/2021/Conference'
+const expectedRedirect = `/challenge?redirect=${encodeURIComponent(currentPath)}`
+
+describe('getChallengeRedirect', () => {
+  it('returns the challenge URL for a 403 ChallengeRequiredError (responseJSON)', () => {
+    const jqXhr = { status: 403, responseJSON: { name: 'ChallengeRequiredError' } }
+    expect(getChallengeRedirect(jqXhr, currentPath)).toBe(expectedRedirect)
+  })
+
+  it('falls back to responseText when responseJSON is not populated', () => {
+    const jqXhr = { status: 403, responseText: JSON.stringify({ name: 'ChallengeRequiredError' }) }
+    expect(getChallengeRedirect(jqXhr, currentPath)).toBe(expectedRedirect)
+  })
+
+  it('returns null for a 403 ForbiddenError (handled elsewhere as login)', () => {
+    const jqXhr = { status: 403, responseJSON: { name: 'ForbiddenError' } }
+    expect(getChallengeRedirect(jqXhr, currentPath)).toBeNull()
+  })
+
+  it('returns null for a non-403 error even if the name matches', () => {
+    const jqXhr = { status: 500, responseJSON: { name: 'ChallengeRequiredError' } }
+    expect(getChallengeRedirect(jqXhr, currentPath)).toBeNull()
+  })
+
+  it('returns null when responseText is not valid JSON', () => {
+    const jqXhr = { status: 403, responseText: 'gateway timeout' }
+    expect(getChallengeRedirect(jqXhr, currentPath)).toBeNull()
+  })
+
+  it('returns null when the XHR is missing', () => {
+    expect(getChallengeRedirect(undefined, currentPath)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
Companion web change for the API v1 challenge gate (openreview/openreview-api-v1#3129). Legacy venue pages (V1 webfields) fetch through jQuery `$.ajax`, which bypasses the `lib/api-client.js` `checkStatus` handler — and several calls use `handleErrors: false`, so they never reach `jqErrorCallback` either. A guest blocked by the gate got a swallowed `403 ChallengeRequiredError` with no redirect and no Turnstile widget. This adds a single central hook so those guests are sent to the challenge page and returned to where they were once cleared.

## Changes
- **`client/getChallengeRedirect.js`** (new): pure helper — given a failed jqXhr and the current path, returns the `/challenge?redirect=…` URL for a `403 ChallengeRequiredError` (with a `responseText` JSON fallback), otherwise `null`.
- **`client/globals.js`**: registers one global `$(document).ajaxError` handler that fires for every legacy `$.ajax` request regardless of its `handleErrors` setting, and navigates blocked guests to the challenge page. Mirrors the client-side redirect already in `api-client.js`.
- **`unitTests/ChallengeGateRedirect.test.js`** (new): covers the redirect decision — 403 + `ChallengeRequiredError` → redirect (incl. `responseText` fallback), `ForbiddenError` / non-403 / malformed body / missing xhr → no redirect.

## Notes
Requires the API v1 gate (openreview/openreview-api-v1#3129). For the clearance cookie (set by the V2 `/challenge/verify`) to satisfy the v1 gate, it must be scoped to cover both API hosts (e.g. `Domain=.openreview.net`) and the v1/v2 gates must share the signing secret — a deployment/config matter, not web code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)