### PR TITLE
Fix/ Display of obj authors

### DIFF
--- a/components/NoteContent.js
+++ b/components/NoteContent.js
@@ -1,7 +1,6 @@
 'use client'
 
-/* globals DOMPurify,marked: false */
-
+import { Space } from 'antd'
 import union from 'lodash/union'
 import { marked } from 'marked'
 import React, { useState, useEffect } from 'react'
@@ -13,6 +12,7 @@ import {
   classNames,
 } from '../lib/utils'
 import Icon from './Icon'
+import ProfileLink from './webfield/ProfileLink'
 
 function NoteContent({
   id,
@@ -250,6 +250,38 @@ export const NoteContentV2 = ({
         const showPrivateIcon =
           fieldReaders && noteReaders && !noteReaders.every((p, j) => p === fieldReaders[j])
 
+        const renderFieldValue = () => {
+          if (fieldValue.isObjAuthorList) {
+            return (
+              <Space size={0} separator={',\u00a0'} wrap>
+                {fieldValue.authors.map(({ username, fullname }) => (
+                  <ProfileLink key={username ?? fullname} id={username} name={fullname} />
+                ))}
+              </Space>
+            )
+          }
+          if (fieldValue.startsWith('/attachment/') || fieldValue.startsWith('/pdf/')) {
+            return (
+              <span className="note-content-value">
+                <DownloadLink
+                  noteId={id}
+                  fieldName={fieldName}
+                  fieldValue={fieldValue}
+                  isReference={isEdit}
+                  isV2
+                />
+              </span>
+            )
+          }
+          return (
+            <NoteContentValue
+              content={fieldValue}
+              enableMarkdown={enableMarkdown}
+              fullMarkdown={fullMarkdown}
+            />
+          )
+        }
+
         return (
           <div key={fieldName}>
             <NoteContentField name={fieldName} customFieldName={customFieldName} />{' '}
@@ -262,23 +294,7 @@ export const NoteContentV2 = ({
                   .join(', ')}`}
               />
             )}
-            {fieldValue.startsWith('/attachment/') || fieldValue.startsWith('/pdf/') ? (
-              <span className="note-content-value">
-                <DownloadLink
-                  noteId={id}
-                  fieldName={fieldName}
-                  fieldValue={fieldValue}
-                  isReference={isEdit}
-                  isV2
-                />
-              </span>
-            ) : (
-              <NoteContentValue
-                content={fieldValue}
-                enableMarkdown={enableMarkdown}
-                fullMarkdown={fullMarkdown}
-              />
-            )}
+            {renderFieldValue()}
           </div>
         )
       })}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,3 @@
-/* globals $,view2: false */
-
 import cloneDeep from 'lodash/cloneDeep'
 import deburr from 'lodash/deburr'
 import escapeRegExp from 'lodash/escapeRegExp'
@@ -136,6 +134,9 @@ export function prettyContentValue(val, dataType) {
       timeZoneName: 'short',
       hour12: false,
     })
+  }
+  if (dataType === 'author{}' && Array.isArray(val)) {
+    return { isObjAuthorList: true, authors: val }
   }
   if (valType === 'string') {
     return val.trim()

--- a/unitTests/NoteContent.test.js
+++ b/unitTests/NoteContent.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom'
-import { NoteContentV2 } from '../components/NoteContent'
 import { marked } from 'marked'
+import { NoteContentV2 } from '../components/NoteContent'
+import '@testing-library/jest-dom'
 
 jest.mock('nanoid', () => ({ nanoid: () => 'some id' }))
 jest.mock('marked', () => {
@@ -181,5 +181,35 @@ describe('NoteContentV2', () => {
     )
 
     expect(screen.getByText('orcid:12345')).not.toHaveAttribute('href')
+  })
+
+  test('render author{} field as profile links', () => {
+    const props = {
+      id: 'some id',
+      content: {
+        reciprocal_reviewers: {
+          value: [
+            { username: '~Author_One1', fullname: 'Author One' },
+            { username: '~Author_Two1', fullname: 'Author Two' },
+          ],
+        },
+      },
+      presentation: [{ name: 'reciprocal_reviewers', order: 1, type: 'author{}' }],
+    }
+
+    render(<NoteContentV2 {...props} />)
+
+    expect(screen.getAllByRole('link').length).toEqual(2)
+    expect(screen.getByRole('link', { name: 'Author One' })).toHaveAttribute(
+      'href',
+      '/profile?id=~Author_One1'
+    )
+    expect(screen.getByRole('link', { name: 'Author Two' })).toHaveAttribute(
+      'href',
+      '/profile?id=~Author_Two1'
+    )
+    expect(screen.getByText('Reciprocal Reviewers:').parentElement).toHaveTextContent(
+      'Author One, Author Two'
+    )
   })
 })

--- a/unitTests/utils.test.js
+++ b/unitTests/utils.test.js
@@ -14,6 +14,7 @@ import {
   getNoteAuthors,
   normalizeName,
   getDeviceFromUserAgent,
+  prettyContentValue,
 } from '../lib/utils'
 import '@testing-library/jest-dom'
 
@@ -1252,5 +1253,21 @@ describe('utils', () => {
     fullname = 'ﬁle ﬂow Ⅻ ①'
     expectedNormalizedName = 'file flow XII 1'
     expect(normalizeName(fullname)).toEqual(expectedNormalizedName)
+  })
+
+  test('return author list object in prettyContentValue for author{} type', () => {
+    const reciprocal_reviewers = [
+      { username: '~Test_User1', fullname: 'Test User' },
+      { username: 'test@email.com', fullname: 'Email User' },
+    ]
+    expect(prettyContentValue(reciprocal_reviewers, 'author{}')).toEqual({
+      isObjAuthorList: true,
+      authors: reciprocal_reviewers,
+    })
+
+    // fallback to string if presentation is not author{}
+    expect(prettyContentValue(reciprocal_reviewers, 'string')).toEqual(
+      JSON.stringify(reciprocal_reviewers, undefined, 2).replace(/"/g, '')
+    )
   })
 })


### PR DESCRIPTION
this pr should properly handle obj author display in note content, for example reciprocal_reviewers
which is currently displayed as stringified json

this pr assumes the field is an array