### PR TITLE
Fix/ Vouch - handle username match when username is changed

### DIFF
--- a/components/ProfileTag.js
+++ b/components/ProfileTag.js
@@ -18,7 +18,7 @@ const ProfileTag = ({ tag, onDelete, showProfileId, borderless }) => {
 
   const getColorClass = () => {
     if (label === 'require vouch') return styles.requireVouch
-    if (label.startsWith('user sent document')) return styles.userSentDocument
+    if (label?.startsWith('user sent document')) return styles.userSentDocument
     if (label === 'potential spam') return styles.potentialSpam
     if (parentInvitations?.endsWith('_Role')) return styles.serviceRole
     return ''

--- a/components/profile/RelationsSection.js
+++ b/components/profile/RelationsSection.js
@@ -591,7 +591,12 @@ const RelationsSection = ({
       const { profiles } = await api.getAllProfilesByIds(usernames)
       setRelationProfileStates(
         Object.fromEntries(
-          profiles.map((candidateProfile) => [candidateProfile.id, candidateProfile.state])
+          profiles.flatMap((candidateProfile) => {
+            const allUserNames = (candidateProfile.content.names ?? []).map(
+              (p) => p.username ?? []
+            )
+            return allUserNames.map((p) => [p, candidateProfile.state])
+          })
         )
       )
     } catch {}


### PR DESCRIPTION
when a user is added in a relation with username ~A1 and the user goes to change name to ~B1
the ~A1 relation will not show vouch button because it won't find the profile state

this pr should change it to map all ids to the correct state so that the vouch button is shown correctly

it should also fix #2856 in case there's no label