### PR TITLE
Feat/deploy dev via cloud run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: openreview
+          repositories: openreview-cloud
+      - name: Checkout openreview-cloud
+        uses: actions/checkout@v6
+        with:
+          repository: openreview/openreview-cloud
+          path: openreview-cloud
+          token: ${{ steps.app-token.outputs.token }}
       - name: Authenticate with Google Cloud
         id: auth
         uses: google-github-actions/auth@v3
@@ -241,7 +255,14 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           skip_install: true
-      - name: Deploy to dev
+      - name: Build and deploy web to Cloud Run
+        run: |
+          gcloud builds submit \
+            --config openreview-cloud/Terraform/dev/web-cloudrun/build/cloudbuild.yaml \
+            --substitutions=_WEB_REF=master \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            openreview-cloud/Terraform/dev/web-cloudrun/build
+      - name: Deploy openreview-py to dev
         run: |
           instance_prefix='openreview-dev-'
 
@@ -263,7 +284,5 @@ jobs:
           for i in ${!instance_names[@]}; do
             echo Deploying to ${instance_names[$i]}
 
-            gcloud compute ssh --zone ${zones[$i]} --tunnel-through-iap openreview@${instance_names[$i]} --command 'bash bin/build-web.sh' --quiet
-            gcloud compute ssh --zone ${zones[$i]} --tunnel-through-iap openreview@${instance_names[$i]} --command 'bash bin/deploy-web.sh' --quiet
             gcloud compute ssh --zone ${zones[$i]} --tunnel-through-iap openreview@${instance_names[$i]} --command 'bash bin/deploy-openreview-py.sh' --quiet
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,6 +223,10 @@ jobs:
 
     needs: build
 
+    concurrency:
+      group: dev-web-deploy
+      cancel-in-progress: false
+
     if: github.ref == 'refs/heads/master' && (github.event_name != 'repository_dispatch' || github.event.action != 'openreview-api-updated')
     steps:
       - name: Checkout code
@@ -259,7 +263,7 @@ jobs:
         run: |
           gcloud builds submit \
             --config openreview-cloud/Terraform/dev/web-cloudrun/build/cloudbuild.yaml \
-            --substitutions=_WEB_REF=master \
+            --substitutions=_WEB_REF=${{ github.sha }} \
             --project ${{ secrets.GCP_PROJECT_ID }} \
             openreview-cloud/Terraform/dev/web-cloudrun/build
       - name: Deploy openreview-py to dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,20 +231,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: openreview
-          repositories: openreview-cloud
-      - name: Checkout openreview-cloud
-        uses: actions/checkout@v6
-        with:
-          repository: openreview/openreview-cloud
-          path: openreview-cloud
-          token: ${{ steps.app-token.outputs.token }}
       - name: Authenticate with Google Cloud
         id: auth
         uses: google-github-actions/auth@v3
@@ -261,11 +247,16 @@ jobs:
           skip_install: true
       - name: Build and deploy web to Cloud Run
         run: |
-          gcloud builds submit \
-            --config openreview-cloud/Terraform/dev/web-cloudrun/build/cloudbuild.yaml \
+          BUILD_ID=$(gcloud builds triggers run openreview-web-dev-deploy \
+            --region=global --branch=main \
             --substitutions=_WEB_REF=${{ github.sha }} \
             --project ${{ secrets.GCP_PROJECT_ID }} \
-            openreview-cloud/Terraform/dev/web-cloudrun/build
+            --format='value(metadata.build.id)')
+          echo "Triggered Cloud Build: $BUILD_ID"
+          gcloud builds log --stream "$BUILD_ID" --project ${{ secrets.GCP_PROJECT_ID }} || true
+          STATUS=$(gcloud builds describe "$BUILD_ID" --project ${{ secrets.GCP_PROJECT_ID }} --format='value(status)')
+          echo "Final build status: $STATUS"
+          [ "$STATUS" = "SUCCESS" ] || exit 1
       - name: Deploy openreview-py to dev
         run: |
           instance_prefix='openreview-dev-'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,6 +26,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: openreview
+          repositories: openreview-cloud
+      - name: Checkout openreview-cloud
+        uses: actions/checkout@v6
+        with:
+          repository: openreview/openreview-cloud
+          path: openreview-cloud
+          token: ${{ steps.app-token.outputs.token }}
       - name: Authenticate with Google Cloud
         id: auth
         uses: google-github-actions/auth@v3
@@ -40,25 +54,10 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           skip_install: true
-      - name: Run deploy script
+      - name: Build and deploy to Cloud Run
         run: |
-          instance_prefix='openreview-dev-'
-
-          instances=$(gcloud compute instances list | grep "$instance_prefix" | grep RUNNING | tr -s ' ' | cut -d' ' -f1,2)
-
-          instances_arr=(${instances// / })
-
-          instance_names=()
-          zones=()
-          for i in ${!instances_arr[@]}; do
-            if echo "${instances_arr[$i]}" | grep -q "$instance_prefix"; then
-              instance_names+=(${instances_arr[$i]})
-            else
-              zones+=(${instances_arr[$i]})
-            fi
-          done
-
-          for i in ${!instance_names[@]}; do
-            echo Deploying to ${instance_names[$i]}
-            gcloud compute ssh --zone ${zones[$i]} --tunnel-through-iap openreview@${instance_names[$i]} --command "bash bin/build-web.sh ${TAG} && bash bin/deploy-web.sh ${TAG}"
-          done
+          gcloud builds submit \
+            --config openreview-cloud/Terraform/dev/web-cloudrun/build/cloudbuild.yaml \
+            --substitutions=_WEB_REF=${TAG} \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            openreview-cloud/Terraform/dev/web-cloudrun/build

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,21 +29,6 @@ jobs:
       TAG: ${{ github.event.inputs.tag }}
 
     steps:
-      - uses: actions/checkout@v6
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: openreview
-          repositories: openreview-cloud
-      - name: Checkout openreview-cloud
-        uses: actions/checkout@v6
-        with:
-          repository: openreview/openreview-cloud
-          path: openreview-cloud
-          token: ${{ steps.app-token.outputs.token }}
       - name: Authenticate with Google Cloud
         id: auth
         uses: google-github-actions/auth@v3
@@ -60,8 +45,13 @@ jobs:
           skip_install: true
       - name: Build and deploy to Cloud Run
         run: |
-          gcloud builds submit \
-            --config openreview-cloud/Terraform/dev/web-cloudrun/build/cloudbuild.yaml \
+          BUILD_ID=$(gcloud builds triggers run openreview-web-dev-deploy \
+            --region=global --branch=main \
             --substitutions="^::^_WEB_REF=${TAG}" \
             --project ${{ secrets.GCP_PROJECT_ID }} \
-            openreview-cloud/Terraform/dev/web-cloudrun/build
+            --format='value(metadata.build.id)')
+          echo "Triggered Cloud Build: $BUILD_ID"
+          gcloud builds log --stream "$BUILD_ID" --project ${{ secrets.GCP_PROJECT_ID }} || true
+          STATUS=$(gcloud builds describe "$BUILD_ID" --project ${{ secrets.GCP_PROJECT_ID }} --format='value(status)')
+          echo "Final build status: $STATUS"
+          [ "$STATUS" = "SUCCESS" ] || exit 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -21,6 +21,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: dev-web-deploy
+      cancel-in-progress: false
+
     env:
       TAG: ${{ github.event.inputs.tag }}
 
@@ -58,6 +62,6 @@ jobs:
         run: |
           gcloud builds submit \
             --config openreview-cloud/Terraform/dev/web-cloudrun/build/cloudbuild.yaml \
-            --substitutions=_WEB_REF=${TAG} \
+            --substitutions="^::^_WEB_REF=${TAG}" \
             --project ${{ secrets.GCP_PROJECT_ID }} \
             openreview-cloud/Terraform/dev/web-cloudrun/build


### PR DESCRIPTION
## Migrate dev web deployment to Cloud Run

Repoints the two dev-deploy paths from building the Next.js app on the dev VM to building + deploying the `openreview-web-dev` Cloud Run service via Cloud Build. Same auth maintained.

The build config and Dockerfile live in `openreview-cloud` (`Terraform/dev/web-cloudrun/build`), which each job checks out via a GitHub App token (mirroring `deploy-prod.yml`), then runs `gcloud builds submit`. Cloud Build clones this repo at the target ref, bakes `staging.env`, pushes the image, and `gcloud run deploy`s it.

### Changes
- **`deploy-dev.yml` (manual Staging Deployment):** replaces the per-VM SSH `build-web.sh`/`deploy-web.sh` loop with `gcloud builds submit` using the dispatched `tag` (`_WEB_REF=${TAG}`).
- **`build.yml` (deploy job, on push to master):** same swap with `_WEB_REF=master`. The `lint`/`build` CI jobs are unchanged. The `deploy-openreview-py.sh` step is retained as an SSH step — it refreshes openreview-py on the dev box itself and is unrelated to web?



### Tested staging deployment
https://github.com/openreview/openreview-web/actions/runs/33192132067