### PR TITLE
Fix/ ProfilePreviewModal - show activate with id check button

### DIFF
--- a/components/profile/ProfilePreviewModal.js
+++ b/components/profile/ProfilePreviewModal.js
@@ -40,7 +40,7 @@ const ProfilePreviewModal = ({
   ]
   const [tagInvitation, setTagInvitation] = useState(tagInvitationOptions[0].value)
   const needsModeration = profileToPreview?.state === 'Needs Moderation'
-  const isRejectedProfile = profileToPreview?.state === 'Rejected'
+  const isProfileActivatable = profileToPreview?.state === 'Rejected' || needsModeration
 
   const tagAndActivateProfile = async () => {
     await api.post('/tags', {
@@ -249,9 +249,9 @@ const ProfilePreviewModal = ({
                     (document) => document.type !== 'parentalConsent'
                   )}
                   loadIdentityDocuments={loadIdentityDocuments}
-                  deleteAllLabel={isRejectedProfile ? 'Activate with ID check' : undefined}
-                  onBeforeDeleteAll={isRejectedProfile ? tagAndActivateProfile : undefined}
-                  onAfterDeleteAll={isRejectedProfile ? loadTags : undefined}
+                  deleteAllLabel={isProfileActivatable ? 'Activate with ID check' : undefined}
+                  onBeforeDeleteAll={isProfileActivatable ? tagAndActivateProfile : undefined}
+                  onAfterDeleteAll={isProfileActivatable ? loadTags : undefined}
                 />
               </ProfileViewSection>
             )}


### PR DESCRIPTION
current implementation requires profile to be in pending moderation state to show
activate with id check
button
so that moderator can know user has completed uploading all profiles.

most of the time this check is not necessary or user will forget to submit profile
so this pr change to check to show activate with id check button when profile is in reject or pending moderation state