### PR TITLE
Fix/ DBLP Import

### DIFF
--- a/components/DblpImportModal.js
+++ b/components/DblpImportModal.js
@@ -1,14 +1,12 @@
-/* globals $,clearMessage,promptError: false */
-
 import { nanoid } from 'nanoid'
 import { useState, useRef, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { setBannerContent } from '../bannerSlice'
 import {
-  getDblpPublicationsFromXmlUrl,
   getAllPapersByGroupId,
   postOrUpdatePaper,
   getAllPapersImportedByOtherProfiles,
+  getDblpPublicationsFromSparQL,
 } from '../lib/profiles'
 import { deburrString, getNameString, inflect } from '../lib/utils'
 import DblpPublicationTable from './DblpPublicationTable'
@@ -115,8 +113,8 @@ export default function DblpImportModal({ profileId, profileNames, updateDBLPUrl
 
     try {
       const { notes: allDblpPublications, possibleNames } =
-        await getDblpPublicationsFromXmlUrl(
-          `${url.trim()}.xml`,
+        await getDblpPublicationsFromSparQL(
+          url,
           profileId,
           profileNames.map((p) => getNameString(p))
         )

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -433,7 +433,7 @@ export async function getDblpPublicationsFromSparQL(url, profileId, profileNames
   const publicationRows = await runDblpSparqlQuery(`
     PREFIX dblp: <https://dblp.org/rdf/schema#>
     SELECT ?pub ?bibtype ?title ?year ?month ?venue ?journal ?volume ?number ?chapter ?pages
-          ?ee ?isbn ?booktitle ?crossref ?publisher ?authors
+          ?ee ?isbn ?booktitle ?crossref ?publisher ?school ?authors
     WHERE {
       {
         SELECT ?pub
@@ -461,6 +461,7 @@ export async function getDblpPublicationsFromSparQL(url, profileId, profileNames
       OPTIONAL { ?pub dblp:isbn ?isbn }
       OPTIONAL { ?pub dblp:publishedAsPartOf ?crossref }
       OPTIONAL { ?pub dblp:publishedBy ?publisher }
+      OPTIONAL { ?pub dblp:thesisAcceptedBySchool ?school }
     }`)
 
   const publicationsByKey = new Map()

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -403,73 +403,114 @@ export function xpathSelect(xpathExpression, contextNode, atomNameSpace = false)
   return xmlNodes
 }
 
-export async function getDblpPublicationsFromXmlUrl(xmlUrl, profileId, profileNames) {
-  const xPathPublicationsSelector =
-    '//dblpperson/r/article|//dblpperson/r/inproceedings|//dblpperson/r/proceedings|//dblpperson/r/conference|//dblpperson/r/book|//dblpperson/r/incollection|//dblpperson/r/phdthesis|//dblpperson/r/masterthesis'
-  const xPathHomoAuthorSelector = '//dblpperson//person[@publtype="disambiguation"]'
-  const xPathAuthorSelector = '//dblpperson/person/author'
-  const possibleNames = new Set()
+const dblpSparqlEndpoint = 'https://sparql.dblp.org/sparql'
+
+const runDblpSparqlQuery = async (query) => {
   try {
-    const xmlDoc = await $.ajax(xmlUrl)
-    const authorPidInXML = xpathSelect('//dblpperson', xmlDoc)[0].getAttribute('pid')
-    const publicationNodes = xpathSelect(xPathPublicationsSelector, xmlDoc)
-    const homoAuthorName = xpathSelect(xPathHomoAuthorSelector, xmlDoc)?.[0]?.textContent
-    const authorNodes = xpathSelect(xPathAuthorSelector, xmlDoc)
-    if (homoAuthorName) {
-      possibleNames.add(homoAuthorName)
-    } else {
-      authorNodes?.forEach((authorNode) => possibleNames.add(authorNode?.textContent))
-    }
+    const result = await $.ajax({
+      method: 'post',
+      url: dblpSparqlEndpoint,
+      headers: { Accept: 'application/sparql-results+json' },
+      dataType: 'json',
+      data: { query },
+    })
+    return result.results.bindings
+  } catch {
+    throw new Error('Fetching publications from DBLP failed')
+  }
+}
+
+export async function getDblpPublicationsFromSparQL(url, profileId, profileNames) {
+  if (!url.startsWith('https://dblp.org/pid/')) throw new URIError(url)
+  const persistentUrl = url.endsWith('.html') ? url.slice(0, -5) : url
+
+  const personRows = await runDblpSparqlQuery(`
+    PREFIX dblp: <https://dblp.org/rdf/schema#>
+    SELECT DISTINCT ?name WHERE { <${persistentUrl}> dblp:creatorName ?name }`)
+  const possibleNames = [...new Set(personRows.map((row) => row.name.value))]
+  if (possibleNames.length === 0) throw new URIError(url)
+
+  const publicationRows = await runDblpSparqlQuery(`
+    PREFIX dblp: <https://dblp.org/rdf/schema#>
+    SELECT ?pub ?bibtype ?title ?year ?month ?venue ?journal ?volume ?number ?chapter ?pages
+          ?ee ?isbn ?booktitle ?crossref ?publisher ?authors
+    WHERE {
+      {
+        SELECT ?pub
+          (GROUP_CONCAT(CONCAT(STR(?ord), "|", ?name, "|", COALESCE(STR(?creator), "")); SEPARATOR=";;") AS ?authors)
+        WHERE {
+          ?pub dblp:authoredBy <${persistentUrl}> ; dblp:hasSignature ?sig .
+          ?sig dblp:signatureOrdinal ?ord ; dblp:signatureDblpName ?name .
+          OPTIONAL { ?sig dblp:signatureCreator ?creator }
+          FILTER NOT EXISTS { ?pub a dblp:Data }
+        }
+        GROUP BY ?pub
+      }
+      ?pub dblp:title ?title .
+      OPTIONAL { ?pub dblp:bibtexType ?bibtype }
+      OPTIONAL { ?pub dblp:yearOfPublication ?year }
+      OPTIONAL { ?pub dblp:monthOfPublication ?month }
+      OPTIONAL { ?pub dblp:publishedIn ?venue }
+      OPTIONAL { ?pub dblp:publishedInJournal ?journal }
+      OPTIONAL { ?pub dblp:publishedInJournalVolume ?volume }
+      OPTIONAL { ?pub dblp:publishedInJournalVolumeIssue ?number }
+      OPTIONAL { ?pub dblp:publishedInBook ?booktitle }
+      OPTIONAL { ?pub dblp:publishedInBookChapter ?chapter }
+      OPTIONAL { ?pub dblp:pagination ?pages }
+      OPTIONAL { ?pub dblp:primaryDocumentPage ?ee }
+      OPTIONAL { ?pub dblp:isbn ?isbn }
+      OPTIONAL { ?pub dblp:publishedAsPartOf ?crossref }
+      OPTIONAL { ?pub dblp:publishedBy ?publisher }
+    }`)
+
+  const publicationsByKey = new Map()
+  publicationRows.forEach((row) => {
+    const key = row.pub.value.replace('https://dblp.org/rec/', '')
+    if (!publicationsByKey.has(key)) publicationsByKey.set(key, row) // a repeated optional value repeats the row
+  })
+
+  const notes = [...publicationsByKey].map(([key, row]) => {
+    const authors = row.authors.value
+      .split(';;')
+      .map((signature) => {
+        const [ordinal, name, creator] = signature.split('|')
+        return {
+          ordinal: Number(ordinal),
+          name,
+          pid: creator ? creator.replace('https://dblp.org/pid/', '') : undefined,
+        }
+      })
+      .sort((a, b) => a.ordinal - b.ordinal) // GROUP_CONCAT order is not guaranteed
+    const authorNames = authors.map((author) => author.name)
+    const authorIndex = authorNames.findIndex((name) => {
+      const normalizedName = normalizeName(name)
+      return profileNames.some((p) => normalizedName.includes(normalizeName(p)))
+    })
+    const originalTitle = row.title?.value
+    const year = row.year?.value
+    let venue = row.venue?.value
+    if (year) venue = `${venue} ${year}`
 
     return {
-      notes: publicationNodes.flatMap((publicationNode) => {
-        if (publicationNode.getElementsByTagName('author').length === 0) return []
-
-        const authorPids = Array.from(publicationNode.getElementsByTagName('author')).map(
-          (p) => p.getAttribute('pid')
-        )
-        if (authorPids.indexOf(authorPidInXML) === -1) {
-          return [] // could be editor
-        }
-        const originalTitle = publicationNode.getElementsByTagName('title')[0].textContent
-        let venue =
-          publicationNode.getElementsByTagName('journal')[0]?.textContent ??
-          publicationNode.getElementsByTagName('booktitle')[0]?.textContent
-        const year = publicationNode.getElementsByTagName('year')[0]?.textContent
-        if (year) venue = `${venue} ${year}`
-        const authorNames = Object.values(publicationNode.getElementsByTagName('author')).map(
-          (p) => p.textContent
-        )
-        const authorIndex = authorNames.findIndex((name) => {
-          const normalizedName = normalizeName(name)
-          return profileNames.some((p) => normalizedName.includes(normalizeName(p)))
-        })
-
-        return {
-          note: {
-            content: {
-              dblp: publicationNode.outerHTML,
-            },
-            invitation: 'dblp.org/-/record',
-            readers: ['everyone'],
-            writers: ['dblp.org'],
-            signatures: [profileId],
-          },
-          title: originalTitle,
-          formattedTitle: titleNameTransformation(originalTitle),
-          authorIndex,
-          authorNames,
-          authorCount: authorPids.length,
-          venue,
-          year: year ?? 'Unknown',
-          externalId: `dblp:${publicationNode.getAttribute('key')}`,
-        }
-      }),
-      possibleNames: [...possibleNames],
+      note: {
+        content: { json: row },
+        invitation: 'dblp.org/-/record',
+        readers: ['everyone'],
+        writers: ['dblp.org'],
+        signatures: [profileId],
+      },
+      title: originalTitle,
+      formattedTitle: titleNameTransformation(originalTitle),
+      authorIndex,
+      authorNames,
+      authorCount: authorNames.length,
+      venue,
+      year: year ?? 'Unknown',
+      externalId: `dblp:${key}`,
     }
-  } catch (error) {
-    throw new URIError(`${xmlUrl}`)
-  }
+  })
+
+  return { notes, possibleNames }
 }
 
 export async function getAllPapersByGroupId(profileId) {
@@ -586,8 +627,8 @@ export async function postOrUpdatePaper(dblpPublication, profileId, names) {
     invitation: `${process.env.SUPER_USER}/Public_Article/DBLP.org/-/Record`,
     signatures: [profileId],
     content: {
-      xml: {
-        value: dblpPublication.note.content.dblp,
+      json: {
+        value: dblpPublication.note.content.json,
       },
     },
     note: {

--- a/tests/e2e_1/profilePage.ts
+++ b/tests/e2e_1/profilePage.ts
@@ -30,144 +30,6 @@ const userARole = Role(`http://localhost:${process.env.NEXT_PORT}`, async (t) =>
     .click(Selector('button').withText('Login to OpenReview'))
 })
 
-const userBAlternateId = '~Di_Xu1'
-
-const responseDBLPXML = `<?xml version="1.0"?>
-<dblpperson name="Di Xu 0001" pid="95/7448-1" n="8">
-<person key="homepages/95/7448-1" mdate="2019-11-26">
-<author pid="95/7448-1">Di Xu 0001</author>
-<note type="affiliation">University of British Columbia, Department of Electrical and Computer Engineering, Canada</note>
-</person>
-<homonyms n="1">
-<h f="x/Xu:Di"><person publtype="disambiguation" key="homepages/95/7448" mdate="2019-11-26">
-<author pid="95/7448">Di Xu</author>
-</person>
-</h>
-</homonyms>
-<r><inproceedings key="conf/3dtv/Coria-MendozaXN12" mdate="2019-11-26">
-<author pid="32/5783">Lino Coria-Mendoza</author>
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>Automatic stereoscopic 3D video reframing.</title>
-<pages>1-4</pages>
-<year>2012</year>
-<booktitle>3DTV-Conference</booktitle>
-<ee>https://doi.org/10.1109/3DTV.2012.6365428</ee>
-<crossref>conf/3dtv/2012</crossref>
-<url>db/conf/3dtv/3dtv2012.html#Coria-MendozaXN12</url>
-</inproceedings>
-</r>
-<r><inproceedings key="conf/iccel/XuCN12" mdate="2019-11-26">
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="161/3963">Lino E. Coria</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>Quality of experience for the horizontal pixel parallax adjustment of stereoscopic 3D videos.</title>
-<pages>394-395</pages>
-<year>2012</year>
-<booktitle>ICCE</booktitle>
-<ee>https://doi.org/10.1109/ICCE.2012.6161918</ee>
-<crossref>conf/iccel/2012</crossref>
-<url>db/conf/iccel/icce2012.html#XuCN12</url>
-</inproceedings>
-</r>
-<r><inproceedings key="conf/ictai/PourazadXN12" mdate="2023-03-24">
-<author pid="55/6295">Mahsa T. Pourazad</author>
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>Random Forests Based View Generation for Multiview TV.</title>
-<pages>367-372</pages>
-<year>2012</year>
-<crossref>conf/ictai/2012</crossref>
-<booktitle>ICTAI</booktitle>
-<ee>https://doi.org/10.1109/ICTAI.2012.57</ee>
-<ee>https://doi.ieeecomputersociety.org/10.1109/ICTAI.2012.57</ee>
-<url>db/conf/ictai/ictai2012.html#PourazadXN12</url>
-</inproceedings>
-</r>
-<r><article key="journals/tvcg/XuDN11" mdate="2019-11-26">
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="58/3497">Colin Doutre</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>Correction of Clipped Pixels in Color Images.</title>
-<pages>333-344</pages>
-<year>2011</year>
-<volume>17</volume>
-<journal>IEEE Trans. Vis. Comput. Graph.</journal>
-<number>3</number>
-<ee>https://doi.org/10.1109/TVCG.2010.63</ee>
-<ee>http://doi.ieeecomputersociety.org/10.1109/TVCG.2010.63</ee>
-<ee>https://www.wikidata.org/entity/Q51701964</ee>
-<url>db/journals/tvcg/tvcg17.html#XuDN11</url>
-</article>
-</r>
-<r><inproceedings key="conf/icecsys/XuCN10" mdate="2019-11-26">
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="32/5783">Lino Coria-Mendoza</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>Guidelines for capturing high quality stereoscopic content based on a systematic subjective evaluation.</title>
-<pages>162-165</pages>
-<year>2010</year>
-<booktitle>ICECS</booktitle>
-<ee>https://doi.org/10.1109/ICECS.2010.5724479</ee>
-<crossref>conf/icecsys/2010</crossref>
-<url>db/conf/icecsys/icecsys2010.html#XuCN10</url>
-</inproceedings>
-</r>
-<r><inproceedings key="conf/icip/XuDN10" mdate="2019-11-26">
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="58/3497">Colin Doutre</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>An improved Bayesian algorithm for color image desaturation.</title>
-<pages>1325-1328</pages>
-<year>2010</year>
-<booktitle>ICIP</booktitle>
-<ee>https://doi.org/10.1109/ICIP.2010.5649486</ee>
-<crossref>conf/icip/2010</crossref>
-<url>db/conf/icip/icip2010.html#XuDN10</url>
-</inproceedings>
-</r>
-<r><inproceedings key="conf/iscas/XuDN10" mdate="2019-11-26">
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="58/3497">Colin Doutre</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>Saturated-pixel enhancement for color images.</title>
-<pages>3377-3380</pages>
-<year>2010</year>
-<booktitle>ISCAS</booktitle>
-<ee>https://doi.org/10.1109/ISCAS.2010.5537871</ee>
-<crossref>conf/iscas/2010</crossref>
-<url>db/conf/iscas/iscas2010.html#XuDN10</url>
-</inproceedings>
-</r>
-<r><inproceedings key="conf/icip/XuN09" mdate="2019-11-26">
-<author pid="95/7448-1">Di Xu 0001</author>
-<author pid="55/3871">Panos Nasiopoulos</author>
-<title>Logo insertion transcoding for H.264/AVC compressed video.</title>
-<pages>3693-3696</pages>
-<year>2009</year>
-<booktitle>ICIP</booktitle>
-<ee>https://doi.org/10.1109/ICIP.2009.5414225</ee>
-<crossref>conf/icip/2009</crossref>
-<url>db/conf/icip/icip2009.html#XuN09</url>
-</inproceedings>
-</r>
-<coauthors n="5" nc="1">
-<co c="0"><na f="c/Coria:Lino_E=" pid="161/3963">Lino E. Coria</na></co>
-<co c="0"><na f="c/Coria=Mendoza:Lino" pid="32/5783">Lino Coria-Mendoza</na></co>
-<co c="0"><na f="d/Doutre:Colin" pid="58/3497">Colin Doutre</na></co>
-<co c="0"><na f="n/Nasiopoulos:Panos" pid="55/3871">Panos Nasiopoulos</na></co>
-<co c="0"><na f="p/Pourazad:Mahsa_T=" pid="55/6295">Mahsa T. Pourazad</na></co>
-</coauthors>
-</dblpperson>
-`
-
-const dblpMock = RequestMock()
-  .onRequestTo('https://dblp.org/pid/95/7448-1.xml')
-  .respond(responseDBLPXML, 200, {
-    'access-control-allow-origin': '*',
-    'content-type': 'application/xml',
-  })
-
 const orcidMock = RequestMock()
   .onRequestTo('https://pub.orcid.org/v3.0/0000-0002-0613-2229/person')
   .respond(
@@ -826,12 +688,10 @@ const orcidImportModalAddToProfileBtn = Selector('#orcid-import-modal')
 
 // #endregion
 
-fixture`Profile page`
-  .before(async (ctx) => {
-    ctx.superUserToken = await getToken(superUserName, strongPassword)
-    return ctx
-  })
-  .requestHooks(dblpMock)
+fixture`Profile page`.before(async (ctx) => {
+  ctx.superUserToken = await getToken(superUserName, strongPassword)
+  return ctx
+})
 
 test('user open own profile', async (t) => {
   await t


### PR DESCRIPTION
this pr contains changes to stop getting dblp from xml which is blocked by captcha, instead it will fetch json from sparql.dblp.org using sparql

this pr also remove the dblp mock so that similar changes from dblp can be caught 

still require changes in:
1. new function in openreview-js to perform the json to note conversion 
https://github.com/openreview/openreview-js/pull/154
2. Public_Article/DBLP.org/-/Record invitation to accept json of type json instead of xml and change to postprocess to call util function defined in 1 
https://github.com/openreview/openreview-py/pull/3198