### PR TITLE
Speed up user moderation queue query

### DIFF
--- a/app/user/moderation/UserModerationTab.js
+++ b/app/user/moderation/UserModerationTab.js
@@ -332,7 +332,7 @@ const UserModerationQueue = ({
     token.startsWith('~') || token.includes('@') || isValidDomain(token.toLowerCase())
 
   const getProfiles = async () => {
-    const queryOptions = onlyModeration ? { needsModeration: true } : {}
+    const queryOptions = onlyModeration ? { state: 'Needs Moderation' } : {}
     const cleanSearchTerm = filters.term?.trim()
     const shouldSearchProfile = profileStateOption === 'All' && cleanSearchTerm
     const sortKey = onlyModeration ? 'tmdate' : 'tcdate'


### PR DESCRIPTION
## Summary
The user moderation queue used a slow `needsModeration=true` filter to fetch pending profiles. This switches to the faster `state=Needs Moderation` query, addressing #2850.

## Changes
- **`app/user/moderation/UserModerationTab.js`**: Replaced `needsModeration: true` with `state: 'Needs Moderation'` in the moderation profiles query. Safe because the profile-state dropdown that also sets `state` only renders outside the moderation queue, so there's no conflict.

Closes #2850

🤖 Generated with [Claude Code](https://claude.com/claude-code)