### PR TITLE
Fix/ e2e test - Adjust testcafe command

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -3,7 +3,7 @@
   "selectorTimeout": 30000,
   "assertionTimeout": 10000,
   "pageRequestTimeout": 30000,
-  "browserInitTimeout": 360000,
+  "browserInitTimeout": 120000,
   "hostname": "localhost",
   "retryTestPages": true
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "next build",
     "start": "next start --port $NEXT_PORT",
     "unit-test": "jest",
-    "test": "testcafe firefox:headless tests/setup --concurrency 2 && (testcafe firefox:headless tests/e2e_1 --ports 1341,1342 & p1=$!; sleep 15; testcafe firefox:headless tests/e2e_2 --ports 1343,1344 & p2=$!; sleep 15; testcafe firefox:headless tests/e2e_3 --ports 1345,1346 & p3=$!; wait $p1; r1=$?; wait $p2; r2=$?; wait $p3; r3=$?; exit $((r1|r2|r3))) && testcafe firefox tests/setup_redbutton_venue && testcafe firefox:headless tests/e2e_redbutton",
+    "test": "TMPDIR=$(mktemp -d) testcafe firefox:headless tests/setup --concurrency 2 && (TMPDIR=$(mktemp -d) testcafe firefox:headless tests/e2e_1 --ports 1341,1342 & p1=$!; sleep 15; TMPDIR=$(mktemp -d) testcafe firefox:headless tests/e2e_2 --ports 1343,1344 & p2=$!; sleep 15; TMPDIR=$(mktemp -d) testcafe firefox:headless tests/e2e_3 --ports 1345,1346 & p3=$!; wait $p1; r1=$?; wait $p2; r2=$?; wait $p3; r3=$?; exit $((r1|r2|r3))) && TMPDIR=$(mktemp -d) testcafe firefox tests/setup_redbutton_venue && TMPDIR=$(mktemp -d) testcafe firefox:headless tests/e2e_redbutton",
     "doc": "jsdoc2md 'components/webfield/*Console.js' > webfieldconfig.md",
     "test-setup": "testcafe firefox:headless tests/setup --concurrency 2",
     "templates": "handlebars client/templates/ -n 'window.Handlebars.templates' -f client/templates.js -e 'hbs'",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "next build",
     "start": "next start --port $NEXT_PORT",
     "unit-test": "jest",
-    "test": "testcafe firefox:headless tests/setup --concurrency 2 && (testcafe firefox:headless tests/e2e_1 & p1=$!; testcafe firefox:headless tests/e2e_2 & p2=$!; testcafe firefox:headless tests/e2e_3 & p3=$!; wait $p1 && wait $p2 && wait $p3) && testcafe firefox tests/setup_redbutton_venue && testcafe firefox:headless tests/e2e_redbutton",
+    "test": "testcafe firefox:headless tests/setup --concurrency 2 && (testcafe firefox:headless tests/e2e_1 --ports 1341,1342 & p1=$!; sleep 15; testcafe firefox:headless tests/e2e_2 --ports 1343,1344 & p2=$!; sleep 15; testcafe firefox:headless tests/e2e_3 --ports 1345,1346 & p3=$!; wait $p1; r1=$?; wait $p2; r2=$?; wait $p3; r3=$?; exit $((r1|r2|r3))) && testcafe firefox tests/setup_redbutton_venue && testcafe firefox:headless tests/e2e_redbutton",
     "doc": "jsdoc2md 'components/webfield/*Console.js' > webfieldconfig.md",
     "test-setup": "testcafe firefox:headless tests/setup --concurrency 2",
     "templates": "handlebars client/templates/ -n 'window.Handlebars.templates' -f client/templates.js -e 'hbs'",


### PR DESCRIPTION
this pr should try to fix the browser initialization timeout error in github action runs
by 
- adding a delay of 15 seconds before each test suite start to avoid spike of cpu/memory usage
- assign dedicated communication port to avoid potential port collision
- lower browserInitTimeout so that it fail faster