### PR TITLE
Fix/ Not to show actual script value for sub invitation content field

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1740,6 +1740,9 @@ export function getSubInvitationContentFieldDisplayValue(
       </ul>
     )
   }
+  if (type === 'script') {
+    return 'script'
+  }
   if (type === 'date') {
     return fieldValue !== undefined && fieldValue !== null
       ? formatDateTime(fieldValue, {

--- a/unitTests/utils.test.js
+++ b/unitTests/utils.test.js
@@ -499,6 +499,21 @@ describe('utils', () => {
     expect(expectedValue).toEqual(resultValue)
     // #endregion
 
+    // #region script not to show actual script
+    workflowInvitation = {
+      id: 'ICLR.cc/2025/Conference/-/Confidential_Comment',
+      edit: {
+        invitation: {
+          preprocess: 'async func...',
+        },
+      },
+    }
+    path = 'edit.invitation.preprocess'
+    expectedValue = 'script'
+    resultValue = getSubInvitationContentFieldDisplayValue(workflowInvitation, path, 'script')
+    expect(expectedValue).toEqual(resultValue)
+    // #endregion
+
     // #region date as formatted string
     workflowInvitation = {
       id: 'ICLR.cc/2025/Conference/-/Confidential_Comment',


### PR DESCRIPTION
when sub invitation content field is of type script, the value can get long and showing it is useless to users
this pr should change it to show only "script"