### PR TITLE
Fix/ Profile edit - update history section input

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,6 +27,7 @@
     "promptError": "readonly",
     "promptLogin": "readonly",
     "promptRefresh": "readonly",
-    "clearMessage": "readonly"
+    "clearMessage": "readonly",
+    "$": "readonly"
   }
 }

--- a/ThemeProvider.js
+++ b/ThemeProvider.js
@@ -43,6 +43,9 @@ const theme = {
       lineWidth: 2,
       optionSelectedBg: primaryColor,
       optionSelectedColor: backgroundWhite,
+      optionSelectedFontWeight: 400,
+      colorError: orRed,
+      colorErrorHover: orRed,
     },
     Input: {
       colorBorder: primaryColor,
@@ -51,6 +54,8 @@ const theme = {
       colorBgContainer: '#fffaf4',
       lineWidth: 2,
       colorTextPlaceholder: '#999',
+      colorError: orRed,
+      colorErrorBorderHover: orRed,
     },
     DatePicker: {
       colorBgContainer: '#fffaf4',

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -63,11 +63,13 @@ const EducationHistoryRow = ({
       } else {
         institutionName = institution.fullname
       }
+      if (lastLookedUpDomain.current !== domain) return
       setHistory({
         type: institutionDomainType,
         data: { value: { institutionDomain: domain, institutionName }, key },
       })
     } catch (error) {
+      if (lastLookedUpDomain.current !== domain) return
       setHistory({
         type: institutionDomainType,
         data: { value: { institutionDomain: domain, institutionName: '' }, key },
@@ -203,7 +205,7 @@ const EducationHistoryRow = ({
           suffixIcon={null}
           optionRender={(option) => <div style={{ whiteSpace: 'normal' }}>{option.label}</div>}
           showSearch={{ optionFilterProp: 'label' }}
-          notFoundContent="No matching found"
+          notFoundContent="No match found"
           aria-label="Institution Country/Region"
         />
       </div>
@@ -317,6 +319,7 @@ const EducationHistorySection = ({
           const recordCopy = { ...p, institution: { ...p.institution } }
           if (p.key === action.data.key) {
             recordCopy.institution = {
+              ...p.institution,
               domain: action.data.value.institutionDomain,
               name: action.data.value.institutionName,
             }

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -1,6 +1,6 @@
 import { AutoComplete, Input, Select } from 'antd'
 import { nanoid } from 'nanoid'
-import { useEffect, useReducer } from 'react'
+import { useEffect, useReducer, useRef } from 'react'
 import useBreakpoint from '../../hooks/useBreakPoint'
 import api from '../../lib/api-client'
 import { getStartEndYear } from '../../lib/utils'
@@ -37,7 +37,10 @@ const EducationHistoryRow = ({
   const isIndependentResearcher = p.position === 'Independent Researcher'
   const invalidFieldMessages = invalidFields ? [...new Set(Object.values(invalidFields))] : []
 
+  const lastLookedUpDomain = useRef(p.institution?.domain)
+
   const updateDomain = async (domain, key) => {
+    lastLookedUpDomain.current = domain
     if (!domain) {
       setHistory({
         type: institutionDomainType,
@@ -124,7 +127,25 @@ const EducationHistoryRow = ({
           value={p.institution?.domain}
           style={{ width: '100%' }}
           status={invalidFields?.institutionDomain ? 'error' : undefined}
-          onChange={(e) => updateDomain(e ?? '', p.key)}
+          onChange={(e) => {
+            setHistory({
+              type: institutionDomainType,
+              data: {
+                value: {
+                  institutionDomain: e ?? '',
+                  institutionName: e ? (p.institution?.name ?? '') : '',
+                },
+                key: p.key,
+              },
+            })
+          }}
+          onSelect={(value) => updateDomain(value, p.key)}
+          onBlur={() => {
+            const currentDomain = p.institution?.domain ?? ''
+            if (currentDomain && currentDomain !== lastLookedUpDomain.current) {
+              updateDomain(currentDomain, p.key)
+            }
+          }}
           placeholder={institutionPlaceholder}
           showSearch={{ filterOption: true }}
           allowClear

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -44,7 +44,7 @@ const EducationHistoryRow = ({
     if (!domain) {
       setHistory({
         type: institutionDomainType,
-        data: { value: { institutionDomain: '', institutionName: '' }, key },
+        data: { value: { institutionDomain: '', institutionName: '' }, key, isCommit: true },
       })
       return
     }
@@ -66,13 +66,17 @@ const EducationHistoryRow = ({
       if (lastLookedUpDomain.current !== domain) return
       setHistory({
         type: institutionDomainType,
-        data: { value: { institutionDomain: domain, institutionName }, key },
+        data: { value: { institutionDomain: domain, institutionName }, key, isCommit: true },
       })
     } catch (error) {
       if (lastLookedUpDomain.current !== domain) return
       setHistory({
         type: institutionDomainType,
-        data: { value: { institutionDomain: domain, institutionName: '' }, key },
+        data: {
+          value: { institutionDomain: domain, institutionName: '' },
+          key,
+          isCommit: true,
+        },
       })
     }
   }
@@ -319,7 +323,7 @@ const EducationHistorySection = ({
           const recordCopy = { ...p, institution: { ...p.institution } }
           if (p.key === action.data.key) {
             recordCopy.institution = {
-              ...p.institution,
+              ...(action.data.isCommit ? {} : p.institution),
               domain: action.data.value.institutionDomain,
               name: action.data.value.institutionName,
             }

--- a/components/profile/EducationHistorySection.js
+++ b/components/profile/EducationHistorySection.js
@@ -1,26 +1,10 @@
+import { AutoComplete, Input, Select } from 'antd'
 import { nanoid } from 'nanoid'
-import dynamic from 'next/dynamic'
-/* globals promptError,$: false */
-import { useEffect, useReducer, useState } from 'react'
+import { useEffect, useReducer } from 'react'
 import useBreakpoint from '../../hooks/useBreakPoint'
 import api from '../../lib/api-client'
 import { getStartEndYear } from '../../lib/utils'
-import Dropdown from '../Dropdown'
 import Icon from '../Icon'
-
-const CreatableDropdown = dynamic(
-  () => import('../Dropdown').then((mod) => mod.CreatableDropdown),
-  {
-    ssr: false,
-    loading: () => (
-      <input
-        className="form-control position-dropdown__placeholder"
-        value="loading..."
-        onChange={() => {}}
-      />
-    ),
-  }
-)
 
 const positionPlaceholder = 'Choose or type a position'
 const institutionPlaceholder = 'Choose or type an institution'
@@ -49,9 +33,6 @@ const EducationHistoryRow = ({
   countryOptions,
   isMobile,
 }) => {
-  const [isPositionClicked, setIsPositionClicked] = useState(false)
-  const [isDomainClicked, setIsDomainClicked] = useState(false)
-  const [isRegionClicked, setIsRegionClicked] = useState(false)
   const invalidFields = profileHistory?.find((q) => q.key === p.key)?.invalidFields
   const isIndependentResearcher = p.position === 'Independent Researcher'
   const invalidFieldMessages = invalidFields ? [...new Set(Object.values(invalidFields))] : []
@@ -95,169 +76,73 @@ const EducationHistoryRow = ({
     <div className="row">
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-2">Position</div>}
-        {isPositionClicked ? (
-          <CreatableDropdown
-            autofocus
-            clientOnly
-            defaultMenuIsOpen
-            hideArrow
-            disableMouseMove
-            isClearable
-            classNamePrefix="position-dropdown"
-            placeholder={positionPlaceholder}
-            isInvalid={invalidFields?.position}
-            defaultValue={p.position ? { value: p.position, label: p.position } : null}
-            onChange={(e) => {
-              setHistory({
-                type: posititonType,
-                data: { value: e ? e.value : '', key: p.key },
-              })
-              if (e) setIsPositionClicked(false)
-            }}
-            onBlur={(e) => {
-              if (e.target.value) {
-                setHistory({
-                  type: posititonType,
-                  data: { value: e.target.value, key: p.key },
-                })
-              }
-              setIsPositionClicked(false)
-            }}
-            options={positionOptions}
-          />
-        ) : (
-          <input
-            className={`form-control position-dropdown__placeholder ${
-              invalidFields?.position ? 'invalid-value' : ''
-            }`}
-            placeholder={positionPlaceholder}
-            value={p.position}
-            onClick={() => setIsPositionClicked(true)}
-            onFocus={() => setIsPositionClicked(true)}
-            onChange={() => {}}
-            aria-label="Position"
-          />
-        )}
-        {/* {invalidFields?.position && (
-          <span
-            className="invalid-value-icon"
-            data-toggle="tooltip"
-            data-placement="top"
-            title={invalidFields.position}
-          >
-            <Icon name="exclamation-sign" />
-          </span>
-        )} */}
+        <AutoComplete
+          options={positionOptions}
+          value={p.position}
+          style={{ width: '100%' }}
+          status={invalidFields?.position ? 'error' : undefined}
+          onChange={(e) =>
+            setHistory({
+              type: posititonType,
+              data: { value: e ?? '', key: p.key },
+            })
+          }
+          placeholder={positionPlaceholder}
+          showSearch={{ filterOption: true }}
+          allowClear
+          aria-label="Position"
+        />
       </div>
       <div className="col-md-1 history__value">
         {isMobile && <div className="small-heading col-md-1">Start</div>}
-        <input
-          className={`form-control ${invalidFields?.startYear ? 'invalid-value' : ''}`}
-          value={p.start ?? ''}
+        <Input
+          value={p.start}
+          status={invalidFields?.startYear ? 'error' : undefined}
           placeholder="start year"
           onChange={(e) =>
             setHistory({ type: startType, data: { value: e.target.value, key: p.key } })
           }
           aria-label="start year"
         />
-        {/* {invalidFields?.startYear && (
-          <span
-            className="invalid-value-icon"
-            data-toggle="tooltip"
-            data-placement="top"
-            title={invalidFields.startYear}
-          >
-            <Icon name="exclamation-sign" />
-          </span>
-        )} */}
       </div>
       <div className="col-md-1 history__value">
         {isMobile && <div className="small-heading col-md-1">End</div>}
-        <input
-          className={`form-control ${invalidFields?.endYear ? 'invalid-value' : ''}`}
-          value={p.end ?? ''}
+        <Input
+          value={p.end}
+          status={invalidFields?.endYear ? 'error' : undefined}
           placeholder="end year"
           onChange={(e) =>
             setHistory({ type: endType, data: { value: e.target.value, key: p.key } })
           }
           aria-label="end year"
         />
-        {/* {invalidFields?.endYear && (
-          <span
-            className="invalid-value-icon"
-            data-toggle="tooltip"
-            data-placement="top"
-            title={invalidFields.endYear}
-          >
-            <Icon name="exclamation-sign" />
-          </span>
-        )} */}
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-3">Institution Domain</div>}
-        {isDomainClicked && !isIndependentResearcher ? (
-          <CreatableDropdown
-            autofocus
-            clientOnly
-            defaultMenuIsOpen
-            hideArrow
-            disableMouseMove
-            virtualList
-            isClearable
-            classNamePrefix="institution-dropdown"
-            placeholder={institutionPlaceholder}
-            isInvalid={invalidFields?.institutionDomain}
-            defaultValue={
-              p.institution?.domain
-                ? { value: p.institution?.domain, label: p.institution?.domain }
-                : null
-            }
-            onChange={(e) => {
-              updateDomain(e?.value ?? '', p.key)
-              if (e) setIsDomainClicked(false)
-            }}
-            onBlur={(e) => {
-              if (e.target.value) {
-                updateDomain(e.target.value, p.key)
-                setIsDomainClicked(false)
-              }
-            }}
-            options={institutionDomainOptions}
-          />
-        ) : (
-          <input
-            className={`form-control institution-dropdown__placeholder ${
-              invalidFields?.institutionDomain ? 'invalid-value' : ''
-            }`}
-            placeholder={institutionPlaceholder}
-            value={p.institution?.domain}
-            disabled={isIndependentResearcher}
-            onClick={() => setIsDomainClicked(true)}
-            onFocus={() => setIsDomainClicked(true)}
-            onChange={() => {}}
-            aria-label="Institution Domain"
-          />
-        )}
-        {/* {invalidFields?.institutionDomain && (
-          <span
-            className="invalid-value-icon"
-            data-toggle="tooltip"
-            data-placement="top"
-            title={invalidFields.institutionDomain}
-          >
-            <Icon name="exclamation-sign" />
-          </span>
-        )} */}
+        <AutoComplete
+          options={institutionDomainOptions}
+          value={p.institution?.domain}
+          style={{ width: '100%' }}
+          status={invalidFields?.institutionDomain ? 'error' : undefined}
+          onChange={(e) => updateDomain(e ?? '', p.key)}
+          placeholder={institutionPlaceholder}
+          showSearch={{ filterOption: true }}
+          allowClear
+          aria-label="Institution Domain"
+          disabled={isIndependentResearcher}
+          styles={
+            isIndependentResearcher ? { input: { color: 'rgba(0, 0, 0, 0.25)' } } : undefined
+          }
+        />
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-4">Institution Name</div>}
-        <input
-          className={`form-control institution-dropdown__name ${
-            invalidFields?.institutionName ? 'invalid-value' : ''
-          }`}
-          placeholder="Institution Name"
-          value={p.institution?.name ?? ''}
+        <Input
+          value={p.institution?.name}
           disabled={isIndependentResearcher}
+          style={isIndependentResearcher ? { borderColor: '#d9d9d9' } : undefined}
+          status={invalidFields?.institutionName ? 'error' : undefined}
+          placeholder="Institution Name"
           onChange={(e) =>
             setHistory({
               type: institutionNameType,
@@ -266,16 +151,6 @@ const EducationHistoryRow = ({
           }
           aria-label="Institution Name"
         />
-        {/* {invalidFields?.institutionName && (
-          <span
-            className="invalid-value-icon"
-            data-toggle="tooltip"
-            data-placement="top"
-            title={invalidFields.institutionName}
-          >
-            <Icon name="exclamation-sign" />
-          </span>
-        )} */}
       </div>
       <div className="col-md-1 history__value">
         {history.length > 1 && (
@@ -291,57 +166,31 @@ const EducationHistoryRow = ({
       </div>
       <div className="col-md-2 history__value">
         {isMobile && <div className="small-heading col-md-4">Institution Country/Region</div>}
-        {isRegionClicked ? (
-          <Dropdown
-            options={countryOptions}
-            onChange={(e) => {
-              setHistory({
-                type: institutionCountryType,
-                data: { value: e?.value, key: p.key },
-              })
-              if (e) setIsRegionClicked(false)
-            }}
-            isInvalid={invalidFields?.institutionCountryRegion}
-            value={countryOptions?.find((q) => q.value === p.institution?.country)}
-            placeholder={regionPlaceholder}
-            classNamePrefix="country-dropdown"
-            hideArrow
-            isClearable
-            defaultMenuIsOpen
-            autoFocus
-          />
-        ) : (
-          <input
-            className={`form-control region-dropdown__placeholder ${
-              invalidFields?.institutionCountryRegion ? 'invalid-value' : ''
-            }`}
-            placeholder={regionPlaceholder}
-            value={
-              countryOptions?.find((q) => q.value === p.institution?.country)?.label ?? ''
-            }
-            onClick={() => setIsRegionClicked(true)}
-            onFocus={() => setIsRegionClicked(true)}
-            onChange={() => {}}
-            aria-label="Institution Country/Region"
-          />
-        )}
-        {/* {invalidFields?.institutionCountryRegion && (
-          <span
-            className="invalid-value-icon"
-            data-toggle="tooltip"
-            data-placement="top"
-            title={invalidFields.institutionCountryRegion}
-          >
-            <Icon name="exclamation-sign" />
-          </span>
-        )} */}
+        <Select
+          options={countryOptions}
+          value={p.institution?.country}
+          placeholder={regionPlaceholder}
+          style={{ width: '100%' }}
+          status={invalidFields?.institutionCountryRegion ? 'error' : undefined}
+          onChange={(e) => {
+            setHistory({
+              type: institutionCountryType,
+              data: { value: e, key: p.key },
+            })
+          }}
+          allowClear
+          suffixIcon={null}
+          optionRender={(option) => <div style={{ whiteSpace: 'normal' }}>{option.label}</div>}
+          showSearch={{ optionFilterProp: 'label' }}
+          notFoundContent="No matching found"
+          aria-label="Institution Country/Region"
+        />
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-4">Institution State/Province</div>}
-        <input
-          className="form-control institution-state"
+        <Input
+          value={p.institution?.stateProvince}
           placeholder="Institution State/Province"
-          value={p.institution?.stateProvince ?? ''}
           onChange={(e) =>
             setHistory({
               type: institutionStateProvinceType,
@@ -353,10 +202,9 @@ const EducationHistoryRow = ({
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-4">Institution City</div>}
-        <input
-          className="form-control institution-city"
+        <Input
+          value={p.institution?.city}
           placeholder="Institution City"
-          value={p.institution?.city ?? ''}
           onChange={(e) =>
             setHistory({
               type: institutionCityType,
@@ -368,10 +216,9 @@ const EducationHistoryRow = ({
       </div>
       <div className="col-md-3 history__value">
         {isMobile && <div className="small-heading col-md-4">Department of Institution</div>}
-        <input
-          className="form-control institution-department"
+        <Input
+          value={p.institution?.department}
           placeholder="Department of Institution"
-          value={p.institution?.department ?? ''}
           onChange={(e) =>
             setHistory({
               type: institutionDepartmentType,
@@ -419,8 +266,7 @@ const EducationHistorySection = ({
           const recordCopy = { ...p }
           if (p.key === action.data.key) {
             recordCopy.position = action.data.value
-            if (action.data.value.toLowerCase().includes('independent')) {
-              recordCopy.position = 'Independent Researcher'
+            if (action.data.value === 'Independent Researcher') {
               recordCopy.institution = {
                 domain: 'independent-researcher.org',
                 name: 'Independent',

--- a/tests/e2e_3/registerPage.ts
+++ b/tests/e2e_3/registerPage.ts
@@ -456,17 +456,19 @@ test('update profile', async (t) => {
     .click(nextSectiomButtonSelector) // links
     .typeText(Selector('#homepage_url'), 'http://homepage.do', { paste: true })
     .click(nextSectiomButtonSelector) // history
-    .click(Selector('input.position-dropdown__placeholder').nth(0))
+    .click(positionInputs.nth(0))
     .wait(300)
     .pressKey('M S space s t u d e n t tab')
     // the institution of the email of the profile must be in the history
-    .click(Selector('input.institution-dropdown__placeholder').nth(0))
-    .typeText(Selector('input.institution-dropdown__input'), 'umass.edu')
-    .click(Selector('div.institution-dropdown__option').withExactText('umass.edu'))
+    .click(historyDomainInputs.nth(0))
+    .typeText(historyDomainInputs.nth(0), 'umass.edu')
+    .click(visibleOptions.withExactText('umass.edu'))
     .pressKey('tab')
+    // let the institution lookup commit before touching region, as it resets country/region
+    .wait(300)
     // add mandatory region
-    .click(Selector('input.region-dropdown__placeholder'))
-    .click(Selector('div.country-dropdown__option').nth(3))
+    .click(regionInputs.nth(0))
+    .click(visibleOptions.nth(3))
 
     .click(nextSectiomButtonSelector) // last section expertise
     .expect(Selector('p').withText('last updated September 24, 2024').exists)
@@ -523,17 +525,19 @@ test('register a profile with an institutional email', async (t) => {
     .click(nextSectiomButtonSelector) // links
     .typeText(Selector('#homepage_url'), 'http://kevinmalone.com', { paste: true })
     .click(nextSectiomButtonSelector) // history
-    .click(Selector('input.position-dropdown__placeholder').nth(0))
+    .click(positionInputs.nth(0))
     .wait(300)
     .pressKey('M S space s t u d e n t tab')
     // the institution of the email of the profile must be in the history
-    .click(Selector('input.institution-dropdown__placeholder').nth(0))
-    .typeText(Selector('input.institution-dropdown__input'), 'umass.edu')
-    .click(Selector('div.institution-dropdown__option').withExactText('umass.edu'))
+    .click(historyDomainInputs.nth(0))
+    .typeText(historyDomainInputs.nth(0), 'umass.edu')
+    .click(visibleOptions.withExactText('umass.edu'))
     .pressKey('tab')
+    // let the institution lookup commit before touching region, as it resets country/region
+    .wait(300)
     // add mandatory region
-    .click(Selector('input.region-dropdown__placeholder'))
-    .click(Selector('div.country-dropdown__option').nth(3))
+    .click(regionInputs.nth(0))
+    .click(visibleOptions.nth(3))
 
     .click(nextSectiomButtonSelector)
     .click(Selector('button').withText('Register for OpenReview'))
@@ -555,7 +559,13 @@ const institutionEmailUserRole = Role(
       .click(Selector('button').withText('Login to OpenReview'))
   }
 )
-const institutionDomainInput = Selector('input.institution-dropdown__input')
+const positionInputs = Selector('div.history')
+  .find('input')
+  .withAttribute('aria-label', 'Position')
+const regionInputs = Selector('div.history')
+  .find('input')
+  .withAttribute('aria-label', 'Institution Country/Region')
+const visibleOptions = Selector('.ant-select-item-option').filterVisible()
 const historyDomainInputs = Selector('div.history')
   .find('input')
   .withAttribute('aria-label', 'Institution Domain')
@@ -596,15 +606,16 @@ test('register a profile with an institution which is not the one of the email',
     .expect(historySectionError.innerText)
     .contains("Career & Education History can't be empty.")
 
-    .click(Selector('input.position-dropdown__placeholder').nth(0))
+    .click(positionInputs.nth(0))
     .wait(300)
     .pressKey('M S space s t u d e n t tab')
-    .click(Selector('input.institution-dropdown__placeholder').nth(0))
-    .typeText(institutionDomainInput, otherInstitutionDomain)
-    .pressKey('enter')
-    .click(Selector('input.institution-dropdown__placeholder').nth(1))
-    .typeText(institutionDomainInput, otherInstitutionDomain)
-    .pressKey('enter')
+    // custom domains are committed on blur (tab), then the failed lookup clears the name
+    .typeText(historyDomainInputs.nth(0), otherInstitutionDomain)
+    .pressKey('tab')
+    .wait(300)
+    .typeText(historyDomainInputs.nth(1), otherInstitutionDomain)
+    .pressKey('tab')
+    .wait(300)
     .typeText(historyNameInputs.nth(1), otherInstitutionName)
     .typeText(historyStartInputs.nth(1), '2020', { paste: true })
     .typeText(historyEndInputs.nth(1), '2015', { paste: true })
@@ -635,8 +646,8 @@ test('register a profile with an institution which is not the one of the email',
     .click(historyDomainInputs.nth(1).parent('div.row').find('[aria-label="remove history"]'))
     .typeText(historyNameInputs.nth(0), otherInstitutionName)
     // add mandatory region
-    .click(Selector('input.region-dropdown__placeholder'))
-    .click(Selector('div.country-dropdown__option').nth(3))
+    .click(regionInputs.nth(0))
+    .click(visibleOptions.nth(3))
 
     .click(nextSectiomButtonSelector)
     .click(Selector('button').withText('Register for OpenReview'))
@@ -653,13 +664,15 @@ test('register a profile with an institution which is not the one of the email',
 
     // the profile is created once the institution of the email is in the history
     .click(Selector('.ant-steps-item').withText('History'))
-    .click(Selector('input.institution-dropdown__placeholder').nth(0))
-    .typeText(institutionDomainInput, institutionEmailDomain)
-    .click(Selector('div.institution-dropdown__option').withExactText(institutionEmailDomain))
+    .click(historyDomainInputs.nth(0))
+    .typeText(historyDomainInputs.nth(0), institutionEmailDomain, { replace: true })
+    .click(visibleOptions.withExactText(institutionEmailDomain))
     .pressKey('tab')
+    // let the institution lookup commit before touching region, as it resets country/region
+    .wait(300)
     // add mandatory region again as selecting an institution resets country/region
-    .click(Selector('input.region-dropdown__placeholder'))
-    .click(Selector('div.country-dropdown__option').nth(3))
+    .click(regionInputs.nth(0))
+    .click(visibleOptions.nth(3))
     .click(nextSectiomButtonSelector)
     .click(Selector('button').withText('Register for OpenReview'))
     .expect(messageSelector.innerText)
@@ -681,15 +694,16 @@ test('replace the institution of the email in the history', async (t) => {
     .eql(institutionEmailDomain)
     // add the history of another institution
     .click(Selector('[aria-label="add another history"]'))
-    .click(Selector('input.position-dropdown__placeholder').nth(1))
+    .click(positionInputs.nth(1))
     .wait(300)
     .pressKey('M S space s t u d e n t tab')
-    .click(Selector('input.institution-dropdown__placeholder').nth(1))
-    .typeText(institutionDomainInput, otherInstitutionDomain)
-    .pressKey('enter')
+    // custom domains are committed on blur (tab), then the failed lookup clears the name
+    .typeText(historyDomainInputs.nth(1), otherInstitutionDomain)
+    .pressKey('tab')
+    .wait(300)
     .typeText(historyNameInputs.nth(1), otherInstitutionName)
-    .click(Selector('input.region-dropdown__placeholder').nth(1))
-    .click(Selector('div.country-dropdown__option').nth(3))
+    .click(regionInputs.nth(1))
+    .click(visibleOptions.nth(3))
     // remove the history of the institution of the email
     .click(historyDomainInputs.nth(0).parent('div.row').find('[aria-label="remove history"]'))
     .expect(historyDomainInputs.count)


### PR DESCRIPTION
this is part of the change to add 
Independent Researcher
High School Student 

in position dropdown

all input in history row are converted to use antd controls so that it's easier to use
as independent researcher is an option, the include "independent" logic and lock domain logic is removed 

modify prefixed_positions document after this pr is merged