### PR TITLE
Fix/ Leaving OpenReview warning

### DIFF
--- a/app/group/ComponentGroup.js
+++ b/app/group/ComponentGroup.js
@@ -1,13 +1,14 @@
 'use client'
 
-/* globals promptError: false */
-import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
+import { useEffect, useRef, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import WebFieldContext from '../../components/WebFieldContext'
-import LoadingSpinner from '../../components/LoadingSpinner'
 import { setBannerContent } from '../../bannerSlice'
+import ExternalLinkNotice from '../../components/ExternalLinkNotice'
+import LoadingSpinner from '../../components/LoadingSpinner'
+import WebFieldContext from '../../components/WebFieldContext'
 import CommonLayout from '../CommonLayout'
+
 import styles from './Group.module.scss'
 
 export default function ComponentGroup({ componentObj, editBanner }) {
@@ -17,6 +18,7 @@ export default function ComponentGroup({ componentObj, editBanner }) {
     ['ProgramChairConsole', 'SeniorAreaChairConsole'].includes(componentObj?.component) &&
     webComponentProps.displayReplyInvitations?.length
   const dispatch = useDispatch()
+  const containerRef = useRef(null)
 
   useEffect(() => {
     if (!componentObj) return
@@ -59,11 +61,12 @@ export default function ComponentGroup({ componentObj, editBanner }) {
     >
       <div className={styles.group}>
         <WebFieldContext.Provider value={webComponentProps}>
-          <div id="group-container">
+          <div id="group-container" ref={containerRef}>
             <WebComponent
               appContext={{ setBannerContent: (e) => dispatch(setBannerContent(e)) }}
             />
           </div>
+          <ExternalLinkNotice containerRef={containerRef} />
         </WebFieldContext.Provider>
       </div>
     </CommonLayout>

--- a/app/invitation/ComponentInvitation.js
+++ b/app/invitation/ComponentInvitation.js
@@ -1,18 +1,19 @@
 'use client'
 
-/* globals promptError: false */
-import { use, useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
+import { use, useEffect, useRef, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import WebFieldContext from '../../components/WebFieldContext'
-import LoadingSpinner from '../../components/LoadingSpinner'
 import { setBannerContent } from '../../bannerSlice'
+import ExternalLinkNotice from '../../components/ExternalLinkNotice'
+import LoadingSpinner from '../../components/LoadingSpinner'
+import WebFieldContext from '../../components/WebFieldContext'
 
 export default function ComponentInvitation({ componentObjP }) {
   const componentObj = use(componentObjP)
   const [WebComponent, setWebComponent] = useState(null)
   const [webComponentProps, setWebComponentProps] = useState({})
   const dispatch = useDispatch()
+  const containerRef = useRef(null)
 
   useEffect(() => {
     if (!componentObj) return
@@ -47,7 +48,7 @@ export default function ComponentInvitation({ componentObjP }) {
 
   return (
     <WebFieldContext.Provider value={webComponentProps}>
-      <div id="invitation-container">
+      <div id="invitation-container" ref={containerRef}>
         {WebComponent && webComponentProps ? (
           <WebComponent
             appContext={{ setBannerContent: (e) => dispatch(setBannerContent(e)) }}
@@ -56,6 +57,7 @@ export default function ComponentInvitation({ componentObjP }) {
           <LoadingSpinner />
         )}
       </div>
+      <ExternalLinkNotice containerRef={containerRef} />
     </WebFieldContext.Provider>
   )
 }

--- a/components/ExternalLinkNotice.js
+++ b/components/ExternalLinkNotice.js
@@ -61,7 +61,7 @@ export default function ExternalLinkNotice({ containerRef }) {
       onCancel={() => setExternalLink(null)}
     >
       <Typography.Paragraph>
-        This site is outside OpenReview and we are not responsible for its content or safety.
+        This site is outside OpenReview. OpenReview is not responsible for its content or safety.
       </Typography.Paragraph>
       <Typography.Paragraph style={{ overflowWrap: 'anywhere' }}>
         {externalLink}

--- a/components/ExternalLinkNotice.js
+++ b/components/ExternalLinkNotice.js
@@ -61,7 +61,8 @@ export default function ExternalLinkNotice({ containerRef }) {
       onCancel={() => setExternalLink(null)}
     >
       <Typography.Paragraph>
-        This site is outside OpenReview. OpenReview is not responsible for its content or safety.
+        This site is outside OpenReview. OpenReview is not responsible for its content or
+        safety.
       </Typography.Paragraph>
       <Typography.Paragraph style={{ overflowWrap: 'anywhere' }}>
         {externalLink}

--- a/components/ExternalLinkNotice.js
+++ b/components/ExternalLinkNotice.js
@@ -1,0 +1,71 @@
+import { Modal, Typography } from 'antd'
+import { useEffect, useState } from 'react'
+
+export function getExternalUrl(href) {
+  let url
+  try {
+    url = new URL(href, window.location.href)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+
+  return url.hostname === window.location.hostname ? null : url
+}
+
+export default function ExternalLinkNotice({ containerRef }) {
+  const [externalLink, setExternalLink] = useState(null)
+
+  useEffect(() => {
+    const container = containerRef?.current
+    if (!container) return undefined
+
+    const interceptClick = (event) => {
+      if (event.defaultPrevented || event.button !== 0) return
+      const anchor = event.target.closest?.('a[href]')
+      if (!anchor || !container.contains(anchor)) return
+      const url = getExternalUrl(anchor.getAttribute('href'))
+      if (!url) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      setExternalLink(url.href)
+    }
+
+    container.addEventListener('click', interceptClick, true)
+    return () => container.removeEventListener('click', interceptClick, true)
+  }, [containerRef])
+
+  const continueToLink = () => {
+    window.open(externalLink, '_blank', 'noopener,noreferrer')
+    setExternalLink(null)
+  }
+
+  return (
+    <Modal
+      centered
+      open={!!externalLink}
+      zIndex={1080}
+      mousePosition={{ x: 0, y: 0 }}
+      title="You are leaving OpenReview"
+      closable={false}
+      styles={{
+        container: { padding: '2.5rem' },
+        header: { marginBottom: '2.5rem' },
+        title: { textAlign: 'center' },
+        footer: { marginTop: '2.5rem' },
+      }}
+      okText="Continue"
+      cancelText="Cancel"
+      onOk={continueToLink}
+      onCancel={() => setExternalLink(null)}
+    >
+      <Typography.Paragraph>
+        This site is outside OpenReview and we are not responsible for its content or safety.
+      </Typography.Paragraph>
+      <Typography.Paragraph style={{ overflowWrap: 'anywhere' }}>
+        {externalLink}
+      </Typography.Paragraph>
+    </Modal>
+  )
+}

--- a/components/ExternalLinkNotice.js
+++ b/components/ExternalLinkNotice.js
@@ -47,7 +47,7 @@ export default function ExternalLinkNotice({ containerRef }) {
       open={!!externalLink}
       zIndex={1080}
       mousePosition={{ x: 0, y: 0 }}
-      title="You are leaving OpenReview"
+      title="You're leaving OpenReview"
       closable={false}
       styles={{
         container: { padding: '2.5rem' },
@@ -61,11 +61,14 @@ export default function ExternalLinkNotice({ containerRef }) {
       onCancel={() => setExternalLink(null)}
     >
       <Typography.Paragraph>
-        This site is outside OpenReview. OpenReview is not responsible for its content or
-        safety.
+        This link was posted by a user and takes you to a site OpenReview doesn&apos;t control:
       </Typography.Paragraph>
       <Typography.Paragraph style={{ overflowWrap: 'anywhere' }}>
         {externalLink}
+      </Typography.Paragraph>
+      <Typography.Paragraph>
+        OpenReview doesn&apos;t review, endorse, or take responsibility for content on external
+        sites. Check the address above before continuing.
       </Typography.Paragraph>
     </Modal>
   )


### PR DESCRIPTION
this pr should intercept click event in group and invitation page and show a modal to warn the user when the link leaves openreview