### PR TITLE
Deploy production web via blue/green cutover

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -306,15 +306,6 @@ jobs:
             -var="green_image=${{ steps.state.outputs.green_img }}" \
             -var="warm_idle_size=0"
 
-          OLD_GROUP=${{ steps.state.outputs.active_group }}
-          insts=$(gcloud compute instance-groups managed list-instances "$OLD_GROUP" \
-            --region=us-central1 --project=$PROJECT_ID --format="value(instance.basename())" | paste -sd, -)
-          if [ -n "$insts" ]; then
-            echo "Draining old color $OLD_GROUP: $insts"
-            gcloud compute instance-groups managed delete-instances "$OLD_GROUP" \
-              --instances="$insts" --region=us-central1 --project=$PROJECT_ID
-          fi
-
       - name: Failover to previous color if the cutover failed before flipping
         if: failure() && steps.flip.outcome != 'success'
         env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -114,6 +114,7 @@ jobs:
 
             echo "copying build to Google Cloud."
             gsutil cp "/tmp/${build_id}.tar.gz" "gs://openreview-general/openreview-web-builds/${build_id}.tar.gz"
+            echo "$build_id" | gsutil cp - gs://openreview-general/static-upload-pending/${build_id}
             curl -s "https://cowsay.morecode.org/say?message=MOO%21%20YOU%20CREATED%20A%20BUILD%20SUCCESSFULLY&format=text"
           fi
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -299,6 +299,17 @@ jobs:
           PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
+          retiring_size=$(gcloud compute instance-groups managed describe ${{ steps.state.outputs.active_group }} \
+            --region=us-central1 --project=$PROJECT_ID --format="value(targetSize)")
+          [ -n "$retiring_size" ] || { echo "Could not read retiring group size"; exit 1; }
+          echo "Apply 1: flip modes, hold retiring ${{ steps.state.outputs.active_group }} at its live size ${retiring_size} so it is not resized while still autoscaled"
+          terraform apply -auto-approve \
+            -var="project_id=$PROJECT_ID" \
+            -var="active_color=${{ steps.state.outputs.idle }}" \
+            -var="blue_image=${{ steps.state.outputs.blue_img }}" \
+            -var="green_image=${{ steps.state.outputs.green_img }}" \
+            -var="warm_idle_size=${retiring_size}"
+          echo "Apply 2: retiring color now OFF, drain it to 0"
           terraform apply -auto-approve \
             -var="project_id=$PROJECT_ID" \
             -var="active_color=${{ steps.state.outputs.idle }}" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -178,43 +178,131 @@ jobs:
           gsutil cp $GITHUB_WORKSPACE/deployment.conf gs://openreview-general/conf/deployment.conf
 
       - name: Setup Terraform
-        if: steps.check-mapping.outputs.is_rollback == 'false'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
 
-      - name: Terraform apply — update instance template and roll MIG
-        if: steps.check-mapping.outputs.is_rollback == 'false'
-        working-directory: openreview-cloud/Terraform/prod/web
-        env:
-          IMAGE: ${{ steps.packer.outputs.image }}
-        run: |
-          terraform init
-          terraform apply -auto-approve \
-            -var="project_id=${{ secrets.GCP_PROJECT_ID }}" \
-            -var="image=${IMAGE}"
-
-      - name: Start MIG rolling update
+      - name: Resolve image to deploy
+        id: image
         run: |
           if [ "${{ steps.check-mapping.outputs.is_rollback }}" = "true" ]; then
             IMAGE=$(gsutil cat gs://openreview-general/web-image-map/${TAG})
-            echo "Rolling back to image: $IMAGE"
           else
             IMAGE="${{ steps.packer.outputs.image }}"
           fi
-          gcloud compute instance-groups managed rolling-action start-update openreview-web \
-            --region=us-central1 \
-            --project=${{ secrets.GCP_PROJECT_ID }} \
-            --version=template=projects/${{ secrets.GCP_PROJECT_ID }}/regions/us-central1/instanceTemplates/openreview-web-template-${IMAGE} \
-            --max-surge=3 \
-            --max-unavailable=0
+          echo "Deploying image: $IMAGE"
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
 
-      - name: Wait for rollout to complete
+      - name: Determine active color, size, and current image
+        id: state
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
-          gcloud compute instance-groups managed wait-until openreview-web \
-            --version-target-reached \
-            --region=us-central1 \
-            --project=${{ secrets.GCP_PROJECT_ID }}
+          set -euo pipefail
+          REGION=us-central1
+          GLB=openreview-web-backend-service
+          ACTIVE_GROUP=$(gcloud compute backend-services describe $GLB --global --project=$PROJECT_ID \
+            --format=json | jq -r '.backends[] | select(.capacityScaler==1.0) | .group | split("/") | last')
+          if [ "$ACTIVE_GROUP" = "openreview-web" ]; then
+            ACTIVE=blue;  IDLE=green; IDLE_GROUP=openreview-web-grn
+          elif [ "$ACTIVE_GROUP" = "openreview-web-grn" ]; then
+            ACTIVE=green; IDLE=blue;  IDLE_GROUP=openreview-web
+          else
+            echo "Could not determine active color (no backend at capacity_scaler=1.0)"; exit 1
+          fi
+
+          N=$(gcloud compute instance-groups managed describe $ACTIVE_GROUP --region=$REGION \
+            --project=$PROJECT_ID --format="value(targetSize)")
+          [ "${N:-0}" -lt 2 ] && N=2
+
+          ACTIVE_TPL=$(gcloud compute instance-groups managed describe $ACTIVE_GROUP --region=$REGION \
+            --project=$PROJECT_ID --format="value(versions[0].instanceTemplate)" | xargs basename)
+          ACTIVE_IMG=$(gcloud compute instance-templates describe $ACTIVE_TPL --region=$REGION \
+            --project=$PROJECT_ID --format="value(properties.disks[0].initializeParams.sourceImage)" | xargs basename)
+
+          if [ "$ACTIVE" = "blue" ]; then
+            BLUE_IMG=$ACTIVE_IMG; GREEN_IMG=${{ steps.image.outputs.image }}
+          else
+            GREEN_IMG=$ACTIVE_IMG; BLUE_IMG=${{ steps.image.outputs.image }}
+          fi
+
+          echo "active=$ACTIVE (N=$N, img=$ACTIVE_IMG) -> idle=$IDLE gets ${{ steps.image.outputs.image }}"
+          for kv in "active=$ACTIVE" "idle=$IDLE" "idle_group=$IDLE_GROUP" "n=$N" \
+                    "blue_img=$BLUE_IMG" "green_img=$GREEN_IMG"; do echo "$kv" >> $GITHUB_OUTPUT; done
+
+      - name: Warm idle color to active's instance count on the new image
+        id: warm
+        working-directory: openreview-cloud/Terraform/prod/web
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve \
+            -var="project_id=$PROJECT_ID" \
+            -var="active_color=${{ steps.state.outputs.active }}" \
+            -var="blue_image=${{ steps.state.outputs.blue_img }}" \
+            -var="green_image=${{ steps.state.outputs.green_img }}" \
+            -var="warm_idle_size=${{ steps.state.outputs.n }}"
+
+      - name: Wait for idle color to reach N healthy on the load balancer
+        id: wait
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          GLB=openreview-web-backend-service
+          IDLE_GROUP=${{ steps.state.outputs.idle_group }}
+          N=${{ steps.state.outputs.n }}
+          deadline=$(( $(date +%s) + 900 ))
+          while :; do
+            healthy=$(gcloud compute backend-services get-health $GLB --global --project=$PROJECT_ID \
+              --format=json | jq --arg g "$IDLE_GROUP" \
+              '[.[] | select(.backend|test("/"+$g+"$")) | .status.healthStatus[]? | select(.healthState=="HEALTHY")] | length')
+            healthy=${healthy:-0}
+            echo "  $IDLE_GROUP: $healthy/$N healthy"
+            [ "$healthy" -ge "$N" ] && break
+            [ "$(date +%s)" -ge "$deadline" ] && { echo "TIMEOUT: idle did not reach $N healthy"; exit 1; }
+            sleep 15
+          done
+
+      - name: Flip traffic to idle color on both GLB and ILB backends
+        id: flip
+        working-directory: openreview-cloud/Terraform/prod/lb
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve \
+            -var="project_id=$PROJECT_ID" \
+            -var="web_active_color=${{ steps.state.outputs.idle }}" \
+            -target=google_compute_backend_service.web \
+            -target=google_compute_region_backend_service.web_ilb
+
+      - name: Settle new active color and drain the old one
+        working-directory: openreview-cloud/Terraform/prod/web
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          terraform apply -auto-approve \
+            -var="project_id=$PROJECT_ID" \
+            -var="active_color=${{ steps.state.outputs.idle }}" \
+            -var="blue_image=${{ steps.state.outputs.blue_img }}" \
+            -var="green_image=${{ steps.state.outputs.green_img }}" \
+            -var="warm_idle_size=0"
+
+      - name: Failover to previous color if the cutover failed before flipping
+        if: failure() && steps.flip.outcome != 'success'
+        working-directory: openreview-cloud/Terraform/prod/web
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          echo "Cutover failed before flip; ${{ steps.state.outputs.active }} still serving. Draining idle."
+          terraform apply -auto-approve \
+            -var="project_id=$PROJECT_ID" \
+            -var="active_color=${{ steps.state.outputs.active }}" \
+            -var="blue_image=${{ steps.state.outputs.blue_img }}" \
+            -var="green_image=${{ steps.state.outputs.green_img }}" \
+            -var="warm_idle_size=0"
 
       - name: Sync error pages to GCS
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,6 +21,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: prod-web-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     permissions:
@@ -312,11 +316,20 @@ jobs:
 
       - name: Failover to previous color if the cutover failed before flipping
         if: failure() && steps.flip.outcome != 'success'
-        working-directory: openreview-cloud/Terraform/prod/web
         env:
           PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
-          echo "Cutover failed before flip; ${{ steps.state.outputs.active }} still serving. Draining idle."
+          set -euo pipefail
+          echo "Cutover failed at or before flip; re-asserting ${{ steps.state.outputs.active }} on both backends, then draining idle."
+          cd $GITHUB_WORKSPACE/openreview-cloud/Terraform/prod/lb
+          terraform init -input=false
+          terraform apply -auto-approve \
+            -var="project_id=$PROJECT_ID" \
+            -var="web_active_color=${{ steps.state.outputs.active }}" \
+            -target=google_compute_backend_service.web \
+            -target=google_compute_region_backend_service.web_ilb
+          cd $GITHUB_WORKSPACE/openreview-cloud/Terraform/prod/web
+          terraform init -input=false
           terraform apply -auto-approve \
             -var="project_id=$PROJECT_ID" \
             -var="active_color=${{ steps.state.outputs.active }}" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -221,8 +221,24 @@ jobs:
           fi
 
           echo "active=$ACTIVE (N=$N, img=$ACTIVE_IMG) -> idle=$IDLE gets ${{ steps.image.outputs.image }}"
-          for kv in "active=$ACTIVE" "idle=$IDLE" "idle_group=$IDLE_GROUP" "n=$N" \
+          for kv in "active=$ACTIVE" "idle=$IDLE" "active_group=$ACTIVE_GROUP" "idle_group=$IDLE_GROUP" "n=$N" \
                     "blue_img=$BLUE_IMG" "green_img=$GREEN_IMG"; do echo "$kv" >> $GITHUB_OUTPUT; done
+
+      - name: Ensure idle color is empty before warming
+        env:
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          IDLE_GROUP=${{ steps.state.outputs.idle_group }}
+          size=$(gcloud compute instance-groups managed describe "$IDLE_GROUP" \
+            --region=us-central1 --project=$PROJECT_ID --format="value(targetSize)")
+          if [ "${size:-0}" -ne 0 ]; then
+            echo "Idle color $IDLE_GROUP still has ${size} instance(s) draining from a previous deploy."
+            echo "Blue/green requires it at 0 so it boots fresh on the new image. Wait a few minutes and re-run."
+            echo "Aborting before any change -- the active color keeps serving."
+            exit 1
+          fi
+          echo "Idle color $IDLE_GROUP is empty; safe to warm."
 
       - name: Warm idle color to active's instance count on the new image
         id: warm
@@ -277,12 +293,22 @@ jobs:
         env:
           PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
+          set -euo pipefail
           terraform apply -auto-approve \
             -var="project_id=$PROJECT_ID" \
             -var="active_color=${{ steps.state.outputs.idle }}" \
             -var="blue_image=${{ steps.state.outputs.blue_img }}" \
             -var="green_image=${{ steps.state.outputs.green_img }}" \
             -var="warm_idle_size=0"
+
+          OLD_GROUP=${{ steps.state.outputs.active_group }}
+          insts=$(gcloud compute instance-groups managed list-instances "$OLD_GROUP" \
+            --region=us-central1 --project=$PROJECT_ID --format="value(instance.basename())" | paste -sd, -)
+          if [ -n "$insts" ]; then
+            echo "Draining old color $OLD_GROUP: $insts"
+            gcloud compute instance-groups managed delete-instances "$OLD_GROUP" \
+              --instances="$insts" --region=us-central1 --project=$PROJECT_ID
+          fi
 
       - name: Failover to previous color if the cutover failed before flipping
         if: failure() && steps.flip.outcome != 'success'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,15 +1,9 @@
 # This workflow deploys any branch, tag, or commit hash to the production environment.
-# Flow (normal deploy):
-#   1. Build Next.js and upload artifact to GCS (skipped if build already exists)
-#   2. Run Packer to bake the artifact into a new GCE image
-#   3. Terraform apply to update the instance template
-#   4. Rolling update — replace MIG instances one at a time with zero downtime
-#   5. Deploy static files to nginx (symlinks /_next and .html files into nginx html dir)
-#
-# Flow (rollback — tag already has a GCS image mapping and force_rebuild is false):
-#   1. Resolve tag to previously baked image via GCS mapping
-#   2. Rolling update directly — skips build, Packer, and Terraform
-#   3. Deploy static files to nginx
+# Flow: build Next.js, bake a GCE image with Packer, then a blue/green cutover (warm the idle color
+# on the new image, wait for it healthy on the LB, flip both web backend services), then sync static
+# files to nginx. The web MIG is flexible so it cannot be rolled in place; see the blue/green model
+# in openreview-cloud Terraform/prod/web/README.md.
+# Rollback: re-run with an older tag; its mapped image skips build/Packer and runs the same cutover.
 
 name: Production Deployment
 


### PR DESCRIPTION
## Summary

The production web MIG is now flexible (mixed machine families for stockout
resilience), which forces an `OPPORTUNISTIC` update policy and makes an in-place
rolling update impossible — `rolling-action start-update` (the current deploy step)
errors on a flexible MIG. This switches the web rollout to a blue/green cutover.

## Changes

Replaces the `terraform apply` + `rolling-action start-update` + `wait-until` steps
with a blue/green flow (build, Packer, and image→tag mapping are unchanged):

- Determine the active color and its instance count from the load balancer.
- Warm the idle color to that count on the new image (active color untouched, still
  serving 100%).
- Wait for the idle color to reach that count healthy on the LB before flipping.
- Flip `capacity_scaler` on both web backend services — the external GLB and the
  internal ILB (nginx path) — in one apply.
- Settle the new active color (floor + prewarm) and drain the old one to 0.
- On any failure before the flip, the previous color keeps serving and the idle
  color is drained.

`terraform` now runs on the rollback path too, since a rollback is the same cutover
onto the mapped image. Dispatch inputs (`tag`, `force_rebuild`) are unchanged.

## Depends on

openreview/openreview-cloud#117 — the blue/green Terraform for the web MIGs and the
backend-service flip. Must be merged before this workflow will run correctly.

## Rollback

Unchanged for operators: re-run the workflow with the previous `tag`; it reuses that
tag's baked image and cuts over to it (no rebuild).
