### PR TITLE
Add "Leave Impersonation" to the user menu

### DIFF
--- a/app/(Home)/LeaveImpersonationLink.js
+++ b/app/(Home)/LeaveImpersonationLink.js
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next/link'
+import api from '../../lib/api-client'
+
+export default function LeaveImpersonationLink({ className, style, onClick }) {
+  const handleLeaveImpersonation = async (e) => {
+    e.preventDefault()
+    onClick?.()
+
+    try {
+      await api.post('/impersonate/exit')
+      window.location.assign('/user/impersonate')
+    } catch (error) {
+      // oxlint-disable-next-line no-console
+      console.log('Error in LeaveImpersonationLink', {
+        page: 'Home',
+        component: 'LeaveImpersonationLink',
+        apiError: error,
+        apiRequest: {
+          endpoint: '/impersonate/exit',
+        },
+      })
+      promptError(error.message)
+    }
+  }
+
+  return (
+    <Link href="#" onClick={handleLeaveImpersonation} className={className} style={style}>
+      Leave Impersonation
+    </Link>
+  )
+}

--- a/app/(Home)/NavLg.js
+++ b/app/(Home)/NavLg.js
@@ -3,6 +3,7 @@
 import { Dropdown } from 'antd'
 import truncate from 'lodash/truncate'
 import Link from 'next/link'
+import LeaveImpersonationLink from './LeaveImpersonationLink'
 import LogoutLink from './LogoutLink'
 import NavSearch from './NavSearch'
 
@@ -34,6 +35,15 @@ export default function NavLg({ user, notificationCountSlot, dropdownOpen, setDr
           style: { padding: 0 },
         },
         { type: 'divider' },
+        ...(user.impersonator
+          ? [
+              {
+                key: 'leave-impersonation',
+                label: <LeaveImpersonationLink className={legacyNavStyles.navDropdownItem} />,
+                style: { padding: 0 },
+              },
+            ]
+          : []),
         {
           key: 'logout',
           label: <LogoutLink className={legacyNavStyles.navDropdownItem} />,

--- a/app/(Home)/NavMd.js
+++ b/app/(Home)/NavMd.js
@@ -3,6 +3,7 @@
 import { Dropdown } from 'antd'
 import truncate from 'lodash/truncate'
 import Link from 'next/link'
+import LeaveImpersonationLink from './LeaveImpersonationLink'
 import LogoutLink from './LogoutLink'
 import NavSearch from './NavSearch'
 
@@ -70,6 +71,15 @@ export default function NavMd({ user, notificationCountSlot, dropdownOpen, setDr
           style: { padding: 0 },
         },
         { type: 'divider' },
+        ...(user.impersonator
+          ? [
+              {
+                key: 'leave-impersonation',
+                label: <LeaveImpersonationLink className={legacyNavStyles.navDropdownItem} />,
+                style: { padding: 0 },
+              },
+            ]
+          : []),
         {
           key: 'logout',
           label: <LogoutLink className={legacyNavStyles.navDropdownItem} />,

--- a/app/(Home)/NavSm.js
+++ b/app/(Home)/NavSm.js
@@ -3,6 +3,7 @@
 import { Drawer } from 'antd'
 import truncate from 'lodash/truncate'
 import Link from 'next/link'
+import LeaveImpersonationLink from './LeaveImpersonationLink'
 import LogoutLink from './LogoutLink'
 import NavSearch from './NavSearch'
 
@@ -111,6 +112,12 @@ export default function NavSm({
               </>
             )}
             <hr className={legacyNavStyles.navDrawerDivider} />
+            {user.impersonator && (
+              <LeaveImpersonationLink
+                className={legacyNavStyles.navDrawerLink}
+                onClick={closeDrawer}
+              />
+            )}
             <LogoutLink className={legacyNavStyles.navDrawerLink} onClick={closeDrawer} />
           </>
         ) : (


### PR DESCRIPTION
## Motivation

Once impersonating a user there was no way back to your own session from the UI: the nav shows "(Impersonated)" but the only exits were logging out entirely or manually clearing cookies. Support workflows often require impersonating several users in a row (e.g. checking a venue's consoles as different reviewers), so leaving impersonation should be one click and should drop you where the next impersonation starts.

## Changes

### New `app/(Home)/LeaveImpersonationLink.js`

Mirrors the existing `LogoutLink` pattern: posts to the new API endpoint `POST /impersonate/exit`, which invalidates the impersonated access/refresh tokens server-side and restores the impersonator's own session cookies. On success it navigates (full page load, `window.location.assign`) to `/user/impersonate`, so the app re-reads the restored cookies and the impersonator lands on the Impersonate User page — with their Previous Impersonations list handy for jumping to the next user. Errors surface via `promptError`, matching `LogoutLink`.

### Nav menus (`NavLg`, `NavMd`, `NavSm`)

The item is rendered only while impersonating (`user.impersonator` is set — the same flag that already drives the "(Impersonated)" label):

- **NavLg / NavMd** (antd Dropdown): added between the divider and Logout.
- **NavSm** (mobile drawer): added directly above Logout; closes the drawer on tap.

No change when not impersonating — the menus render exactly as before.

## Testing

- Verified end to end against a local stack (test data from `test_reviewers_only.py`) with headless Firefox:
  - Impersonating `~ReviewerOne_ABCD1` as the super user, the desktop dropdown shows Profile / Password & Security / **Leave Impersonation** / Logout.
  - Clicking it lands on `/user/impersonate` with the nav showing the original user again (no "(Impersonated)").
  - Not impersonating: the item is absent.
- `oxlint` and `oxfmt --check` clean on the four touched files.

## Dependencies

Requires the openreview-api branch `worktree-fix+1199-allow-impersonation-mode-to-be-logged-out`, which adds `POST /impersonate/exit` (blacklists the abandoned impersonated tokens, restores the impersonator's cookies). Merge/deploy the API side first — without it the link fails with a 404, surfaced via `promptError`.
