### PR TITLE
Add donation contact info to donate page

### DIFF
--- a/app/donate/page.js
+++ b/app/donate/page.js
@@ -369,6 +369,11 @@ export default function Page() {
         </div>
       </div>
       <div className={`${styles.section} ${styles.qna}`}>
+        <p>
+          If you have questions about making a donation to support OpenReview, please email{' '}
+          <a href="mailto:donations@openreview.net">donations@openreview.net</a> or call{' '}
+          <a href="tel:+14134865231">413-486-5231</a>.
+        </p>
         <strong>What is OpenReview?</strong>
         <ul>
           <li>


### PR DESCRIPTION
## Summary
Adds a contact line for donation-related questions to the top of the Q&A section on `/donate`, so prospective donors can reach the foundation by email or phone.

## Changes
- **`app/donate/page.js`**: Added a paragraph directly above the "What is OpenReview?" heading with a `mailto:` link to donations@openreview.net and a `tel:` link to 413-486-5231. No new styles needed — the `.qna` flex container supplies the spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZZ7TtYqtCmM3o5yYRgcEq