### PR TITLE
Fix/ Invitation edit/admin - Tab layout break when browser zoom level change

### DIFF
--- a/components/CodeEditor.js
+++ b/components/CodeEditor.js
@@ -1,14 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
-import { EditorView, basicSetup } from 'codemirror'
+import { indentWithTab } from '@codemirror/commands'
+import { javascriptLanguage, esLint } from '@codemirror/lang-javascript'
+import { jsonLanguage, jsonParseLinter } from '@codemirror/lang-json'
+import { pythonLanguage } from '@codemirror/lang-python'
+import { LanguageSupport } from '@codemirror/language'
+import { linter } from '@codemirror/lint'
 import { StateEffect } from '@codemirror/state'
 import { keymap } from '@codemirror/view'
-import { indentWithTab } from '@codemirror/commands'
-import { LanguageSupport } from '@codemirror/language'
-import { jsonLanguage, jsonParseLinter } from '@codemirror/lang-json'
-import { javascriptLanguage, esLint } from '@codemirror/lang-javascript'
-import { pythonLanguage } from '@codemirror/lang-python'
-import { linter } from '@codemirror/lint'
+import { EditorView, basicSetup } from 'codemirror'
 import Linter from 'eslint4b-prebuilt'
+import { useEffect, useRef, useState } from 'react'
 
 const CodeEditor = ({
   code,
@@ -126,7 +126,13 @@ const CodeEditor = ({
     ])
   }, [language, isVisible])
 
-  return <div className="code-editor disable-tex-rendering" ref={containerRef} />
+  return (
+    <div
+      className="code-editor disable-tex-rendering"
+      style={{ minHeight }}
+      ref={containerRef}
+    />
+  )
 }
 
 export default CodeEditor

--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react'
 import { Tabs as ATabs } from 'antd'
+import { useEffect, useRef } from 'react'
 import Icon from './Icon'
 
 const ORStyles = {
@@ -69,6 +69,6 @@ export function TabPanel({ id, className, children }) {
   )
 }
 
-export function AntdTabs({ items, ...props }) {
-  return <ATabs {...props} items={items} styles={ORStyles} />
+export function AntdTabs({ items, styles, ...props }) {
+  return <ATabs {...props} items={items} styles={{ ...ORStyles, ...styles }} />
 }

--- a/components/invitation/ContentProcessFunctions.js
+++ b/components/invitation/ContentProcessFunctions.js
@@ -1,9 +1,8 @@
-/* globals promptMessage,promptError,$: false */
-
-import { Tab, TabList, TabPanel, TabPanels, Tabs } from '../Tabs'
-import EditorSection from '../EditorSection'
-import { InvitationCodeV2 } from './InvitationCode'
+import { useMemo } from 'react'
 import { prettyField } from '../../lib/utils'
+import EditorSection from '../EditorSection'
+import { AntdTabs } from '../Tabs'
+import { InvitationCodeV2 } from './InvitationCode'
 
 export default function InvitationProcessFunctionsV2({
   invitation,
@@ -14,37 +13,37 @@ export default function InvitationProcessFunctionsV2({
   const contentScripts = Object.keys(invitation.content ?? {}).filter(
     (key) => key.endsWith('_script') && typeof invitation.content[key].value === 'string'
   )
+  const items = useMemo(
+    () =>
+      contentScripts.map((fieldName) => ({
+        key: fieldName,
+        label: prettyField(fieldName),
+        children: (
+          <InvitationCodeV2
+            invitation={invitation}
+            profileId={profileId}
+            loadInvitation={loadInvitation}
+            codeType={`content.${fieldName}.value`}
+            isMetaInvitation={isMetaInvitation}
+            alwaysShowEditor
+            noTitle
+          />
+        ),
+      })),
+    [invitation]
+  )
+
   if (contentScripts.length === 0) {
     return null
   }
 
   return (
     <EditorSection title="Content Process Functions" className="process-functions">
-      <Tabs>
-        <TabList>
-          {contentScripts.map((fieldName, i) => (
-            <Tab key={fieldName} id={fieldName} active={i === 0}>
-              {prettyField(fieldName)}
-            </Tab>
-          ))}
-        </TabList>
-
-        <TabPanels>
-          {contentScripts.map((fieldName) => (
-            <TabPanel key={fieldName} id={fieldName}>
-              <InvitationCodeV2
-                invitation={invitation}
-                profileId={profileId}
-                loadInvitation={loadInvitation}
-                codeType={`content.${fieldName}.value`}
-                isMetaInvitation={isMetaInvitation}
-                alwaysShowEditor
-                noTitle
-              />
-            </TabPanel>
-          ))}
-        </TabPanels>
-      </Tabs>
+      <AntdTabs
+        type="card"
+        styles={{ header: { marginBottom: 0 }, root: { marginTop: '1rem' } }}
+        items={items}
+      />
     </EditorSection>
   )
 }

--- a/components/invitation/InvitationProcessFunctions.js
+++ b/components/invitation/InvitationProcessFunctions.js
@@ -1,87 +1,100 @@
-/* globals promptMessage,promptError,$: false */
-
-import { Tab, TabList, TabPanel, TabPanels, Tabs } from '../Tabs'
+import { InfoCircleFilled } from '@ant-design/icons'
+import { Space, Tooltip } from 'antd'
 import EditorSection from '../EditorSection'
-import Icon from '../Icon'
-import { InvitationCodeV2 } from './InvitationCode'
+import { AntdTabs } from '../Tabs'
 import DateProcessesEditor from './DateProcessesEditor'
+import { InvitationCodeV2 } from './InvitationCode'
 
 const InvitationProcessFunctionsV2 = ({
   invitation,
   profileId,
   loadInvitation,
   isMetaInvitation,
-}) => (
-  <EditorSection title="Process Functions" className="process-functions">
-    <Tabs>
-      <TabList>
-        <Tab id="preprocess">Pre Process</Tab>
-        <Tab id="process" active>
-          Process
-        </Tab>
-        <Tab id="dateprocesses">
-          Date Process{' '}
-          <Icon
-            name="info-sign"
-            tooltip="Use the form below to specify dates expression and delay of date processes, invitation properties can be references with #{}, e.g. #{4/duedate}"
-          />
-        </Tab>
-        <Tab id="postprocesses">
-          Post Process{' '}
-          <Icon
-            name="info-sign"
-            tooltip="Use the form below to specify dates expression and delay of post processes, invitation properties can be references with #{}, e.g. #{4/duedate}"
-          />
-        </Tab>
-      </TabList>
-
-      <TabPanels>
-        <TabPanel id="preprocess">
-          <InvitationCodeV2
-            key={invitation.id}
-            invitation={invitation}
-            profileId={profileId}
-            loadInvitation={loadInvitation}
-            codeType="preprocess"
-            isMetaInvitation={isMetaInvitation}
-            alwaysShowEditor={true}
-            noTitle={true}
-          />
-        </TabPanel>
-        <TabPanel id="process">
-          <InvitationCodeV2
-            key={invitation.id}
-            invitation={invitation}
-            profileId={profileId}
-            loadInvitation={loadInvitation}
-            codeType="process"
-            isMetaInvitation={isMetaInvitation}
-            alwaysShowEditor={true}
-            noTitle={true}
-          />
-        </TabPanel>
-        <TabPanel id="dateprocesses">
-          <DateProcessesEditor
-            key={invitation.id}
-            invitation={invitation}
-            profileId={profileId}
-            loadInvitation={loadInvitation}
-            isMetaInvitation={isMetaInvitation}
-          />
-        </TabPanel>
-        <TabPanel id="postprocesses">
-          <DateProcessesEditor
-            key={invitation.id}
-            invitation={invitation}
-            profileId={profileId}
-            loadInvitation={loadInvitation}
-            isMetaInvitation={isMetaInvitation}
-            field="postprocesses"
-          />
-        </TabPanel>
-      </TabPanels>
-    </Tabs>
-  </EditorSection>
-)
+}) => {
+  return (
+    <EditorSection title="Process Functions" className="process-functions">
+      <AntdTabs
+        type="card"
+        styles={{ header: { marginBottom: 0 }, root: { marginTop: '1rem' } }}
+        items={[
+          {
+            key: 'preprocess',
+            label: 'Pre Process',
+            children: (
+              <InvitationCodeV2
+                key={invitation.id}
+                invitation={invitation}
+                profileId={profileId}
+                loadInvitation={loadInvitation}
+                codeType="preprocess"
+                isMetaInvitation={isMetaInvitation}
+                alwaysShowEditor={true}
+                noTitle={true}
+              />
+            ),
+          },
+          {
+            key: 'process',
+            label: 'Process',
+            children: (
+              <InvitationCodeV2
+                key={invitation.id}
+                invitation={invitation}
+                profileId={profileId}
+                loadInvitation={loadInvitation}
+                codeType="process"
+                isMetaInvitation={isMetaInvitation}
+                alwaysShowEditor={true}
+                noTitle={true}
+              />
+            ),
+          },
+          {
+            key: 'dateprocesses',
+            label: (
+              <Space>
+                Date Process
+                <Tooltip title="Use the form below to specify dates expression and delay of date processes, invitation properties can be references with #{}, e.g. #{4/duedate}">
+                  <InfoCircleFilled />
+                </Tooltip>
+              </Space>
+            ),
+            children: (
+              <DateProcessesEditor
+                key={invitation.id}
+                invitation={invitation}
+                profileId={profileId}
+                loadInvitation={loadInvitation}
+                isMetaInvitation={isMetaInvitation}
+              />
+            ),
+          },
+          {
+            key: 'postprocesses',
+            label: (
+              <Space>
+                Post Process
+                <Tooltip title="Use the form below to specify dates expression and delay of post processes, invitation properties can be references with #{}, e.g. #{4/duedate}">
+                  <InfoCircleFilled />
+                </Tooltip>
+              </Space>
+            ),
+            children: (
+              <DateProcessesEditor
+                key={invitation.id}
+                invitation={invitation}
+                profileId={profileId}
+                loadInvitation={loadInvitation}
+                isMetaInvitation={isMetaInvitation}
+                field="postprocesses"
+              />
+            ),
+          },
+        ]}
+        defaultActiveKey="process"
+      />
+    </EditorSection>
+  )
+}
 
 export default InvitationProcessFunctionsV2


### PR DESCRIPTION
Process Functions and Content Process Functions in invitation edit/admin page breaks (shifting the code editor to right) when user zoom to page to

- 110%
- 125%
- 175%

this is caused by bootstrap bug in layout calculation
this pr should fix the issue by converting the two sections to use antd tab