### PR TITLE
Fix/ Build workflow - add a step to check formatting of touched files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Run lint
         run: npx --yes oxlint@1.51.0 --report-unused-disable-directives --quiet
+      - name: validate oxfmt
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git diff -z --name-only --diff-filter=ACMR \
+            "$BASE_SHA" HEAD > "$RUNNER_TEMP/changed-files"
+          files=()
+          while IFS= read -r -d '' f; do files+=("$f"); done < "$RUNNER_TEMP/changed-files"
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No files changed."
+            exit 0
+          fi
+          code=0
+          out=$(npx --yes oxfmt@0.36.0 --check "${files[@]}" 2>&1) || code=$?
+          echo "$out"
+          if [ "$code" -eq 2 ] && grep -q "Expected at least one target file" <<< "$out"; then
+            exit 0
+          fi
+          exit "$code"
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this pr should add a step in build pipeline to check whether files touched in a pr are properly formatted
so that ai committed code without formatting are caught and subsequent pr touching the same file do not get irrelevant changes