### PR TITLE
Fix/ Profile Activation - layout broken when history section has error

### DIFF
--- a/app/profile/activate/Activate.module.scss
+++ b/app/profile/activate/Activate.module.scss
@@ -29,6 +29,19 @@
       border-color: constants.$orRed;
     }
 
+    .invalid-value-icon {
+      position: absolute;
+      top: 0.25rem;
+      right: 8px;
+      color: constants.$orRed;
+    }
+
+    .tooltip .tooltip-inner {
+      white-space: nowrap;
+      max-width: none;
+      width: max-content;
+    }
+
     div.instructions {
       font-size: 0.75rem;
       color: constants.$subtleGray;


### PR DESCRIPTION
when there's error in the history record, an exclamation mark which indicates the exact error is shown beside the field
currently it will cause the input position to shift due to missing css

profile edit page is working fine

the css in profile edit page and profile activate page have some duplication
which should be corrected when the page is converted to use antd