### PR TITLE
Fix/ Human verification error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 .DS_Store
 .env
 deploy-out-1
+.claude
 
 # debug
 npm-debug.log*

--- a/ThemeProvider.js
+++ b/ThemeProvider.js
@@ -91,6 +91,13 @@ const theme = {
     },
     Modal: {
       contentBg: backgroundWhite,
+      colorBgMask: 'rgba(44, 58, 74, 0.5)',
+      borderRadiusLG: 0,
+      boxShadow: 'none',
+      titleColor: '#2c3a4a',
+      titleFontSize: 24,
+      titleLineHeight: 1.35,
+      fontWeightStrong: 400,
     },
     Dropdown: {
       controlItemBgHover: backgroundGray,

--- a/app/AppInit.js
+++ b/app/AppInit.js
@@ -5,6 +5,7 @@ import { marked } from 'marked'
 import { nanoid } from 'nanoid'
 import { useEffect, useState } from 'react'
 import BibtexModal from '../components/BibtexModal'
+import HumanVerificationModal from '../components/HumanVerificationModal'
 import usePrompt from '../hooks/usePrompt'
 import mathjaxConfig from '../lib/mathjax-config'
 import { allowedHtmlTags } from '../lib/utils'
@@ -105,6 +106,7 @@ export default function AppInit() {
       {notificationHolder}
       <StripeScript />
       {libarysLoaded && <BibtexModal />}
+      <HumanVerificationModal />
     </>
   )
 }

--- a/components/EditorComponents/FileUploadWidget.js
+++ b/components/EditorComponents/FileUploadWidget.js
@@ -1,6 +1,5 @@
 import { nanoid } from 'nanoid'
-import { useContext, useEffect, useRef, useState } from 'react'
-import useTurnstileToken from '../../hooks/useTurnstileToken'
+import { useContext, useRef, useState } from 'react'
 import api from '../../lib/api-client'
 import { prettyField } from '../../lib/utils'
 import EditorComponentContext from '../EditorComponentContext'
@@ -15,20 +14,13 @@ const FileUploadWidget = () => {
   const fileInputRef = useRef(null)
   const [isLoading, setIsLoading] = useState(false)
   const [uploadPercentage, setUploadPercentage] = useState(2)
-  const [hasHumanVerificationError, setHasHumanVerificationError] = useState(false)
-  const { turnstileToken, turnstileContainerRef } = useTurnstileToken(
-    'fileUpload',
-    hasHumanVerificationError
-  )
-
-  const pendingFileRef = useRef(null)
 
   const fieldName = Object.keys(field)[0]
   const [fileName, setFileName] = useState(prettyField(fieldName))
   const maxSize = field[fieldName].value?.param?.maxSize
   const extensions = field[fieldName].value?.param?.extensions?.map((p) => `.${p}`)
 
-  const uploadSingleFileChunk = async (chunk, index, chunkCount, clientUploadId, token) => {
+  const uploadSingleFileChunk = async (chunk, index, chunkCount, clientUploadId) => {
     const data = new FormData()
     data.append('invitationId', invitation.id)
     data.append('name', fieldName)
@@ -41,7 +33,6 @@ const FileUploadWidget = () => {
       ? await Promise.resolve({ url: 'preview url' })
       : await api.put('/attachment/chunk', data, {
           contentType: 'unset',
-          'cf-turnstile-token': token,
         })
     if (result.url) {
       // upload is completed
@@ -58,7 +49,7 @@ const FileUploadWidget = () => {
     }
   }
 
-  const uploadFile = async (file, token) => {
+  const uploadFile = async (file) => {
     setIsLoading(true)
     try {
       const chunkSize = 1024 * 1000 * 5 // 5mb
@@ -76,33 +67,18 @@ const FileUploadWidget = () => {
       const sendChunksPromises = chunks.reduce(
         (oldPromises, currentChunk, i) =>
           oldPromises.then(() =>
-            uploadSingleFileChunk(currentChunk, i, chunkCount, clientUploadId, token)
+            uploadSingleFileChunk(currentChunk, i, chunkCount, clientUploadId)
           ),
         Promise.resolve()
       )
       await sendChunksPromises
       setFileName(file.name)
-      pendingFileRef.current = null
     } catch (apiError) {
-      if (apiError.name === 'HumanVerificationRequiredError' && !noteEditorPreview) {
-        pendingFileRef.current = file
-        setHasHumanVerificationError(true)
-      } else {
-        promptError(apiError.message)
-        fileInputRef.current.value = ''
-      }
+      promptError(apiError.message)
+      fileInputRef.current.value = ''
     }
     setIsLoading(false)
   }
-
-  useEffect(() => {
-    if (!(turnstileToken && hasHumanVerificationError && pendingFileRef.current)) return
-
-    setHasHumanVerificationError(false)
-    uploadFile(pendingFileRef.current, turnstileToken)
-
-    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
-  }, [turnstileToken, hasHumanVerificationError])
 
   const handleFileSelected = async (e) => {
     const file = e.target.files[0]
@@ -111,14 +87,12 @@ const FileUploadWidget = () => {
       promptError(`File is too large. File size limit is ${maxSize} mb`)
       return
     }
-    await uploadFile(file, turnstileToken)
+    await uploadFile(file)
   }
 
   const handleDeleteFile = () => {
     onChange({ fieldName, value: undefined })
     fileInputRef.current.value = ''
-    pendingFileRef.current = null
-    setHasHumanVerificationError(false)
   }
 
   return (
@@ -134,7 +108,7 @@ const FileUploadWidget = () => {
         type="primary"
         className={`${styles.selectFileButton} ${error ? styles.invalidValue : ''}`}
         onClick={() => fileInputRef.current?.click()}
-        disabled={isLoading || hasHumanVerificationError}
+        disabled={isLoading}
         loading={isLoading}
       >{`Choose ${prettyField(fieldName)}`}</SpinnerButton>
       {isLoading && (
@@ -148,7 +122,6 @@ const FileUploadWidget = () => {
           />
         </div>
       )}
-      <div ref={turnstileContainerRef} />
       {value && (
         <>
           <span className={styles.fileUrl}>{`${fileName} (${value})`}</span>

--- a/components/HumanVerificationModal.js
+++ b/components/HumanVerificationModal.js
@@ -47,16 +47,13 @@ const HumanVerificationModal = () => {
     >
       <Flex vertical gap="large">
         <Typography.Text>
-          <div>Before your change can be saved, please confirm you are not a robot.</div>It
-          will be submitted automatically once verified.
+          Before your change can be saved, please confirm you are not a robot.
+          <br />
+          It will be submitted automatically once verified.
         </Typography.Text>
-        {/* The turnstile iframe is a fixed 300px wide. Auto margins center it while it
-            fits and collapse to zero when a narrow viewport would otherwise crop it —
-            the row then scrolls instead. (antd Flex can't express this: its justify
-            prop only accepts preset values, not "safe center".) */}
-        <div style={{ overflowX: 'auto' }}>
-          <div ref={turnstileContainerRef} style={{ width: 'fit-content', margin: '0 auto' }} />
-        </div>
+        <Flex justify="center">
+          <div ref={turnstileContainerRef} />
+        </Flex>
         {showCancelButton && (
           <Flex justify="center">
             <Typography.Text type="secondary">

--- a/components/HumanVerificationModal.js
+++ b/components/HumanVerificationModal.js
@@ -1,0 +1,72 @@
+import { Button, Flex, Modal, Typography } from 'antd'
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import useTurnstileToken from '../hooks/useTurnstileToken'
+import {
+  shouldShowHumanVerificationModal,
+  subscribeShouldShowHumanVerificationModal,
+  updateHumanVerificationTurnstileToken,
+} from '../lib/human-verification-service'
+
+const HumanVerificationModal = () => {
+  const showHumanVerificationModal = useSyncExternalStore(
+    subscribeShouldShowHumanVerificationModal,
+    shouldShowHumanVerificationModal,
+    () => false
+  )
+  const [showCancelButton, setShowCancelButton] = useState(false)
+  const { turnstileToken, turnstileContainerRef } = useTurnstileToken(
+    'globalHumanVerification',
+    showHumanVerificationModal
+  )
+
+  useEffect(() => {
+    if (turnstileToken) updateHumanVerificationTurnstileToken(turnstileToken)
+  }, [turnstileToken])
+
+  useEffect(() => {
+    if (!showHumanVerificationModal) {
+      setShowCancelButton(false)
+      return undefined
+    }
+    const timer = setTimeout(() => setShowCancelButton(true), 5000)
+    return () => clearTimeout(timer)
+  }, [showHumanVerificationModal])
+
+  const cancelVerification = () => updateHumanVerificationTurnstileToken()
+
+  return (
+    <Modal
+      centered
+      open={showHumanVerificationModal}
+      closable={false}
+      keyboard={false}
+      zIndex={1080}
+      mousePosition={{ x: 0, y: 0 }}
+      title="Verification required"
+      footer={showCancelButton && <Button onClick={cancelVerification}>Cancel</Button>}
+    >
+      <Flex vertical gap="large">
+        <Typography.Text>
+          <div>Before your change can be saved, please confirm you are not a robot.</div>It
+          will be submitted automatically once verified.
+        </Typography.Text>
+        {/* The turnstile iframe is a fixed 300px wide. Auto margins center it while it
+            fits and collapse to zero when a narrow viewport would otherwise crop it —
+            the row then scrolls instead. (antd Flex can't express this: its justify
+            prop only accepts preset values, not "safe center".) */}
+        <div style={{ overflowX: 'auto' }}>
+          <div ref={turnstileContainerRef} style={{ width: 'fit-content', margin: '0 auto' }} />
+        </div>
+        {showCancelButton && (
+          <Flex justify="center">
+            <Typography.Text type="secondary">
+              If you cancel, your change will not be saved.
+            </Typography.Text>
+          </Flex>
+        )}
+      </Flex>
+    </Modal>
+  )
+}
+
+export default HumanVerificationModal

--- a/components/NoteEditor.js
+++ b/components/NoteEditor.js
@@ -1,7 +1,6 @@
 import { intersection, isEmpty } from 'lodash'
 import throttle from 'lodash/throttle'
-import { useEffect, useCallback, useReducer, useState, useContext, useRef } from 'react'
-import useTurnstileToken from '../hooks/useTurnstileToken'
+import { useEffect, useCallback, useReducer, useState, useContext } from 'react'
 import useUser from '../hooks/useUser'
 import api from '../lib/api-client'
 import { getNoteContentValues } from '../lib/forum-utils'
@@ -267,11 +266,6 @@ const NoteEditor = ({
   const [autoStorageKeys, setAutoStorageKeys] = useState([])
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errors, setErrors] = useState([])
-  const [hasHumanVerificationError, setHasHumanVerificationError] = useState(false)
-  const { turnstileToken, turnstileContainerRef } = useTurnstileToken(
-    'noteEditor',
-    hasHumanVerificationError
-  )
   const { noteEditorPreview } = useContext(WebFieldContext) ?? {}
   if (noteEditorPreview)
     customValidator = () => ({
@@ -591,9 +585,7 @@ const NoteEditor = ({
             invitationObj: invitation,
             noteObj: note,
           })
-      const result = await api.post('/notes/edits', editToPost, {
-        'cf-turnstile-token': turnstileToken,
-      })
+      const result = await api.post('/notes/edits', editToPost)
       const createdNote = await getCreatedNote(result.note)
       autoStorageKeys.forEach((key) => localStorage.removeItem(key))
       setNoteEditorData({ type: 'reset' })
@@ -601,11 +593,6 @@ const NoteEditor = ({
       closeNoteEditor()
       onNoteCreated(createdNote)
     } catch (error) {
-      if (error.name === 'HumanVerificationRequiredError' && !noteEditorPreview) {
-        setHasHumanVerificationError(true)
-        setIsSubmitting(false)
-        return
-      }
       if (error.errors) {
         setErrors(
           error.errors.map((p) => {
@@ -818,8 +805,6 @@ const NoteEditor = ({
           />
         </div>
       )}
-
-      <div className={styles.turnstileContainer} ref={turnstileContainerRef} />
 
       {Object.values(loading).some((p) => p) ? (
         <LoadingSpinner inline />

--- a/components/forum/ConfirmDeleteModal.js
+++ b/components/forum/ConfirmDeleteModal.js
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import useTurnstileToken from '../../hooks/useTurnstileToken'
 import api from '../../lib/api-client'
 import { getNoteContentValues } from '../../lib/forum-utils'
 import { prettyId } from '../../lib/utils'
@@ -13,11 +12,6 @@ export default function ConfirmDeleteModal({ note, invitation, updateNote, onClo
   const [editSignatures, setEditSignatures] = useState(null)
   const [readersError, setReadersError] = useState(null)
   const [signaturesError, setSignaturesError] = useState(null)
-  const [hasHumanVerificationError, setHasHumanVerificationError] = useState(false)
-  const { turnstileToken, turnstileContainerRef } = useTurnstileToken(
-    'confirmDeleteModal',
-    hasHumanVerificationError
-  )
 
   const noteTitle = note?.content?.title?.value ?? note?.generatedTitle ?? 'Untitled'
   const isDeleted = note && note.ddate && note.ddate < Date.now()
@@ -49,9 +43,7 @@ export default function ConfirmDeleteModal({ note, invitation, updateNote, onClo
       })
     }
     api
-      .post('/notes/edits', editToPost, {
-        'cf-turnstile-token': turnstileToken,
-      })
+      .post('/notes/edits', editToPost)
       .then((res) =>
         // the return of the post is an edit not the full note, so get the updated note again
         api.get('/notes', { id: res.note.id, trash: !isDeleted })
@@ -63,12 +55,8 @@ export default function ConfirmDeleteModal({ note, invitation, updateNote, onClo
         }
       })
       .catch((error) => {
-        if (error.name === 'HumanVerificationRequiredError') {
-          setHasHumanVerificationError(true)
-        } else {
-          promptError(error.message)
-          if (typeof onClose === 'function') onClose()
-        }
+        promptError(error.message)
+        if (typeof onClose === 'function') onClose()
       })
   }
 
@@ -136,7 +124,6 @@ export default function ConfirmDeleteModal({ note, invitation, updateNote, onClo
           }}
         />
       </EditorComponentHeader>
-      <div ref={turnstileContainerRef} />
     </BasicModal>
   )
 }

--- a/components/invitation/InvitationGeneral.js
+++ b/components/invitation/InvitationGeneral.js
@@ -590,7 +590,8 @@ const InvitationGeneralEditV2 = ({
   isMetaInvitation,
 }) => {
   const [isSaving, setIsSaving] = useState(false)
-  const isNoteInvitation = invitation.edit?.note
+  const showHumanVerificationRequired =
+    invitation.edit?.note || invitation.tag || invitation.edge
   const generalInfoReducer = (state, action) => {
     switch (action.type) {
       case 'activationDateTimezone':
@@ -636,7 +637,7 @@ const InvitationGeneralEditV2 = ({
     expDateTimezone: getDefaultTimezone()?.value,
     deletionDateTimezone: getDefaultTimezone()?.value,
     signatures: invitation.signatures?.join(', '),
-    ...(isNoteInvitation && {
+    ...(showHumanVerificationRequired && {
       humanVerificationRequired: invitation.humanVerificationRequired
         ? JSON.stringify(invitation.humanVerificationRequired, null, 2)
         : null,
@@ -666,7 +667,7 @@ const InvitationGeneralEditV2 = ({
         : parseInt(generalInfo.minReplies, 10)
 
     let humanVerificationRequired
-    if (isNoteInvitation && generalInfo.humanVerificationRequired?.trim()) {
+    if (showHumanVerificationRequired && generalInfo.humanVerificationRequired?.trim()) {
       try {
         humanVerificationRequired = JSON.parse(generalInfo.humanVerificationRequired)
       } catch {
@@ -903,7 +904,7 @@ const InvitationGeneralEditV2 = ({
         </div>
       </div>
 
-      {isNoteInvitation && (
+      {showHumanVerificationRequired && (
         <div className="row d-flex">
           <span className="info-title edit-title">Human Verification:</span>
           <div className="info-edit-control">

--- a/hooks/useTurnstileToken.js
+++ b/hooks/useTurnstileToken.js
@@ -1,22 +1,23 @@
 /* globals promptError: false */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export default function useTurnstileToken(key, renderWidget) {
   const [turnstileToken, setTurnstileToken] = useState(null)
   const [widgetId, setWidgetId] = useState(null)
-  const turnstileContainerRef = useRef()
+  const [turnstileContainer, setTurnstileContainer] = useState(null)
 
   useEffect(() => {
-    if (!turnstileContainerRef.current || renderWidget === false) {
+    if (!turnstileContainer || renderWidget === false) {
       setTurnstileToken(null)
       if (widgetId) {
         window.turnstile.remove(widgetId)
+        setWidgetId(null)
       }
       return
     }
     if (window.turnstile) {
       try {
-        const id = window.turnstile.render(turnstileContainerRef.current, {
+        const id = window.turnstile.render(turnstileContainer, {
           sitekey: process.env.TURNSTILE_SITEKEY,
           action: key,
           callback: (token) => {
@@ -33,7 +34,7 @@ export default function useTurnstileToken(key, renderWidget) {
         'Could not verify browser. Please make sure third-party scripts are not being blocked and try again.'
       )
     }
-  }, [key, renderWidget])
+  }, [key, renderWidget, turnstileContainer])
 
-  return { turnstileToken, turnstileContainerRef }
+  return { turnstileToken, turnstileContainerRef: setTurnstileContainer }
 }

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -1,6 +1,7 @@
 import chunk from 'lodash/chunk'
 import { stringify } from 'query-string'
 import { shouldTryRefreshToken } from './clientAuth'
+import { getHumanVerificationToken } from './human-verification-service'
 
 const formatError = (err) => {
   if (process.env.SERVER_ENV !== 'production') {
@@ -57,11 +58,31 @@ const checkStatus = async (response, originalRequest) => {
 
   // On a challenge requirement, send the client to the frontend-served challenge
   // page (SSR handles this via redirect() instead).
-  if (error.status === 403 && error.name === 'ChallengeRequiredError' && typeof window !== 'undefined') {
+  if (
+    error.status === 403 &&
+    error.name === 'ChallengeRequiredError' &&
+    typeof window !== 'undefined'
+  ) {
     const redirectPath = window.location.pathname + window.location.search
     window.location = `/challenge?redirect=${encodeURIComponent(redirectPath)}`
     // Never-resolving promise: halt the chain while the navigation happens.
     return new Promise(() => {})
+  } else if (
+    error.status === 403 &&
+    error.name === 'HumanVerificationRequiredError' &&
+    originalRequest &&
+    typeof window !== 'undefined'
+  ) {
+    const humanVerificationTurnstileToken = await getHumanVerificationToken()
+    if (humanVerificationTurnstileToken) {
+      return fetchFn(originalRequest.url, {
+        ...originalRequest.options,
+        headers: {
+          ...originalRequest.options.headers,
+          'cf-turnstile-token': humanVerificationTurnstileToken,
+        },
+      }).then((reExecuteResponse) => checkStatus(reExecuteResponse))
+    }
   }
 
   return Promise.reject(error)
@@ -122,7 +143,8 @@ const request = (httpMethod) => {
 
     // Forward the guest clearance cookie on SSR calls; client-side requests carry it automatically.
     if (options.clearanceToken) {
-      const clearanceCookieName = process.env.CLEARANCE_COOKIE_NAME || 'openreview.clearanceToken'
+      const clearanceCookieName =
+        process.env.CLEARANCE_COOKIE_NAME || 'openreview.clearanceToken'
       defaultHeaders.Cookie = `${clearanceCookieName}=${options.clearanceToken}`
     }
 
@@ -193,7 +215,15 @@ const put = request('PUT')
 const patch = request('PATCH')
 const del = request('DELETE')
 
-const getById = async (apiPath, id, accessToken, apiVersion, queryParam, remoteIp, clearanceToken) => {
+const getById = async (
+  apiPath,
+  id,
+  accessToken,
+  apiVersion,
+  queryParam,
+  remoteIp,
+  clearanceToken
+) => {
   try {
     const apiRes = await get(
       `/${apiPath}`,
@@ -238,13 +268,36 @@ const getInvitationById = async (
   )
 }
 
-const getNoteById = async (noteId, accessToken, queryParam1, queryParam2, remoteIp, clearanceToken) => {
-  const noteObj = await getById('notes', noteId, accessToken, 2, queryParam1, remoteIp, clearanceToken)
+const getNoteById = async (
+  noteId,
+  accessToken,
+  queryParam1,
+  queryParam2,
+  remoteIp,
+  clearanceToken
+) => {
+  const noteObj = await getById(
+    'notes',
+    noteId,
+    accessToken,
+    2,
+    queryParam1,
+    remoteIp,
+    clearanceToken
+  )
   if (noteObj) {
     return noteObj
   }
 
-  return getById('notes', noteId, accessToken, 1, queryParam2 ?? queryParam1, remoteIp, clearanceToken)
+  return getById(
+    'notes',
+    noteId,
+    accessToken,
+    1,
+    queryParam2 ?? queryParam1,
+    remoteIp,
+    clearanceToken
+  )
 }
 
 const getGroupById = (groupId, accessToken, queryParam) =>

--- a/lib/human-verification-service.js
+++ b/lib/human-verification-service.js
@@ -1,0 +1,25 @@
+let pendingVerification = null
+let notifyModal
+
+export const getHumanVerificationToken = async () => {
+  if (pendingVerification) return null
+  return new Promise((resolve) => {
+    pendingVerification = { resolve }
+    notifyModal()
+  })
+}
+
+export const subscribeShouldShowHumanVerificationModal = (callback) => {
+  notifyModal = callback
+  return () => {
+    notifyModal = undefined
+  }
+}
+
+export const updateHumanVerificationTurnstileToken = (token) => {
+  pendingVerification?.resolve(token)
+  pendingVerification = null
+  notifyModal()
+}
+
+export const shouldShowHumanVerificationModal = () => pendingVerification !== null

--- a/styles/components/LicenseWidget.module.scss
+++ b/styles/components/LicenseWidget.module.scss
@@ -3,7 +3,8 @@
 .container {
   display: inline-block;
   margin-top: 4px;
-  width: 500px;
+  width: 100%;
+  max-width: 500px;
   :global {
     .tooltip-inner {
       max-width: unset;

--- a/styles/components/NoteEditor.module.scss
+++ b/styles/components/NoteEditor.module.scss
@@ -99,8 +99,3 @@
 .invalidValue {
   border-color: constants.$orRed;
 }
-
-.turnstileContainer {
-  margin-left: -0.5rem;
-  margin-top: 0.25rem;
-}

--- a/unitTests/FileUploadWidget.test.js
+++ b/unitTests/FileUploadWidget.test.js
@@ -5,22 +5,9 @@ import api from '../lib/api-client'
 import { renderWithEditorComponentContext } from './util'
 import '@testing-library/jest-dom'
 
-let useTurnstileTokenProps
-
 jest.mock('../lib/api-client')
 jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
 jest.mock('../hooks/useUser', () => () => ({ user: {}, accessToken: 'some token' }))
-jest.mock('../hooks/useTurnstileToken', () => (key, hasHumanVerificationError) => {
-  useTurnstileTokenProps(key, hasHumanVerificationError)
-  if (!hasHumanVerificationError) return {}
-  return {
-    turnstileToken: 'some token',
-  }
-})
-
-beforeEach(() => {
-  useTurnstileTokenProps = jest.fn()
-})
 
 describe('FileUploadWidget', () => {
   test('display choose file button', () => {
@@ -203,9 +190,11 @@ describe('FileUploadWidget', () => {
     })
   })
 
-  test('show turnstile token when api return human verfication error', async () => {
+  test('show error and clear file input when upload fails', async () => {
     const humanVerificationError = new Error('Human verification required')
     humanVerificationError.name = 'HumanVerificationRequiredError'
+    const promptError = jest.fn()
+    global.promptError = jest.fn()
     const onChange = jest.fn()
     const clearError = jest.fn()
     api.put = jest.fn(() => Promise.reject(humanVerificationError))
@@ -232,60 +221,11 @@ describe('FileUploadWidget', () => {
     const file = new File(['some byte string'], 'test.pdf', { type: 'application/pdf' })
     await userEvent.upload(fileInput, file)
 
-    expect(useTurnstileTokenProps).toHaveBeenCalledWith('fileUpload', true)
-  })
-
-  test('retry upload after HumanVerificationRequiredError and turnstile token obtained', async () => {
-    const humanVerificationError = new Error('Human verification required')
-    humanVerificationError.name = 'HumanVerificationRequiredError'
-    const onChange = jest.fn()
-    const clearError = jest.fn()
-    api.put = jest
-      .fn()
-      .mockRejectedValueOnce(humanVerificationError)
-      .mockResolvedValue({ url: 'test url' })
-
-    const providerProps = {
-      value: {
-        invitation: { id: 'invitationId' },
-        field: {
-          supplementary_material: {
-            value: {
-              param: {
-                type: 'file',
-              },
-            },
-          },
-        },
-        onChange,
-        clearError,
-      },
-    }
-    renderWithEditorComponentContext(<FileUploadWidget />, providerProps)
-
-    const fileInput = screen.getByLabelText('supplementary_material')
-    const file = new File(['some byte string'], 'test.pdf', { type: 'application/pdf' })
-    await userEvent.upload(fileInput, file)
-
-    // initial failure + retry with token
     await waitFor(() => {
-      expect(api.put).toHaveBeenCalledTimes(2)
-      expect(api.put).toHaveBeenNthCalledWith(
-        1,
-        '/attachment/chunk',
-        expect.anything(),
-        expect.objectContaining({
-          'cf-turnstile-token': undefined,
-        })
-      )
-      expect(api.put).toHaveBeenNthCalledWith(
-        2,
-        '/attachment/chunk',
-        expect.anything(),
-        expect.objectContaining({
-          'cf-turnstile-token': 'some token',
-        })
-      )
+      expect(api.put).toHaveBeenCalledTimes(1)
+      expect(global.promptError).toHaveBeenCalledWith('Human verification required')
+      expect(fileInput.value).toBe('')
+      expect(onChange).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
this pr should centralized handling of human verification error to api-client
as more and more parts of the site has been managing human verification error separately (and differently)

previously added handling of human verification error in:
- file upload 
- note editor
- confirm delete modal

are removed in this pr

this pr also allow edge and tag invitation to edit human verification prop in invitation general (currently only note invitation allows that)

this pr should replace #2895 which adds individual handling of human verification error in bidding console