### PR TITLE
Add author-derived options for note editor select fields

### DIFF
--- a/components/EditorComponents/DropdownWidget.js
+++ b/components/EditorComponents/DropdownWidget.js
@@ -1,16 +1,19 @@
-import { useContext, useEffect, useState } from 'react'
 import { isEqual } from 'lodash'
-import Dropdown from '../Dropdown'
-import EditorComponentContext from '../EditorComponentContext'
+import { useContext, useEffect, useState } from 'react'
 import { prettyField, prettyId } from '../../lib/utils'
 import { convertToType } from '../../lib/webfield-utils'
+import Dropdown from '../Dropdown'
+import EditorComponentContext from '../EditorComponentContext'
 
 import styles from '../../styles/components/DropdownWidget.module.scss'
 
 const DropdownWidget = () => {
-  const { field, onChange, value, clearError } = useContext(EditorComponentContext)
+  const { field, onChange, value, clearError, noteEditorValue } =
+    useContext(EditorComponentContext)
   const fieldName = Object.keys(field)[0]
   const fieldType = field[fieldName]?.value?.param?.type
+  const isAuthorDerivedField =
+    field[fieldName]?.value?.param?.enum?.[0] === '${3/authors/value/*/username}'
   const isArrayType = fieldType?.endsWith('[]')
   const dataType = isArrayType ? fieldType?.slice(0, -2) : fieldType
   const [dropdownOptions, setDropdownOptions] = useState([])
@@ -51,6 +54,7 @@ const DropdownWidget = () => {
   }
 
   useEffect(() => {
+    if (isAuthorDerivedField) return
     const enumValues = field[fieldName].value?.param?.enum
     const itemsValues = field[fieldName].value?.param?.items
     let options = []
@@ -97,6 +101,25 @@ const DropdownWidget = () => {
     }
   }, [])
 
+  useEffect(() => {
+    if (!isAuthorDerivedField) return
+    const authors = noteEditorValue?.authors ?? []
+    const authorOptions = authors.map((p) => ({
+      label: p.fullname,
+      value: p.username,
+    }))
+    setDropdownOptions(authorOptions)
+
+    // drop any selected reviewer whose author has been removed from the note
+    if (Array.isArray(value)) {
+      const optionValues = authorOptions.map((p) => p.value)
+      const filteredValue = value.filter((p) => optionValues.includes(p))
+      if (filteredValue.length !== value.length) {
+        onChange({ fieldName, value: filteredValue.length ? filteredValue : undefined })
+      }
+    }
+  }, [noteEditorValue?.authors])
+
   if (!dropdownOptions.length) return null
 
   return (
@@ -106,11 +129,13 @@ const DropdownWidget = () => {
         onChange={dropdownChangeHandler}
         value={
           allowMultiSelect
-            ? value?.map((p) =>
-                dropdownOptions.find((q) =>
-                  typeof p === 'object' ? isEqual(q.value, p) : q.value == p
+            ? value
+                ?.map((p) =>
+                  dropdownOptions.find((q) =>
+                    typeof p === 'object' ? isEqual(q.value, p) : q.value == p
+                  )
                 )
-              )
+                .filter(Boolean)
             : dropdownOptions.filter((p) => p.value == value)
         }
         isClearable={true}

--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -369,6 +369,7 @@ const NoteEditor = ({
             field: { [fieldName]: fieldDescription },
             onChange: setNoteEditorData,
             value: fieldValue,
+            noteEditorValue: noteEditorData,
             isWebfield: false,
             error,
             setErrors,

--- a/unitTests/DropdownWidget.test.js
+++ b/unitTests/DropdownWidget.test.js
@@ -1494,3 +1494,101 @@ describe('DropdownWidget', () => {
     )
   })
 })
+
+describe('DropdownWidget author-derived field (select an author)', () => {
+  const authorReferenceField = {
+    serve_as_reviewer: {
+      value: {
+        param: {
+          type: 'string[]',
+          input: 'select',
+          enum: ['${3/authors/value/*/username}'],
+        },
+      },
+    },
+  }
+
+  test('render options labelled by author display name', async () => {
+    const providerProps = {
+      value: {
+        field: authorReferenceField,
+        noteEditorValue: {
+          authors: [
+            { username: '~Jane_Doe1', fullname: 'Jane Doe' },
+            { username: '~Bob_Lee1', fullname: 'Bob Lee' },
+          ],
+        },
+      },
+    }
+
+    renderWithEditorComponentContext(<DropdownWidget />, providerProps)
+    await userEvent.click(screen.getByRole('combobox'))
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('Bob Lee')).toBeInTheDocument()
+  })
+
+  test('drop a selected reviewer whose author has been removed', () => {
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: authorReferenceField,
+        noteEditorValue: { authors: [{ username: '~Jane_Doe1', fullname: 'Jane Doe' }] },
+        value: ['~Jane_Doe1', '~Removed_Author1'], // second author was removed
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<DropdownWidget />, providerProps)
+    expect(onChange).toHaveBeenCalledWith({
+      fieldName: 'serve_as_reviewer',
+      value: ['~Jane_Doe1'],
+    })
+  })
+
+  test('clear the value when the only selected author is removed', () => {
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: authorReferenceField,
+        noteEditorValue: { authors: [{ username: '~Jane_Doe1', fullname: 'Jane Doe' }] },
+        value: ['~Removed_Author1'],
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<DropdownWidget />, providerProps)
+    expect(onChange).toHaveBeenCalledWith({ fieldName: 'serve_as_reviewer', value: undefined })
+  })
+
+  test('keep a valid selection unchanged (no reconcile dispatch)', () => {
+    const onChange = jest.fn()
+    const providerProps = {
+      value: {
+        field: authorReferenceField,
+        noteEditorValue: {
+          authors: [
+            { username: '~Jane_Doe1', fullname: 'Jane Doe' },
+            { username: '~Bob_Lee1', fullname: 'Bob Lee' },
+          ],
+        },
+        value: ['~Jane_Doe1'],
+        onChange,
+      },
+    }
+
+    renderWithEditorComponentContext(<DropdownWidget />, providerProps)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('render nothing when there are no authors', () => {
+    const providerProps = {
+      value: {
+        field: authorReferenceField,
+        noteEditorValue: { authors: [] },
+      },
+    }
+
+    const { container } = renderWithEditorComponentContext(<DropdownWidget />, providerProps)
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
## What

Adds support for a note-editor `select` field whose options are derived from the note's authors — the "select an author to serve as reviewer" use case.

An invitation field like:

```json
"serve_as_reviewer": {
  "value": { "param": {
    "type": "string[]",
    "enum": ["${3/authors/value/*/username}"],
    "input": "select"
  }}
}
```

now renders a dropdown populated from the note's live `authors` field (value = username, label = full name) instead of showing the raw `${...}` token.

## How

- **`NoteEditor`**: expose `noteEditorValue` (the live editor state) on the field `EditorComponentContext` so a widget can read sibling field values.
- **`DropdownWidget`**: when the enum's first entry is the author reference token, build options from `noteEditorValue.authors`, keyed to re-run only when authors change. A selected reviewer is dropped when their author is removed from the note (with a `.filter(Boolean)` guard on render for the transient frame). Reconcile only dispatches when the selection actually shrank, so it's loop-safe.
- Non-reference dropdowns are unchanged.

## Tests

- 5 new unit tests for the author-derived path (render by display name, drop removed author, clear when only author removed, keep valid selection, hide when no authors).
- Full unit suite green (765 passed) under `TZ=UTC`.

## Notes

Scope is intentionally narrow: only the `author{}` object schema and the exact `${3/authors/value/*/username}` reference. Generalizing to arbitrary field references is deferred until a second use case appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)