### PR TITLE
Fix/ Forum reply - not to pass replyto when editing existing note

### DIFF
--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -564,7 +564,7 @@ const NoteEditor = ({
         noteReaderValues: await getNoteReaderValues(roleNames, invitation, noteEditorData),
         editReaderValues: await getEditReaderValues(roleNames, invitation, noteEditorData),
         editWriterValues: getEditWriterValues(),
-        ...(replyToNote && { replyto: replyToNote.id }),
+        ...(!note?.id && replyToNote && { replyto: replyToNote.id }),
         editContent: editContentData,
       }
 


### PR DESCRIPTION
when the nesting level>3, the replyToNote set for note in >3 nesting is not it's actual parent
so editing the note will cause the replyto to be wrong

this pr should not pass replyto when editing a note