### PR TITLE
Fix/ Forum Institution Authors - consolidate institution domains

### DIFF
--- a/app/forum/page.js
+++ b/app/forum/page.js
@@ -8,6 +8,7 @@ import Forum from '../../components/forum/Forum'
 import LegacyForum from '../../components/forum/LegacyForum'
 import api from '../../lib/api-client'
 import { referrerLink, venueHomepageLink } from '../../lib/banner-links'
+import { getUniqueInstitutions } from '../../lib/forum-utils'
 import { getConferenceName, getIssn, getJournalName } from '../../lib/utils'
 import serverAuth from '../auth'
 import CommonLayout from '../CommonLayout'
@@ -138,7 +139,15 @@ export async function generateMetadata({ searchParams }) {
       redirectPath: pathToRedirectTo,
       challengeRequired,
       errorMessage,
-    } = await getForumNote(token, userAgent, queryId, invitationId, query, remoteIpAddress, clearanceToken)
+    } = await getForumNote(
+      token,
+      userAgent,
+      queryId,
+      invitationId,
+      query,
+      remoteIpAddress,
+      clearanceToken
+    )
     if (errorMessage || challengeRequired || !forumNote) return fallbackMetadata
     if (pathToRedirectTo) return {}
 
@@ -252,7 +261,15 @@ export default async function page({ searchParams }) {
     redirectPath: pathToRedirectTo,
     challengeRequired,
     errorMessage,
-  } = await getForumNote(token, userAgent, queryId, invitationId, query, remoteIpAddress, clearanceToken)
+  } = await getForumNote(
+    token,
+    userAgent,
+    queryId,
+    invitationId,
+    query,
+    remoteIpAddress,
+    clearanceToken
+  )
   if (challengeRequired) {
     redirect(`/challenge?redirect=${encodeURIComponent(`/forum?${stringify(query)}`)}`)
   }
@@ -277,6 +294,25 @@ export default async function page({ searchParams }) {
     banner = venueHomepageLink(groupId)
   }
   if (version === 2) {
+    const authorsValue = forumNote.content?.authors?.value
+    const uniqueInstitutions = authorsValue?.find((p) => p.institutions)
+      ? getUniqueInstitutions(authorsValue)
+      : []
+
+    let officialInstitutions = null
+    if (uniqueInstitutions.length > 0 && uniqueInstitutions.length <= 20) {
+      try {
+        const { institutions } = await api.get(
+          '/settings/institutions',
+          { domains: uniqueInstitutions.map((p) => p.domain) },
+          { accessToken: token, remoteIpAddress }
+        )
+        officialInstitutions = institutions ?? null
+      } catch (_) {
+        officialInstitutions = null
+      }
+    }
+
     return (
       <CommonLayout banner={<Banner>{banner}</Banner>}>
         <div className={styles.forum}>
@@ -286,6 +322,7 @@ export default async function page({ searchParams }) {
             selectedInvitationId={query.invitationId}
             prefilledValues={pickBy(query, (_, key) => key.startsWith('edit.note.'))}
             query={query}
+            officialInstitutions={officialInstitutions}
           />
         </div>
       </CommonLayout>

--- a/components/NoteAuthors.js
+++ b/components/NoteAuthors.js
@@ -1,9 +1,10 @@
 import { Tooltip } from 'antd'
 import isEqual from 'lodash/isEqual'
-/* globals $: false */
 import uniqBy from 'lodash/uniqBy'
 import zip from 'lodash/zip'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import api from '../lib/api-client'
 import { prettyId } from '../lib/utils'
 import ExpandableList from './ExpandableList'
 import Icon from './Icon'
@@ -200,23 +201,65 @@ export const NoteAuthorsV2 = ({
 }
 
 export const NoteAuthorsWithInstitutions = ({ authors, noteReaders }) => {
+  const [uniqueInstitutions, setUniqueInstitutions] = useState([])
   let showPrivateLabel = false
   const sortedReaders = noteReaders ? [...noteReaders].sort() : []
   if (Array.isArray(authors?.readers) && !isEqual(sortedReaders, authors.readers.sort())) {
     showPrivateLabel = !authors.readers.includes('everyone')
   }
 
+  const deduplicateInstitutions = async () => {
+    const uniqueInstitutionsFromAuthor = uniqBy(
+      authors.value
+        .map((p) => p.institutions)
+        .flat()
+        .filter((p) => p?.domain),
+      (p) => p.domain
+    )
+
+    if (
+      uniqueInstitutionsFromAuthor.length === 0 ||
+      uniqueInstitutionsFromAuthor.length > 20
+    ) {
+      setUniqueInstitutions(uniqueInstitutionsFromAuthor)
+      return
+    }
+
+    try {
+      const { institutions } = await api.get('/settings/institutions', {
+        domains: uniqueInstitutionsFromAuthor.map((p) => p.domain),
+      })
+      const resolvedInstitutions = uniqueInstitutionsFromAuthor.map((authorInstitution) => {
+        const official = institutions?.find(
+          (p) =>
+            p.id === authorInstitution.domain || p.domains?.includes(authorInstitution.domain)
+        )
+        return official
+          ? {
+              ...authorInstitution,
+              name: official.fullname ?? authorInstitution.name,
+              domain: official.id,
+              domains: official.domains,
+            }
+          : authorInstitution
+      })
+      setUniqueInstitutions(uniqBy(resolvedInstitutions, (p) => p.domain))
+    } catch (_) {
+      setUniqueInstitutions(uniqueInstitutionsFromAuthor)
+    }
+  }
+
+  useEffect(() => {
+    if (!authors?.value) return
+    deduplicateInstitutions()
+  }, [authors])
+
   if (!authors?.value) return null
-  const uniqueInstitutions = uniqBy(
-    authors.value
-      .map((p) => p.institutions)
-      .flat()
-      .filter((p) => p?.domain),
-    (p) => p.domain
-  )
 
   const institutionIndexMap = new Map(
-    uniqueInstitutions.map((institution, index) => [institution.domain, index + 1])
+    uniqueInstitutions.flatMap((institution, index) =>
+      (institution.domains ?? [institution.domain]).map((domain) => [domain, index + 1])
+    )
   )
 
   const authorsLinks = authors.value.map((author) => {
@@ -232,9 +275,13 @@ export const NoteAuthorsWithInstitutions = ({ authors, noteReaders }) => {
       )
     }
 
-    const institutionNumbers = (author.institutions || []).map((institution) =>
-      institutionIndexMap.get(institution.domain)
-    )
+    const institutionNumbers = [
+      ...new Set(
+        (author.institutions || [])
+          .map((institution) => institutionIndexMap.get(institution?.domain))
+          .filter(Boolean)
+      ),
+    ]
 
     return (
       <span

--- a/components/NoteAuthors.js
+++ b/components/NoteAuthors.js
@@ -3,8 +3,7 @@ import isEqual from 'lodash/isEqual'
 import uniqBy from 'lodash/uniqBy'
 import zip from 'lodash/zip'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
-import api from '../lib/api-client'
+import { getUniqueInstitutions } from '../lib/forum-utils'
 import { prettyId } from '../lib/utils'
 import ExpandableList from './ExpandableList'
 import Icon from './Icon'
@@ -104,9 +103,16 @@ export const NoteAuthorsV2 = ({
   signatures,
   noteReaders,
   showAuthorInstitutions,
+  officialInstitutions,
 }) => {
   if (showAuthorInstitutions && authorsProp?.value && !authorIdsProp?.value) {
-    return <NoteAuthorsWithInstitutions authors={authorsProp} noteReaders={noteReaders} />
+    return (
+      <NoteAuthorsWithInstitutions
+        authors={authorsProp}
+        noteReaders={noteReaders}
+        officialInstitutions={officialInstitutions}
+      />
+    )
   }
 
   // forum note pass raw authors (for NoteAuthorsWithInstitutions)
@@ -200,61 +206,45 @@ export const NoteAuthorsV2 = ({
   )
 }
 
-export const NoteAuthorsWithInstitutions = ({ authors, noteReaders }) => {
-  const [uniqueInstitutions, setUniqueInstitutions] = useState([])
+export function consolidateInstitutions(authorInstitutions, officialInstitutions) {
+  if (!officialInstitutions?.length) return authorInstitutions
+
+  return uniqBy(
+    authorInstitutions.map((authorInstitution) => {
+      const official = officialInstitutions.find(
+        (p) =>
+          p.id === authorInstitution.domain || p.domains?.includes(authorInstitution.domain)
+      )
+      return official
+        ? {
+            ...authorInstitution,
+            name: official.fullname ?? authorInstitution.name,
+            domain: official.id,
+            domains: official.domains,
+          }
+        : authorInstitution
+    }),
+    (p) => p.domain
+  )
+}
+
+export const NoteAuthorsWithInstitutions = ({
+  authors,
+  noteReaders,
+  officialInstitutions,
+}) => {
   let showPrivateLabel = false
   const sortedReaders = noteReaders ? [...noteReaders].sort() : []
   if (Array.isArray(authors?.readers) && !isEqual(sortedReaders, authors.readers.sort())) {
     showPrivateLabel = !authors.readers.includes('everyone')
   }
 
-  const deduplicateInstitutions = async () => {
-    const uniqueInstitutionsFromAuthor = uniqBy(
-      authors.value
-        .map((p) => p.institutions)
-        .flat()
-        .filter((p) => p?.domain),
-      (p) => p.domain
-    )
-
-    if (
-      uniqueInstitutionsFromAuthor.length === 0 ||
-      uniqueInstitutionsFromAuthor.length > 20
-    ) {
-      setUniqueInstitutions(uniqueInstitutionsFromAuthor)
-      return
-    }
-
-    try {
-      const { institutions } = await api.get('/settings/institutions', {
-        domains: uniqueInstitutionsFromAuthor.map((p) => p.domain),
-      })
-      const resolvedInstitutions = uniqueInstitutionsFromAuthor.map((authorInstitution) => {
-        const official = institutions?.find(
-          (p) =>
-            p.id === authorInstitution.domain || p.domains?.includes(authorInstitution.domain)
-        )
-        return official
-          ? {
-              ...authorInstitution,
-              name: official.fullname ?? authorInstitution.name,
-              domain: official.id,
-              domains: official.domains,
-            }
-          : authorInstitution
-      })
-      setUniqueInstitutions(uniqBy(resolvedInstitutions, (p) => p.domain))
-    } catch (_) {
-      setUniqueInstitutions(uniqueInstitutionsFromAuthor)
-    }
-  }
-
-  useEffect(() => {
-    if (!authors?.value) return
-    deduplicateInstitutions()
-  }, [authors])
-
   if (!authors?.value) return null
+
+  const uniqueInstitutions = consolidateInstitutions(
+    getUniqueInstitutions(authors.value),
+    officialInstitutions
+  )
 
   const institutionIndexMap = new Map(
     uniqueInstitutions.flatMap((institution, index) =>

--- a/components/forum/Forum.js
+++ b/components/forum/Forum.js
@@ -1,9 +1,5 @@
 'use client'
 
-/* globals $: false */
-/* globals typesetMathJax: false */
-/* globals promptError: false */
-
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import debounce from 'lodash/debounce'
@@ -87,6 +83,7 @@ export default function Forum({
   prefilledValues,
   query,
   editInvitationIdToHide,
+  officialInstitutions,
 }) {
   const { user, isRefreshing } = useUser()
   const [parentNote, setParentNote] = useState(forumNote)
@@ -1013,6 +1010,7 @@ export default function Forum({
         note={parentNote}
         updateNote={updateParentNote}
         deleteOrRestoreNote={deleteOrRestoreNote}
+        officialInstitutions={officialInstitutions}
       />
 
       {repliesLoaded && (

--- a/components/forum/ForumNote.js
+++ b/components/forum/ForumNote.js
@@ -12,7 +12,7 @@ import OtherVersions from './OtherVersions'
 
 dayjs.extend(relativeTime)
 
-function ForumNote({ note, updateNote, deleteOrRestoreNote }) {
+function ForumNote({ note, updateNote, deleteOrRestoreNote, officialInstitutions }) {
   const { id, content, details, signatures, editInvitations, deleteInvitation } = note
 
   const pastDue = note.ddate && note.ddate < Date.now()
@@ -103,6 +103,7 @@ function ForumNote({ note, updateNote, deleteOrRestoreNote }) {
             signatures={signatures}
             noteReaders={note.readers}
             showAuthorInstitutions={true}
+            officialInstitutions={officialInstitutions}
           />
         </h3>
       </div>

--- a/lib/forum-utils.js
+++ b/lib/forum-utils.js
@@ -1,8 +1,9 @@
 import get from 'lodash/get'
 import isEmpty from 'lodash/isEmpty'
 import truncate from 'lodash/truncate'
-import { prettyId, buildNoteTitle } from './utils'
+import uniqBy from 'lodash/uniqBy'
 import { buildNoteSearchText } from './edge-utils'
+import { prettyId, buildNoteTitle } from './utils'
 
 /**
  * Convert a flat list of tags into a list of tags where each item in the list is
@@ -367,6 +368,22 @@ export function getReplySnippet(replyContent) {
     omission: '...',
     separator: ' ',
   })
+}
+
+/**
+ * Get the unique (by domain) institutions of a note's authors
+ *
+ * @param {array} authorsValue - array of author objects with an institutions field
+ * @returns {array} unique institution objects with a domain
+ */
+export function getUniqueInstitutions(authorsValue) {
+  return uniqBy(
+    (authorsValue ?? [])
+      .map((p) => p?.institutions)
+      .flat()
+      .filter((p) => p?.domain),
+    (p) => p.domain
+  )
 }
 
 /**

--- a/unitTests/NoteAuthors.test.js
+++ b/unitTests/NoteAuthors.test.js
@@ -1,8 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { NoteAuthorsV2 } from '../components/NoteAuthors'
+import api from '../lib/api-client'
 import '@testing-library/jest-dom'
 
 jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
+
+beforeEach(() => {
+  api.get = jest.fn(() => Promise.resolve())
+})
 
 describe('NoteAuthorsV2', () => {
   // Reviewer can see forum note but not authors/authorids
@@ -25,7 +30,7 @@ describe('NoteAuthorsV2', () => {
   })
 
   // object authors has no authorids field
-  test('renders institutions when there are only authors', () => {
+  test('renders institutions when there are only authors', async () => {
     const authors = {
       value: [
         {
@@ -44,9 +49,117 @@ describe('NoteAuthorsV2', () => {
         showAuthorInstitutions
       />
     )
-    expect(container.querySelector('.note-authors-institutions')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'First Last' })).toBeInTheDocument()
-    expect(screen.getByText(/Test Domain/)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(container.querySelector('.note-authors-institutions')).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'First Last' })).toBeInTheDocument()
+      expect(screen.getByText(/Test Domain/)).toBeInTheDocument()
+    })
+  })
+
+  test('consolidate domains that user entered which map to the same institution object', async () => {
+    // both ustc.edu.cn and mail.ustc.edu.cn map to institution object ustc.edu
+    // so they are consolidated and the fullname from institution object should be used
+    api.get = jest.fn(() => ({
+      institutions: [
+        {
+          id: 'ustc.edu',
+          fullname: 'University of Science and Technology of China',
+          domains: ['ustc.edu', 'ustc.edu.cn', 'mail.ustc.edu.cn'],
+        },
+        {
+          id: 'umass.edu',
+          fullname: 'University of Massachusetts at Amherst',
+          domains: ['umass.edu'],
+        },
+      ],
+    }))
+    const authors = {
+      value: [
+        {
+          fullname: 'Author One',
+          username: '~Authro_One1',
+          institutions: [
+            { domain: 'test.domain', name: 'Test Domain' },
+            { domain: 'umass.edu', name: 'UMASS' },
+          ],
+        },
+        {
+          fullname: 'Author Two',
+          username: '~Authro_Two1',
+          institutions: [
+            {
+              domain: 'mail.ustc.edu.cn',
+              name: 'University of Science and Technology of China',
+            },
+            {
+              domain: 'ustc.edu.cn',
+              name: 'Some Other Name',
+            },
+          ],
+        },
+        {
+          fullname: 'Author Three',
+          username: '~Author_Three1',
+          institutions: [
+            {
+              domain: 'ustc.edu.cn',
+              name: 'University of Science and Technology of China',
+            },
+          ],
+        },
+      ],
+      readers: ['everyone'],
+    }
+    const { container } = render(
+      <NoteAuthorsV2
+        authors={authors}
+        authorIds={undefined}
+        noteReaders={['everyone']}
+        showAuthorInstitutions
+      />
+    )
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith('/settings/institutions', {
+        domains: ['test.domain', 'umass.edu', 'mail.ustc.edu.cn', 'ustc.edu.cn'],
+      })
+
+      expect(container.querySelectorAll('.note-authors-institutions>div')).toHaveLength(3) // test,umass,single ustc
+      expect(screen.queryByText(/Some Other Name/)).not.toBeInTheDocument() // replaced by institution obj fullname
+      expect(screen.queryByText(/ustc\.edu\.cn/)).not.toBeInTheDocument() // both replaced by institution id ustc.edu
+      expect(screen.queryByText(/mail\.ustc\.edu\.cn/)).not.toBeInTheDocument()
+
+      const authorTwo = screen.getByRole('link', { name: 'Author Two' })
+      expect(authorTwo.nextSibling.textContent).toEqual('3') // no duplicated ustc
+
+      const authorThree = screen.getByRole('link', { name: 'Author Three' })
+      expect(authorThree.nextSibling.textContent).toEqual('3')
+    })
+  })
+
+  test('skip institution consolidation when there are more than 20 unique domains', async () => {
+    const authors = {
+      value: Array.from({ length: 21 }, (_, i) => ({
+        fullname: `Author ${i}`,
+        username: `~Author_${i}1`,
+        institutions: [{ domain: `domain${i}`, name: `Domain ${i}` }],
+      })),
+      readers: ['everyone'],
+    }
+    const { container } = render(
+      <NoteAuthorsV2
+        authors={authors}
+        authorIds={undefined}
+        noteReaders={['everyone']}
+        showAuthorInstitutions
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.note-authors-institutions>div')).toHaveLength(21)
+      expect(api.get).not.toHaveBeenCalled()
+      expect(screen.getByText('Domain 20 (domain20)')).toBeInTheDocument()
+    })
   })
 
   // email author added with object author schema has no profile link

--- a/unitTests/NoteAuthors.test.js
+++ b/unitTests/NoteAuthors.test.js
@@ -1,13 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { NoteAuthorsV2 } from '../components/NoteAuthors'
-import api from '../lib/api-client'
+import { render, screen } from '@testing-library/react'
+import { NoteAuthorsV2, consolidateInstitutions } from '../components/NoteAuthors'
 import '@testing-library/jest-dom'
 
 jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
-
-beforeEach(() => {
-  api.get = jest.fn(() => Promise.resolve())
-})
 
 describe('NoteAuthorsV2', () => {
   // Reviewer can see forum note but not authors/authorids
@@ -30,7 +25,7 @@ describe('NoteAuthorsV2', () => {
   })
 
   // object authors has no authorids field
-  test('renders institutions when there are only authors', async () => {
+  test('renders institutions when there are only authors', () => {
     const authors = {
       value: [
         {
@@ -49,30 +44,26 @@ describe('NoteAuthorsV2', () => {
         showAuthorInstitutions
       />
     )
-    await waitFor(() => {
-      expect(container.querySelector('.note-authors-institutions')).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'First Last' })).toBeInTheDocument()
-      expect(screen.getByText(/Test Domain/)).toBeInTheDocument()
-    })
+    expect(container.querySelector('.note-authors-institutions')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'First Last' })).toBeInTheDocument()
+    expect(screen.getByText(/Test Domain/)).toBeInTheDocument()
   })
 
-  test('consolidate domains that user entered which map to the same institution object', async () => {
+  test('consolidate domains that user entered which map to the same institution object', () => {
     // both ustc.edu.cn and mail.ustc.edu.cn map to institution object ustc.edu
     // so they are consolidated and the fullname from institution object should be used
-    api.get = jest.fn(() => ({
-      institutions: [
-        {
-          id: 'ustc.edu',
-          fullname: 'University of Science and Technology of China',
-          domains: ['ustc.edu', 'ustc.edu.cn', 'mail.ustc.edu.cn'],
-        },
-        {
-          id: 'umass.edu',
-          fullname: 'University of Massachusetts at Amherst',
-          domains: ['umass.edu'],
-        },
-      ],
-    }))
+    const officialInstitutions = [
+      {
+        id: 'ustc.edu',
+        fullname: 'University of Science and Technology of China',
+        domains: ['ustc.edu', 'ustc.edu.cn', 'mail.ustc.edu.cn'],
+      },
+      {
+        id: 'umass.edu',
+        fullname: 'University of Massachusetts at Amherst',
+        domains: ['umass.edu'],
+      },
+    ]
     const authors = {
       value: [
         {
@@ -116,28 +107,24 @@ describe('NoteAuthorsV2', () => {
         authorIds={undefined}
         noteReaders={['everyone']}
         showAuthorInstitutions
+        officialInstitutions={officialInstitutions}
       />
     )
 
-    await waitFor(() => {
-      expect(api.get).toHaveBeenCalledWith('/settings/institutions', {
-        domains: ['test.domain', 'umass.edu', 'mail.ustc.edu.cn', 'ustc.edu.cn'],
-      })
+    expect(container.querySelectorAll('.note-authors-institutions>div')).toHaveLength(3) // test,umass,single ustc
+    expect(screen.queryByText(/Some Other Name/)).not.toBeInTheDocument() // replaced by institution obj fullname
+    expect(screen.queryByText(/ustc\.edu\.cn/)).not.toBeInTheDocument() // both replaced by institution id ustc.edu
+    expect(screen.queryByText(/mail\.ustc\.edu\.cn/)).not.toBeInTheDocument()
 
-      expect(container.querySelectorAll('.note-authors-institutions>div')).toHaveLength(3) // test,umass,single ustc
-      expect(screen.queryByText(/Some Other Name/)).not.toBeInTheDocument() // replaced by institution obj fullname
-      expect(screen.queryByText(/ustc\.edu\.cn/)).not.toBeInTheDocument() // both replaced by institution id ustc.edu
-      expect(screen.queryByText(/mail\.ustc\.edu\.cn/)).not.toBeInTheDocument()
+    const authorTwo = screen.getByRole('link', { name: 'Author Two' })
+    expect(authorTwo.nextSibling.textContent).toEqual('3') // no duplicated ustc
 
-      const authorTwo = screen.getByRole('link', { name: 'Author Two' })
-      expect(authorTwo.nextSibling.textContent).toEqual('3') // no duplicated ustc
-
-      const authorThree = screen.getByRole('link', { name: 'Author Three' })
-      expect(authorThree.nextSibling.textContent).toEqual('3')
-    })
+    const authorThree = screen.getByRole('link', { name: 'Author Three' })
+    expect(authorThree.nextSibling.textContent).toEqual('3')
   })
 
-  test('skip institution consolidation when there are more than 20 unique domains', async () => {
+  test('render institutions as entered when officialInstitutions is not available', () => {
+    // officialInstitutions is null when the look up is skipped (20+ domains) or failed
     const authors = {
       value: Array.from({ length: 21 }, (_, i) => ({
         fullname: `Author ${i}`,
@@ -152,14 +139,12 @@ describe('NoteAuthorsV2', () => {
         authorIds={undefined}
         noteReaders={['everyone']}
         showAuthorInstitutions
+        officialInstitutions={null}
       />
     )
 
-    await waitFor(() => {
-      expect(container.querySelectorAll('.note-authors-institutions>div')).toHaveLength(21)
-      expect(api.get).not.toHaveBeenCalled()
-      expect(screen.getByText('Domain 20 (domain20)')).toBeInTheDocument()
-    })
+    expect(container.querySelectorAll('.note-authors-institutions>div')).toHaveLength(21)
+    expect(screen.getByText('Domain 20 (domain20)')).toBeInTheDocument()
   })
 
   // email author added with object author schema has no profile link
@@ -272,5 +257,36 @@ describe('NoteAuthorsV2', () => {
       'title',
       'Identities privately revealed to Conference Submission1 Reviewers'
     )
+  })
+})
+
+describe('consolidateInstitutions', () => {
+  const authorInstitutions = [
+    { domain: 'test.domain', name: 'Test Domain' },
+    { domain: 'mail.ustc.edu.cn', name: 'University of Science and Technology of China' },
+    { domain: 'ustc.edu.cn', name: 'Some Other Name' },
+  ]
+
+  test('merge domains of the same institution object and use its id and fullname', () => {
+    const officialInstitutions = [
+      {
+        id: 'ustc.edu',
+        fullname: 'University of Science and Technology of China',
+        domains: ['ustc.edu', 'ustc.edu.cn', 'mail.ustc.edu.cn'],
+      },
+    ]
+    expect(consolidateInstitutions(authorInstitutions, officialInstitutions)).toEqual([
+      { domain: 'test.domain', name: 'Test Domain' },
+      {
+        domain: 'ustc.edu',
+        domains: ['ustc.edu', 'ustc.edu.cn', 'mail.ustc.edu.cn'],
+        name: 'University of Science and Technology of China',
+      },
+    ])
+  })
+
+  test('return author institutions as entered when there are no official institutions', () => {
+    expect(consolidateInstitutions(authorInstitutions, null)).toEqual(authorInstitutions)
+    expect(consolidateInstitutions(authorInstitutions, [])).toEqual(authorInstitutions)
   })
 })

--- a/unitTests/forum-utils.test.js
+++ b/unitTests/forum-utils.test.js
@@ -12,7 +12,10 @@ describe('getUniqueInstitutions', () => {
           { name: 'No Domain Institution' },
         ],
       },
-      { fullname: 'Author Two', institutions: [{ domain: 'umass.edu', name: 'UMass Amherst' }] },
+      {
+        fullname: 'Author Two',
+        institutions: [{ domain: 'umass.edu', name: 'UMass Amherst' }],
+      },
       { fullname: 'Author Three', institutions: null },
     ]
     expect(getUniqueInstitutions(authors)).toEqual([{ domain: 'umass.edu', name: 'UMASS' }])

--- a/unitTests/forum-utils.test.js
+++ b/unitTests/forum-utils.test.js
@@ -1,0 +1,25 @@
+import { getUniqueInstitutions } from '../lib/forum-utils'
+
+jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
+
+describe('getUniqueInstitutions', () => {
+  test('dedup author institutions by domain and drop institutions without domain', () => {
+    const authors = [
+      {
+        fullname: 'Author One',
+        institutions: [
+          { domain: 'umass.edu', name: 'UMASS' },
+          { name: 'No Domain Institution' },
+        ],
+      },
+      { fullname: 'Author Two', institutions: [{ domain: 'umass.edu', name: 'UMass Amherst' }] },
+      { fullname: 'Author Three', institutions: null },
+    ]
+    expect(getUniqueInstitutions(authors)).toEqual([{ domain: 'umass.edu', name: 'UMASS' }])
+  })
+
+  test('return empty list for missing or string authors', () => {
+    expect(getUniqueInstitutions(undefined)).toEqual([])
+    expect(getUniqueInstitutions(['First Last'])).toEqual([])
+  })
+})


### PR DESCRIPTION
currently the same affiliated institution might be shown multiple times when the domain is different

this pr should fix this issue by querying institution objects and look up the domain so that different domains which belong to the same institution object are consolidated

when there are 20+ current institution domains (many authors or many active institutions), the look up is skipped to avoid constructing too long a query