### PR TITLE
Fix/ ProfileTag - update label rendering rules for improved clarity

### DIFF
--- a/components/ProfileTag.js
+++ b/components/ProfileTag.js
@@ -1,8 +1,9 @@
 /* globals $: false */
 import { useEffect } from 'react'
 import { getTagDispayText } from '../lib/utils'
-import styles from '../styles/components/ProfileTag.module.scss'
 import Icon from './Icon'
+
+import styles from '../styles/components/ProfileTag.module.scss'
 
 const ProfileTag = ({ tag, onDelete, showProfileId, borderless }) => {
   const { label, invitation, parentInvitations, readers, signature } = tag
@@ -17,7 +18,7 @@ const ProfileTag = ({ tag, onDelete, showProfileId, borderless }) => {
 
   const getColorClass = () => {
     if (label === 'require vouch') return styles.requireVouch
-    if (label === 'user sent document') return styles.userSentDocument
+    if (label.startsWith('user sent document')) return styles.userSentDocument
     if (label === 'potential spam') return styles.potentialSpam
     if (parentInvitations?.endsWith('_Role')) return styles.serviceRole
     return ''


### PR DESCRIPTION
currently when tag label is 
>user sent document

it will be rendered in green color

sometimes the email user used to send documents are different from the one in profile
so the tag becomes
>user sent document from email.domain

this pr should update the logic to include this case

