### PR TITLE
Fix/ ProfileEditor History - Show section error and row error

### DIFF
--- a/ThemeProvider.js
+++ b/ThemeProvider.js
@@ -4,6 +4,8 @@ import { ConfigProvider } from 'antd'
 const primaryColor = '#3e6775'
 const backgroundWhite = '#fffdfa'
 const orRed = '#8c1b13'
+const orRedLight = '#ee8a83'
+const alertRed = '#f2dede'
 const subtleGray = '#616161'
 const backgroundGray = '#dddddd'
 
@@ -80,12 +82,15 @@ const theme = {
     Alert: {
       colorInfoBg: backgroundGray,
       colorText: subtleGray,
+      colorError: orRed,
+      colorErrorBg: alertRed,
+      colorErrorBorder: orRedLight,
     },
     Descriptions: {
       paddingXs: 4,
     },
     Notification: {
-      colorErrorBg: '#f2dede',
+      colorErrorBg: alertRed,
       colorSuccessBg: '#dff0d8',
       colorInfoBg: '#dff0d8',
       width: '80vw',

--- a/app/profile/activate/Activate.module.scss
+++ b/app/profile/activate/Activate.module.scss
@@ -253,6 +253,16 @@
           text-overflow: ellipsis;
         }
       }
+      &__error {
+        clear: both;
+        padding-left: 0;
+        margin-bottom: 5px;
+        color: constants.$orRed;
+        font-size: 0.8125rem;
+        .glyphicon {
+          padding-right: 0.25rem;
+        }
+      }
       .glyphicon-minus-sign {
         margin-top: 0.5rem;
         top: 0;

--- a/app/profile/edit/Edit.module.scss
+++ b/app/profile/edit/Edit.module.scss
@@ -352,6 +352,16 @@
           text-overflow: ellipsis;
         }
       }
+      &__error {
+        clear: both;
+        padding-left: 0;
+        margin-bottom: 5px;
+        color: constants.$orRed;
+        font-size: 0.8125rem;
+        .glyphicon {
+          padding-right: 0.25rem;
+        }
+      }
       .glyphicon-minus-sign {
         margin-top: 0.5rem;
         top: 0;

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -54,6 +54,7 @@ const EducationHistoryRow = ({
   const [isRegionClicked, setIsRegionClicked] = useState(false)
   const invalidFields = profileHistory?.find((q) => q.key === p.key)?.invalidFields
   const isIndependentResearcher = p.position === 'Independent Researcher'
+  const invalidFieldMessages = invalidFields ? [...new Set(Object.values(invalidFields))] : []
 
   const updateDomain = async (domain, key) => {
     if (!domain) {
@@ -137,7 +138,7 @@ const EducationHistoryRow = ({
             aria-label="Position"
           />
         )}
-        {invalidFields?.position && (
+        {/* {invalidFields?.position && (
           <span
             className="invalid-value-icon"
             data-toggle="tooltip"
@@ -146,7 +147,7 @@ const EducationHistoryRow = ({
           >
             <Icon name="exclamation-sign" />
           </span>
-        )}
+        )} */}
       </div>
       <div className="col-md-1 history__value">
         {isMobile && <div className="small-heading col-md-1">Start</div>}
@@ -159,7 +160,7 @@ const EducationHistoryRow = ({
           }
           aria-label="start year"
         />
-        {invalidFields?.startYear && (
+        {/* {invalidFields?.startYear && (
           <span
             className="invalid-value-icon"
             data-toggle="tooltip"
@@ -168,7 +169,7 @@ const EducationHistoryRow = ({
           >
             <Icon name="exclamation-sign" />
           </span>
-        )}
+        )} */}
       </div>
       <div className="col-md-1 history__value">
         {isMobile && <div className="small-heading col-md-1">End</div>}
@@ -181,7 +182,7 @@ const EducationHistoryRow = ({
           }
           aria-label="end year"
         />
-        {invalidFields?.endYear && (
+        {/* {invalidFields?.endYear && (
           <span
             className="invalid-value-icon"
             data-toggle="tooltip"
@@ -190,7 +191,7 @@ const EducationHistoryRow = ({
           >
             <Icon name="exclamation-sign" />
           </span>
-        )}
+        )} */}
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-3">Institution Domain</div>}
@@ -237,7 +238,7 @@ const EducationHistoryRow = ({
             aria-label="Institution Domain"
           />
         )}
-        {invalidFields?.institutionDomain && (
+        {/* {invalidFields?.institutionDomain && (
           <span
             className="invalid-value-icon"
             data-toggle="tooltip"
@@ -246,7 +247,7 @@ const EducationHistoryRow = ({
           >
             <Icon name="exclamation-sign" />
           </span>
-        )}
+        )} */}
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-4">Institution Name</div>}
@@ -265,7 +266,7 @@ const EducationHistoryRow = ({
           }
           aria-label="Institution Name"
         />
-        {invalidFields?.institutionName && (
+        {/* {invalidFields?.institutionName && (
           <span
             className="invalid-value-icon"
             data-toggle="tooltip"
@@ -274,7 +275,7 @@ const EducationHistoryRow = ({
           >
             <Icon name="exclamation-sign" />
           </span>
-        )}
+        )} */}
       </div>
       <div className="col-md-1 history__value">
         {history.length > 1 && (
@@ -324,7 +325,7 @@ const EducationHistoryRow = ({
             aria-label="Institution Country/Region"
           />
         )}
-        {invalidFields?.institutionCountryRegion && (
+        {/* {invalidFields?.institutionCountryRegion && (
           <span
             className="invalid-value-icon"
             data-toggle="tooltip"
@@ -333,7 +334,7 @@ const EducationHistoryRow = ({
           >
             <Icon name="exclamation-sign" />
           </span>
-        )}
+        )} */}
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-4">Institution State/Province</div>}
@@ -380,6 +381,15 @@ const EducationHistoryRow = ({
           aria-label="Department of Institution"
         />
       </div>
+      {invalidFieldMessages.length > 0 && (
+        <div className="col-md-12 history__error" role="alert">
+          {invalidFieldMessages.map((message) => (
+            <div key={message}>
+              <Icon name="exclamation-sign" /> {message}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/profile/ProfileEditor.js
+++ b/components/profile/ProfileEditor.js
@@ -1,4 +1,4 @@
-import { Steps } from 'antd'
+import { Steps, Alert } from 'antd'
 import pick from 'lodash/pick'
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import api from '../../lib/api-client'
@@ -48,6 +48,7 @@ export default function ProfileEditor({
   const [renderPublicationEditor, setRenderPublicationEditor] = useState(false)
   const [currentStepKey, setCurrentStepKey] = useState('names')
   const [invalidStepKeys, setInvalidStepKeys] = useState([])
+  const [historySectionError, setHistorySectionError] = useState(null)
   const stepRef = useRef(null)
   const renderPublicationsEditor = useCallback(() => {
     setRenderPublicationEditor((current) => !current)
@@ -154,8 +155,17 @@ export default function ProfileEditor({
       data: profile.history?.map((p, index) => {
         if ((!invalidKeys && index === 0) || invalidKeys.includes(p.key))
           return { ...p, valid: false, invalidFields: keyErrorFieldMessageMap.get(p.key) }
-        return p
+        return { ...p, valid: true, invalidFields: undefined }
       }),
+    })
+    return { isValid: false, profileContent: null }
+  }
+
+  const promptInvalidHistorySection = (message) => {
+    setHistorySectionError(message)
+    setProfile({
+      type: 'history',
+      data: profile.history?.map((p) => ({ ...p, valid: true, invalidFields: undefined })),
     })
     return { isValid: false, profileContent: null }
   }
@@ -247,16 +257,13 @@ export default function ProfileEditor({
     const historyRecords = profileContent.history
     if (!historyRecords?.length) {
       setInvalidStepKeys((current) => [...current, 'history'])
-      promptError('There are errors in your Career & Education History.')
-      return null
+      return promptInvalidHistorySection("Career & Education History can't be empty.")
     }
     if (!historyRecords.find((p) => !p.end || p.end >= new Date().getFullYear())) {
       setInvalidStepKeys((current) => [...current, 'history'])
-      const keyErrorFieldMessageMap = new Map()
-      keyErrorFieldMessageMap.set(profile.history?.[0]?.key, {
-        endYear: 'Your Career & Education History must include at least one current position.',
-      })
-      return promptInvalidHistory([profile.history?.[0]?.key], keyErrorFieldMessageMap)
+      return promptInvalidHistorySection(
+        'Your Career & Education History must include at least one current position. You can leave end year of current positions blank.'
+      )
     }
 
     const invalidKeys = []
@@ -452,6 +459,7 @@ export default function ProfileEditor({
 
   const handleSubmit = async () => {
     setInvalidStepKeys([])
+    setHistorySectionError(null)
     const { isValid, profileContent, profileReaders } = validateCleanProfile()
     if (isValid) {
       await submitHandler(profileContent, profileReaders, publicationIdsToUnlink)
@@ -609,6 +617,13 @@ export default function ProfileEditor({
           conflict of interest detection, author deduplication, analysis of career path history, and
           tallies of institutional diversity. For ongoing positions, leave the End field blank."
           >
+            {historySectionError && (
+              <Alert
+                type="error"
+                title={historySectionError}
+                style={{ marginBottom: '.5rem' }}
+              />
+            )}
             <EducationHistorySection
               profileHistory={profile?.history}
               positions={positions}
@@ -721,8 +736,17 @@ export default function ProfileEditor({
     if (loadedProfile) {
       setProfile({ type: 'reset', data: loadedProfile })
       setInvalidStepKeys([])
+      setHistorySectionError(null)
     }
   }, [loadedProfile])
+
+  useEffect(() => {
+    if (!invalidStepKeys.length) return
+    const firstInvalidStepKey = stepsItems.find((p) => invalidStepKeys.includes(p.key))?.key
+    if (firstInvalidStepKey && firstInvalidStepKey !== currentStepKey) {
+      setCurrentStepKey(firstInvalidStepKey)
+    }
+  }, [invalidStepKeys])
 
   useEffect(() => {
     const loadOptions = async () => {

--- a/tests/e2e_1/profilePage.ts
+++ b/tests/e2e_1/profilePage.ts
@@ -1379,15 +1379,11 @@ test('validate current history', async (t) => {
       paste: true,
     })
     .click(saveProfileButton)
-    .expect(errorMessageSelector.innerText)
-    .eql('Error: There are errors in your Career & Education History.')
-    .expect(
-      Selector('span.invalid-value-icon').withAttribute(
-        'data-original-title',
-        'Your Career & Education History must include at least one current position.'
-      ).exists
+
+    .expect(Selector('.ant-alert-error').innerText)
+    .contains(
+      'Your Career & Education History must include at least one current position. You can leave end year of current positions blank.'
     )
-    .ok()
     // add current end date
     .typeText(firstHistoryEndInput, new Date().getFullYear().toString(), {
       replace: true,
@@ -1396,6 +1392,8 @@ test('validate current history', async (t) => {
     .click(saveProfileButton)
     .expect(saveProfileButton.hasClass('ant-btn-loading'))
     .notOk({ timeout: 15000 })
+    .expect(Selector('.ant-alert-error').exists)
+    .notOk()
     .expect(errorMessageSelector.innerText)
     .eql('Your profile information has been successfully updated')
 

--- a/tests/e2e_3/registerPage.ts
+++ b/tests/e2e_3/registerPage.ts
@@ -468,6 +468,16 @@ const historyDomainInputs = Selector('div.history')
 const historyNameInputs = Selector('div.history')
   .find('input')
   .withAttribute('aria-label', 'Institution Name')
+const historyStartInputs = Selector('div.history')
+  .find('input')
+  .withAttribute('aria-label', 'start year')
+const historyEndInputs = Selector('div.history')
+  .find('input')
+  .withAttribute('aria-label', 'end year')
+const historySection = Selector('div.history')
+const historySectionError = Selector('.ant-alert-error')
+const historyRowErrors = Selector('div.history').find('.history__error')
+const historyStep = Selector('.ant-steps-item').withText('History')
 
 // oxlint-disable-next-line no-unused-expressions
 fixture`Activate with an institution which is not the one of the email`
@@ -478,15 +488,57 @@ test('register a profile with an institution which is not the one of the email',
     .click(nextSectiomButtonSelector) // personal
     .click(nextSectiomButtonSelector) // emails
     .click(nextSectiomButtonSelector) // links
-    .typeText(Selector('#homepage_url'), 'http://pambeesly.com', { paste: true })
+    .typeText(Selector('#homepage_url'), 'http://test.com', { paste: true })
     .click(nextSectiomButtonSelector) // history
+    .click(nextSectiomButtonSelector) // expertise
+    .click(Selector('button').withText('Register for OpenReview'))
+    .expect(notificationSelector.exists)
+    .notOk()
+    // user is taken back to the first step with error
+    .expect(historySection.exists)
+    .ok()
+    .expect(historyStep.hasClass('ant-steps-item-error'))
+    .ok()
+    .expect(historySectionError.innerText)
+    .contains("Career & Education History can't be empty.")
+
     .click(Selector('input.position-dropdown__placeholder').nth(0))
     .wait(300)
     .pressKey('M S space s t u d e n t tab')
-    // an institution which is not the one of the email of the profile
     .click(Selector('input.institution-dropdown__placeholder').nth(0))
     .typeText(institutionDomainInput, otherInstitutionDomain)
     .pressKey('enter')
+    .click(Selector('input.institution-dropdown__placeholder').nth(1))
+    .typeText(institutionDomainInput, otherInstitutionDomain)
+    .pressKey('enter')
+    .typeText(historyNameInputs.nth(1), otherInstitutionName)
+    .typeText(historyStartInputs.nth(1), '2020', { paste: true })
+    .typeText(historyEndInputs.nth(1), '2015', { paste: true })
+    .click(nextSectiomButtonSelector) // expertise
+    .click(Selector('button').withText('Register for OpenReview'))
+    .expect(messageSelector.innerText)
+    .eql('Error: There are errors in your Career & Education History.')
+    .click(notificationCloseButton)
+    .expect(notificationSelector.exists)
+    .notOk()
+    .expect(historySection.exists)
+    .ok()
+    .expect(historyRowErrors.count)
+    .eql(2)
+    .expect(historyRowErrors.nth(0).innerText)
+    .contains('Institution name is required')
+    .expect(historyRowErrors.nth(0).innerText)
+    .contains('Country/Region is required for current positions')
+    .expect(historyRowErrors.nth(1).innerText)
+    .contains('Position is required')
+    .expect(historyRowErrors.nth(1).innerText)
+    .contains('End date should be higher than start date')
+    // the empty history block is replaced by the per record errors
+    .expect(historySectionError.exists)
+    .notOk()
+
+    // drop the second record and complete the first one
+    .click(historyDomainInputs.nth(1).parent('div.row').find('[aria-label="remove history"]'))
     .typeText(historyNameInputs.nth(0), otherInstitutionName)
     // add mandatory region
     .click(Selector('input.region-dropdown__placeholder'))


### PR DESCRIPTION
currently career/education history section shows error in a tooltip inside each input

this pr should change it to 
- show section wide errors which are not related to specific career/education history row on top 
- show all errors about a row below the row