### PR TITLE
Fix/ Flaky register e2e test - error notification swallows the History step click

### DIFF
--- a/tests/e2e_3/registerPage.ts
+++ b/tests/e2e_3/registerPage.ts
@@ -26,6 +26,8 @@ const confirmPasswordInputSelector = Selector('input').withAttribute(
 const sendActivationLinkButtonSelector = Selector('button').withText('Send Activation Link')
 const claimProfileButtonSelector = Selector('button').withText('Claim Profile')
 const messageSelector = Selector('.ant-notification-notice-content').nth(-1)
+const notificationSelector = Selector('.ant-notification-notice')
+const notificationCloseButton = Selector('.ant-notification-notice-close')
 const nextSectiomButtonSelector = Selector('button').withText('Next Section')
 const errorMessageLabel = Selector('.error-message') // server rendered error message
 
@@ -497,6 +499,12 @@ test('register a profile with an institution which is not the one of the email',
     .eql(
       `Error: The institution of your email ${institutionEmailUser.email} must be added to the history`
     )
+
+    // the error notification is an 80vw banner fixed at the top of the viewport,
+    // so it swallows the click on the History step; dismiss it first
+    .click(notificationCloseButton)
+    .expect(notificationSelector.exists)
+    .notOk()
 
     // the profile is created once the institution of the email is in the history
     .click(historyStep)


### PR DESCRIPTION
`register a profile with an institution which is not the one of the email` has been failing intermittently on master since it was added in #2857 — the same commit passes and fails across runs.

### Cause

The antd error notification is an **80vw banner fixed at the top of the viewport** (`ThemeProvider.js` `Notification.width: '80vw'`, `usePrompt.js` `placement: 'top', top: 91`), with `pointer-events: auto` and `z-index: 2050`.

After the failed registration, TestCafe scrolls back up from the "Register for OpenReview" button and parks the steps bar ~50px from the top of the viewport (`DEFAULT_MAX_SCROLL_MARGIN`) — inside the banner. `.click(historyStep)` then lands on the notification, the step never changes, and `input.institution-dropdown__placeholder` never renders, so the next line fails on the 10s selector timeout.

Measured on the live page with the notification showing and the page scrolled the way TestCafe scrolls it:

```
historyBtn rect  : l=1016 t=50  r=1116 b=142  → click point (1066, 96)
notification rect: l=168  t=91  r=1514 b=170
elementFromPoint : div.ant-notification-notice ant-notification-notice-error
```

It is intermittent because the notification auto-dismisses after 4s (`errorDuration`), so whether the click was swallowed depended on API timing.

### Fix

Dismiss the notification and wait for it to leave the DOM before clicking the History step.

### Note

The same overlap can block a real user: for 4s after any error, everything under the top ~80px band is unclickable (and `pauseOnHover` extends that while the cursor rests there). Not addressed here — worth a separate look at whether the notice should be `pointer-events: none`, or narrower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)