### PR TITLE
Fix/ Invalid Array Length error

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -57,7 +57,11 @@ const checkStatus = async (response, originalRequest) => {
 
   // On a challenge requirement, send the client to the frontend-served challenge
   // page (SSR handles this via redirect() instead).
-  if (error.status === 403 && error.name === 'ChallengeRequiredError' && typeof window !== 'undefined') {
+  if (
+    error.status === 403 &&
+    error.name === 'ChallengeRequiredError' &&
+    typeof window !== 'undefined'
+  ) {
     const redirectPath = window.location.pathname + window.location.search
     window.location = `/challenge?redirect=${encodeURIComponent(redirectPath)}`
     // Never-resolving promise: halt the chain while the navigation happens.
@@ -122,7 +126,8 @@ const request = (httpMethod) => {
 
     // Forward the guest clearance cookie on SSR calls; client-side requests carry it automatically.
     if (options.clearanceToken) {
-      const clearanceCookieName = process.env.CLEARANCE_COOKIE_NAME || 'openreview.clearanceToken'
+      const clearanceCookieName =
+        process.env.CLEARANCE_COOKIE_NAME || 'openreview.clearanceToken'
       defaultHeaders.Cookie = `${clearanceCookieName}=${options.clearanceToken}`
     }
 
@@ -193,7 +198,15 @@ const put = request('PUT')
 const patch = request('PATCH')
 const del = request('DELETE')
 
-const getById = async (apiPath, id, accessToken, apiVersion, queryParam, remoteIp, clearanceToken) => {
+const getById = async (
+  apiPath,
+  id,
+  accessToken,
+  apiVersion,
+  queryParam,
+  remoteIp,
+  clearanceToken
+) => {
   try {
     const apiRes = await get(
       `/${apiPath}`,
@@ -238,13 +251,36 @@ const getInvitationById = async (
   )
 }
 
-const getNoteById = async (noteId, accessToken, queryParam1, queryParam2, remoteIp, clearanceToken) => {
-  const noteObj = await getById('notes', noteId, accessToken, 2, queryParam1, remoteIp, clearanceToken)
+const getNoteById = async (
+  noteId,
+  accessToken,
+  queryParam1,
+  queryParam2,
+  remoteIp,
+  clearanceToken
+) => {
+  const noteObj = await getById(
+    'notes',
+    noteId,
+    accessToken,
+    2,
+    queryParam1,
+    remoteIp,
+    clearanceToken
+  )
   if (noteObj) {
     return noteObj
   }
 
-  return getById('notes', noteId, accessToken, 1, queryParam2 ?? queryParam1, remoteIp, clearanceToken)
+  return getById(
+    'notes',
+    noteId,
+    accessToken,
+    1,
+    queryParam2 ?? queryParam1,
+    remoteIp,
+    clearanceToken
+  )
 }
 
 const getGroupById = (groupId, accessToken, queryParam) =>
@@ -320,7 +356,7 @@ const getAll = async (path, queryParam, options = {}) => {
   if (!totalCount) return []
   if (totalCount - initialResults.length <= 0) return initialResults
 
-  const offsetList = [...Array(totalCount - offset - queryObj.limit).keys()]
+  const offsetList = [...Array(Math.max(0, totalCount - offset - queryObj.limit)).keys()]
     .map((p) => p + offset + queryObj.limit)
     .filter((q) => (q - offset - queryObj.limit) % queryObj.limit === 0)
   const remainingRequests = offsetList.map((p) =>


### PR DESCRIPTION
the error happens in edge browser when loading all reviewer profiles in reviewers group
the count returned in the call is greater than the actual profile objects count by 1

causing the check of whether to get subsequent results to fail (totalCount - initialResults.length = 1)
```javascript
if (totalCount - initialResults.length <= 0) return initialResults
``` 

so the offset array is generated using negative value causing the error

this pr should mitigates the error but does not fix the root cause