### PR TITLE
Fix/ Profile preview modal - Add separate delete documents button

### DIFF
--- a/components/profile/IdentityDocumentsSection.js
+++ b/components/profile/IdentityDocumentsSection.js
@@ -62,19 +62,9 @@ const DocumentMetadata = ({ item, loadIdentityDocuments, inline = false }) => {
   )
 }
 
-const IdentityDocumentsSection = ({
-  profileId,
-  profileDocuments,
-  loadIdentityDocuments,
-  deleteAllLabel = 'Delete All Identity Documents',
-  onBeforeDeleteAll,
-  onAfterDeleteAll,
-}) => {
+export const ProfileDocumentsPreview = ({ profileDocuments, loadIdentityDocuments }) => {
   if (!profileDocuments) return <LoadingSpinner inline />
-  if (!profileDocuments.length) return 'No Identity Documents'
-  const shouldShowActionButton = profileDocuments.some(
-    ({ type, ddate }) => type !== 'parentalConsent' && !ddate
-  )
+  if (!profileDocuments.length) return 'No Documents'
 
   const items = profileDocuments.map(
     ({ id, type, extension, filename, size, tcdate, ddate }, index) => ({
@@ -94,13 +84,159 @@ const IdentityDocumentsSection = ({
     })
   )
 
-  const deleteAllDocuments = async () => {
+  return (
+    <Image.PreviewGroup
+      items={items.map((item) => ({ src: item.src }))}
+      preview={{
+        imageRender: (originalNode, { current }) => {
+          const item = items[current]
+          if (!item) return originalNode
+          if (item.ddate) {
+            return (
+              <div
+                onMouseDown={(e) => e.stopPropagation()}
+                style={{
+                  background: '#fff',
+                  borderRadius: 4,
+                  padding: '2.5rem 3rem',
+                  maxWidth: 480,
+                  textAlign: 'left',
+                }}
+              >
+                <DocumentMetadata
+                  item={item}
+                  loadIdentityDocuments={loadIdentityDocuments}
+                  inline
+                />
+              </div>
+            )
+          }
+          let content = originalNode
+          if (item.isPdf) {
+            content = (
+              <iframe
+                title={`Identity document ${current + 1}`}
+                src={item.src}
+                onMouseDown={(e) => e.stopPropagation()}
+                style={{
+                  width: '80vw',
+                  height: '90vh',
+                  border: 'none',
+                  borderRadius: 4,
+                  background: '#fff',
+                }}
+              />
+            )
+          }
+          return (
+            <>
+              {content}
+              <DocumentMetadata item={item} loadIdentityDocuments={loadIdentityDocuments} />
+            </>
+          )
+        },
+
+        actionsRender: (originalNode, { current }) =>
+          items[current]?.isPdf || items[current]?.ddate ? null : originalNode,
+      }}
+    >
+      <Flex gap="small" wrap align="flex-start">
+        {items.map((item, index) => {
+          if (item.ddate) {
+            return (
+              <div key={item.key} style={{ position: 'relative' }}>
+                <Image
+                  src={item.src}
+                  alt={`Identity document ${index + 1} (deleted)`}
+                  width={76}
+                  height={100}
+                  style={{
+                    boxSizing: 'border-box',
+                    border: '1px dashed #d9d9d9',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                  }}
+                />
+                <span
+                  style={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    color: '#999',
+                    fontSize: '0.75rem',
+                    pointerEvents: 'none',
+                  }}
+                >
+                  Deleted
+                </span>
+              </div>
+            )
+          }
+          if (item.isPdf) {
+            return (
+              <Image
+                key={item.key}
+                src={pdfThumbnail}
+                preview={{ src: item.src }}
+                alt={`Identity document ${index + 1} (PDF)`}
+                width={76}
+                height={100}
+                style={{
+                  boxSizing: 'border-box',
+                  padding: 18,
+                  background: '#fafafa',
+                  border: '1px solid #f0f0f0',
+                  borderRadius: 4,
+                  objectFit: 'contain',
+                  cursor: 'pointer',
+                }}
+              />
+            )
+          }
+          return (
+            <Image
+              key={item.key}
+              src={item.src}
+              alt={`Identity document ${index + 1}`}
+              height={100}
+              style={{ borderRadius: 4 }}
+            />
+          )
+        })}
+      </Flex>
+    </Image.PreviewGroup>
+  )
+}
+
+export const ParentalConsentSection = ({ profileDocuments }) => {
+  const parentalConsentDocuments = profileDocuments?.filter(
+    (document) => document.type === 'parentalConsent'
+  )
+  return <ProfileDocumentsPreview profileDocuments={parentalConsentDocuments} />
+}
+
+export const IdentityDocumentsSection = ({
+  profileId,
+  profileDocuments,
+  isProfileActivatable,
+  loadIdentityDocuments,
+  tagAndActivateProfile,
+  loadTags,
+}) => {
+  const identityDocuments = profileDocuments?.filter(
+    (document) => document.type !== 'parentalConsent'
+  )
+  const shouldShowActionButton = identityDocuments?.some(({ ddate }) => !ddate)
+
+  const deleteAllDocuments = async (shouldActiveProfile = false) => {
     const confirmDelete = window.confirm(
       `Identity documents of ${profileId} will be deleted. This action cannot be undone.`
     )
     if (!confirmDelete) return
     try {
-      await onBeforeDeleteAll?.()
+      if (shouldActiveProfile) await tagAndActivateProfile?.()
+
       const { deletedCount } = await api.delete(
         `/profile-documents/identity/profiles/${profileId}`
       )
@@ -108,142 +244,36 @@ const IdentityDocumentsSection = ({
         `${inflect(deletedCount, 'document has', 'documents have', true)} been deleted`
       )
       loadIdentityDocuments()
-      onAfterDeleteAll?.()
+      if (shouldActiveProfile) loadTags?.()
     } catch (error) {
+      console.log('error:', error)
       promptError(error.message)
     }
   }
 
   return (
     <div>
-      <Image.PreviewGroup
-        items={items.map((item) => ({ src: item.src }))}
-        preview={{
-          imageRender: (originalNode, { current }) => {
-            const item = items[current]
-            if (!item) return originalNode
-            if (item.ddate) {
-              return (
-                <div
-                  onMouseDown={(e) => e.stopPropagation()}
-                  style={{
-                    background: '#fff',
-                    borderRadius: 4,
-                    padding: '2.5rem 3rem',
-                    maxWidth: 480,
-                    textAlign: 'left',
-                  }}
-                >
-                  <DocumentMetadata
-                    item={item}
-                    loadIdentityDocuments={loadIdentityDocuments}
-                    inline
-                  />
-                </div>
-              )
-            }
-            let content = originalNode
-            if (item.isPdf) {
-              content = (
-                <iframe
-                  title={`Identity document ${current + 1}`}
-                  src={item.src}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  style={{
-                    width: '80vw',
-                    height: '90vh',
-                    border: 'none',
-                    borderRadius: 4,
-                    background: '#fff',
-                  }}
-                />
-              )
-            }
-            return (
-              <>
-                {content}
-                <DocumentMetadata item={item} loadIdentityDocuments={loadIdentityDocuments} />
-              </>
-            )
-          },
-
-          actionsRender: (originalNode, { current }) =>
-            items[current]?.isPdf || items[current]?.ddate ? null : originalNode,
-        }}
-      >
-        <Flex gap="small" wrap align="flex-start">
-          {items.map((item, index) => {
-            if (item.ddate) {
-              return (
-                <div key={item.key} style={{ position: 'relative' }}>
-                  <Image
-                    src={item.src}
-                    alt={`Identity document ${index + 1} (deleted)`}
-                    width={76}
-                    height={100}
-                    style={{
-                      boxSizing: 'border-box',
-                      border: '1px dashed #d9d9d9',
-                      borderRadius: 4,
-                      cursor: 'pointer',
-                    }}
-                  />
-                  <span
-                    style={{
-                      position: 'absolute',
-                      top: '50%',
-                      left: '50%',
-                      transform: 'translate(-50%, -50%)',
-                      color: '#999',
-                      fontSize: '0.75rem',
-                      pointerEvents: 'none',
-                    }}
-                  >
-                    Deleted
-                  </span>
-                </div>
-              )
-            }
-            if (item.isPdf) {
-              return (
-                <Image
-                  key={item.key}
-                  src={pdfThumbnail}
-                  preview={{ src: item.src }}
-                  alt={`Identity document ${index + 1} (PDF)`}
-                  width={76}
-                  height={100}
-                  style={{
-                    boxSizing: 'border-box',
-                    padding: 18,
-                    background: '#fafafa',
-                    border: '1px solid #f0f0f0',
-                    borderRadius: 4,
-                    objectFit: 'contain',
-                    cursor: 'pointer',
-                  }}
-                />
-              )
-            }
-            return (
-              <Image
-                key={item.key}
-                src={item.src}
-                alt={`Identity document ${index + 1}`}
-                height={100}
-                style={{ borderRadius: 4 }}
-              />
-            )
-          })}
-        </Flex>
-      </Image.PreviewGroup>
+      <ProfileDocumentsPreview profileDocuments={identityDocuments} />
       {shouldShowActionButton && (
-        <Button type="primary" style={{ marginTop: '.25rem' }} onClick={deleteAllDocuments}>
-          {deleteAllLabel}
-        </Button>
+        <Space>
+          <Button
+            type="primary"
+            style={{ marginTop: '.25rem' }}
+            onClick={() => deleteAllDocuments()}
+          >
+            {isProfileActivatable ? 'Delete Documents Only' : 'Delete Identity Documents'}
+          </Button>
+          {isProfileActivatable && (
+            <Button
+              type="primary"
+              style={{ marginTop: '.25rem' }}
+              onClick={() => deleteAllDocuments(true)}
+            >
+              Activate with ID check
+            </Button>
+          )}
+        </Space>
       )}
     </div>
   )
 }
-
-export default IdentityDocumentsSection

--- a/components/profile/IdentityDocumentsSection.js
+++ b/components/profile/IdentityDocumentsSection.js
@@ -246,7 +246,6 @@ export const IdentityDocumentsSection = ({
       loadIdentityDocuments()
       if (shouldActiveProfile) loadTags?.()
     } catch (error) {
-      console.log('error:', error)
       promptError(error.message)
     }
   }

--- a/components/profile/ProfilePreviewModal.js
+++ b/components/profile/ProfilePreviewModal.js
@@ -5,7 +5,7 @@ import { getRejectionReasons } from '../../lib/utils'
 import ErrorAlert from '../ErrorAlert'
 import ProfileTag from '../ProfileTag'
 import BasicProfileView from './BasicProfileView'
-import IdentityDocumentsSection from './IdentityDocumentsSection'
+import { IdentityDocumentsSection, ParentalConsentSection } from './IdentityDocumentsSection'
 import MessagesSection from './MessagesSection'
 import PastStatesSection from './PastStatesSection'
 import ProfilePublications from './ProfilePublications'
@@ -233,25 +233,18 @@ const ProfilePreviewModal = ({
           <>
             {profileDocuments?.some((document) => document.type === 'parentalConsent') && (
               <ProfileViewSection title="Parental Consent">
-                <IdentityDocumentsSection
-                  profileId={profileToPreview.id}
-                  profileDocuments={profileDocuments.filter(
-                    (document) => document.type === 'parentalConsent'
-                  )}
-                />
+                <ParentalConsentSection profileDocuments={profileDocuments} />
               </ProfileViewSection>
             )}
             {profileDocuments?.some((document) => document.type !== 'parentalConsent') && (
               <ProfileViewSection title="Identity Documents">
                 <IdentityDocumentsSection
                   profileId={profileToPreview.id}
-                  profileDocuments={profileDocuments.filter(
-                    (document) => document.type !== 'parentalConsent'
-                  )}
+                  profileDocuments={profileDocuments}
+                  isProfileActivatable={isProfileActivatable}
                   loadIdentityDocuments={loadIdentityDocuments}
-                  deleteAllLabel={isProfileActivatable ? 'Activate with ID check' : undefined}
-                  onBeforeDeleteAll={isProfileActivatable ? tagAndActivateProfile : undefined}
-                  onAfterDeleteAll={isProfileActivatable ? loadTags : undefined}
+                  tagAndActivateProfile={tagAndActivateProfile}
+                  loadTags={loadTags}
                 />
               </ProfileViewSection>
             )}

--- a/unitTests/IdentityDocumentsSection.test.js
+++ b/unitTests/IdentityDocumentsSection.test.js
@@ -1,6 +1,10 @@
 import { screen, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import IdentityDocumentsSection from '../components/profile/IdentityDocumentsSection'
+import {
+  IdentityDocumentsSection,
+  ParentalConsentSection,
+  ProfileDocumentsPreview,
+} from '../components/profile/IdentityDocumentsSection'
 import api from '../lib/api-client'
 import '@testing-library/jest-dom'
 
@@ -11,13 +15,13 @@ jest.mock('antd', () => ({
   Image: { PreviewGroup: () => <span>preview</span> },
 }))
 
-describe('IdentityDocumentsSection', () => {
+describe('ProfileDocumentsPreview', () => {
   test('show loading spinner when documents are being loaded', () => {
     const props = {
       profileDocuments: undefined,
     }
 
-    render(<IdentityDocumentsSection {...props} />)
+    render(<ProfileDocumentsPreview {...props} />)
     expect(screen.getByText('loading spinner')).toBeInTheDocument()
   })
 
@@ -26,9 +30,9 @@ describe('IdentityDocumentsSection', () => {
       profileDocuments: [],
     }
 
-    render(<IdentityDocumentsSection {...props} />)
+    render(<ProfileDocumentsPreview {...props} />)
     expect(screen.queryByText('loading spinner')).not.toBeInTheDocument()
-    expect(screen.getByText('No Identity Documents')).toBeInTheDocument()
+    expect(screen.getByText('No Documents')).toBeInTheDocument()
   })
 
   test('show image preview', () => {
@@ -45,12 +49,53 @@ describe('IdentityDocumentsSection', () => {
       ],
     }
 
-    render(<IdentityDocumentsSection {...props} />)
+    render(<ProfileDocumentsPreview {...props} />)
 
     expect(screen.getByText('preview')).toBeInTheDocument()
   })
+})
 
-  test('show default deleteAllLabel when not passed', () => {
+describe('IdentityDocumentsSection', () => {
+  test('not to show button when there are no documents', () => {
+    const props = {
+      profileDocuments: undefined,
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  test('not to show button when all documents are deleted documents', () => {
+    const props = {
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+          ddate: 'some ddate',
+        },
+        {
+          id: 'another id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'another name',
+          size: '12345',
+          tcdate: 'test tcdate',
+          ddate: 'some ddate',
+        },
+      ],
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  test('show delete documents button', () => {
     const props = {
       profileDocuments: [
         {
@@ -61,18 +106,27 @@ describe('IdentityDocumentsSection', () => {
           size: '12345',
           tcdate: 'test tcdate',
         },
+        {
+          id: 'another id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'another name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
       ],
-      deleteAllLabel: undefined,
+      isProfileActivatable: false, // for exmaple profile is already active
     }
 
     render(<IdentityDocumentsSection {...props} />)
 
+    expect(screen.queryAllByRole('button')).toHaveLength(1)
     expect(
-      screen.getByRole('button', { name: 'Delete All Identity Documents' })
+      screen.getByRole('button', { name: 'Delete Identity Documents' })
     ).toBeInTheDocument()
   })
 
-  test('allow custom deleteAllLabel', () => {
+  test('show delete documents and activate profile button', () => {
     const props = {
       profileDocuments: [
         {
@@ -83,18 +137,29 @@ describe('IdentityDocumentsSection', () => {
           size: '12345',
           tcdate: 'test tcdate',
         },
+        {
+          id: 'another id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'another name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
       ],
-      deleteAllLabel: 'Activate with ID check',
+      isProfileActivatable: true,
     }
 
     render(<IdentityDocumentsSection {...props} />)
 
+    expect(screen.queryAllByRole('button')).toHaveLength(2)
+    expect(screen.getByRole('button', { name: 'Delete Documents Only' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Activate with ID check' })).toBeInTheDocument()
   })
 
   test('show confirm window before deleting all documents', async () => {
     window.confirm = jest.fn()
     const props = {
+      profileId: '~Test_Id1',
       profileDocuments: [
         {
           id: 'some id',
@@ -104,28 +169,36 @@ describe('IdentityDocumentsSection', () => {
           size: '12345',
           tcdate: 'test tcdate',
         },
+        {
+          id: 'another id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'another name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
       ],
-      deleteAllLabel: undefined,
+      isProfileActivatable: false,
     }
 
     render(<IdentityDocumentsSection {...props} />)
 
-    const deleteButton = screen.getByRole('button', { name: 'Delete All Identity Documents' })
+    const deleteButton = screen.getByRole('button', { name: 'Delete Identity Documents' })
     await userEvent.click(deleteButton)
 
     await waitFor(() => {
       expect(window.confirm).toHaveBeenCalledWith(
-        `Identity documents of undefined will be deleted. This action cannot be undone.`
+        `Identity documents of ~Test_Id1 will be deleted. This action cannot be undone.`
       )
     })
   })
 
-  test('call beforeDelete, delete and afterDelete', async () => {
+  test('delete all documents when delete documents button is clicked', async () => {
     window.confirm = jest.fn(() => true)
-    beforeDelete = jest.fn()
-    afterDelete = jest.fn()
+    const loadIdentityDocuments = jest.fn()
+    const tagAndActivateProfile = jest.fn()
+    const loadTags = jest.fn()
     api.delete = jest.fn(() => Promise.resolve({ deletedCount: 1 }))
-    loadIdentityDocuments = jest.fn()
     global.promptMessage = jest.fn()
 
     const props = {
@@ -139,24 +212,122 @@ describe('IdentityDocumentsSection', () => {
           size: '12345',
           tcdate: 'test tcdate',
         },
+        {
+          id: 'another id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'another name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
       ],
-      deleteAllLabel: undefined,
-      onBeforeDeleteAll: beforeDelete,
-      onAfterDeleteAll: afterDelete,
-      loadIdentityDocuments: loadIdentityDocuments,
+      isProfileActivatable: true,
+      loadIdentityDocuments,
+      tagAndActivateProfile,
+      loadTags,
     }
 
     render(<IdentityDocumentsSection {...props} />)
 
-    const deleteButton = screen.getByRole('button', { name: 'Delete All Identity Documents' })
+    const deleteButton = screen.getByRole('button', { name: 'Delete Documents Only' })
     await userEvent.click(deleteButton)
 
     await waitFor(() => {
-      expect(beforeDelete).toHaveBeenCalled()
       expect(api.delete).toHaveBeenCalledWith('/profile-documents/identity/profiles/~Test_Id1')
       expect(global.promptMessage).toHaveBeenCalledWith('1 document has been deleted')
       expect(loadIdentityDocuments).toHaveBeenCalled()
-      expect(afterDelete).toHaveBeenCalled()
+      expect(tagAndActivateProfile).not.toHaveBeenCalled()
+      expect(loadTags).not.toHaveBeenCalled()
     })
+  })
+
+  test('delete all documents and activate profile when activate with id check button is clicked', async () => {
+    window.confirm = jest.fn(() => true)
+    const loadIdentityDocuments = jest.fn()
+    const tagAndActivateProfile = jest.fn()
+    const loadTags = jest.fn()
+    api.delete = jest.fn(() => Promise.resolve({ deletedCount: 1 }))
+    global.promptMessage = jest.fn()
+
+    const props = {
+      profileId: '~Test_Id1',
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+        {
+          id: 'another id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'another name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+      isProfileActivatable: true,
+      loadIdentityDocuments,
+      tagAndActivateProfile,
+      loadTags,
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    const activateWithIDCheckButton = screen.getByRole('button', {
+      name: 'Activate with ID check',
+    })
+    await userEvent.click(activateWithIDCheckButton)
+
+    await waitFor(() => {
+      expect(api.delete).toHaveBeenCalledWith('/profile-documents/identity/profiles/~Test_Id1')
+      expect(global.promptMessage).toHaveBeenCalledWith('1 document has been deleted')
+      expect(loadIdentityDocuments).toHaveBeenCalled()
+      expect(tagAndActivateProfile).toHaveBeenCalled()
+      expect(loadTags).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('ParentalConsentSection', () => {
+  test('show parental consent documents', () => {
+    const props = {
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'parentalConsent',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+    }
+
+    render(<ParentalConsentSection {...props} />)
+
+    expect(screen.getByText('preview')).toBeInTheDocument()
+  })
+
+  test('not to show identity documents', () => {
+    const props = {
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+    }
+
+    render(<ParentalConsentSection {...props} />)
+
+    expect(screen.queryByText('preview')).not.toBeInTheDocument()
   })
 })

--- a/unitTests/IdentityDocumentsSection.test.js
+++ b/unitTests/IdentityDocumentsSection.test.js
@@ -1,0 +1,162 @@
+import { screen, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import IdentityDocumentsSection from '../components/profile/IdentityDocumentsSection'
+import api from '../lib/api-client'
+import '@testing-library/jest-dom'
+
+jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
+jest.mock('../components/LoadingSpinner', () => () => <span>loading spinner</span>)
+jest.mock('antd', () => ({
+  ...jest.requireActual('antd'),
+  Image: { PreviewGroup: () => <span>preview</span> },
+}))
+
+describe('IdentityDocumentsSection', () => {
+  test('show loading spinner when documents are being loaded', () => {
+    const props = {
+      profileDocuments: undefined,
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+    expect(screen.getByText('loading spinner')).toBeInTheDocument()
+  })
+
+  test('show empty text when there are no documents', () => {
+    const props = {
+      profileDocuments: [],
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+    expect(screen.queryByText('loading spinner')).not.toBeInTheDocument()
+    expect(screen.getByText('No Identity Documents')).toBeInTheDocument()
+  })
+
+  test('show image preview', () => {
+    const props = {
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    expect(screen.getByText('preview')).toBeInTheDocument()
+  })
+
+  test('show default deleteAllLabel when not passed', () => {
+    const props = {
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+      deleteAllLabel: undefined,
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Delete All Identity Documents' })
+    ).toBeInTheDocument()
+  })
+
+  test('allow custom deleteAllLabel', () => {
+    const props = {
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+      deleteAllLabel: 'Activate with ID check',
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    expect(screen.getByRole('button', { name: 'Activate with ID check' })).toBeInTheDocument()
+  })
+
+  test('show confirm window before deleting all documents', async () => {
+    window.confirm = jest.fn()
+    const props = {
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+      deleteAllLabel: undefined,
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete All Identity Documents' })
+    await userEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledWith(
+        `Identity documents of undefined will be deleted. This action cannot be undone.`
+      )
+    })
+  })
+
+  test('call beforeDelete, delete and afterDelete', async () => {
+    window.confirm = jest.fn(() => true)
+    beforeDelete = jest.fn()
+    afterDelete = jest.fn()
+    api.delete = jest.fn(() => Promise.resolve({ deletedCount: 1 }))
+    loadIdentityDocuments = jest.fn()
+    global.promptMessage = jest.fn()
+
+    const props = {
+      profileId: '~Test_Id1',
+      profileDocuments: [
+        {
+          id: 'some id',
+          type: 'identity',
+          extension: 'pdf',
+          filename: 'some name',
+          size: '12345',
+          tcdate: 'test tcdate',
+        },
+      ],
+      deleteAllLabel: undefined,
+      onBeforeDeleteAll: beforeDelete,
+      onAfterDeleteAll: afterDelete,
+      loadIdentityDocuments: loadIdentityDocuments,
+    }
+
+    render(<IdentityDocumentsSection {...props} />)
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete All Identity Documents' })
+    await userEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(beforeDelete).toHaveBeenCalled()
+      expect(api.delete).toHaveBeenCalledWith('/profile-documents/identity/profiles/~Test_Id1')
+      expect(global.promptMessage).toHaveBeenCalledWith('1 document has been deleted')
+      expect(loadIdentityDocuments).toHaveBeenCalled()
+      expect(afterDelete).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
this pr should show a button to only delete the document without activating the profile
besides existing "activate with id check" button

the purpose is to clear a non-responding user from the identity documents list?